### PR TITLE
[Feat/#22] 카메라 촬영 기능 구현

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		605DA0C92C07097F00CC9450 /* ImagePreviewButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0C82C07097F00CC9450 /* ImagePreviewButton.swift */; };
+		605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0CC2C070A0300CC9450 /* Camera.swift */; };
+		605DA0CF2C07118900CC9450 /* SubmitRouterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0CE2C07118900CC9450 /* SubmitRouterView.swift */; };
+		605DA0D12C0711CA00CC9450 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0D02C0711CA00CC9450 /* CameraView.swift */; };
+		605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0D22C0711E900CC9450 /* CameraViewModel.swift */; };
+		605DA0D62C07123400CC9450 /* View++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0D52C07123400CC9450 /* View++.swift */; };
+		6060B2EA2C08947B0083944D /* Image++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6060B2E92C08947B0083944D /* Image++.swift */; };
 		607FCBD42BFA648000BB2D04 /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FCBD32BFA648000BB2D04 /* Tab.swift */; };
 		607FCBD62BFA660C00BB2D04 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FCBD52BFA660C00BB2D04 /* MainTabView.swift */; };
 		607FCBD82BFA681500BB2D04 /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FCBD72BFA681500BB2D04 /* ApprovalView.swift */; };
@@ -49,6 +56,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		605DA0C82C07097F00CC9450 /* ImagePreviewButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewButton.swift; sourceTree = "<group>"; };
+		605DA0CC2C070A0300CC9450 /* Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
+		605DA0CE2C07118900CC9450 /* SubmitRouterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterView.swift; sourceTree = "<group>"; };
+		605DA0D02C0711CA00CC9450 /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
+		605DA0D22C0711E900CC9450 /* CameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewModel.swift; sourceTree = "<group>"; };
+		605DA0D52C07123400CC9450 /* View++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View++.swift"; sourceTree = "<group>"; };
+		6060B2E92C08947B0083944D /* Image++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image++.swift"; sourceTree = "<group>"; };
 		607FCBD32BFA648000BB2D04 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		607FCBD52BFA660C00BB2D04 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		607FCBD72BFA681500BB2D04 /* ApprovalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalView.swift; sourceTree = "<group>"; };
@@ -102,6 +116,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		605DA0D42C07122200CC9450 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				605DA0D52C07123400CC9450 /* View++.swift */,
+				6060B2E92C08947B0083944D /* Image++.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		6060B2EB2C08D0C80083944D /* Camera */ = {
+			isa = PBXGroup;
+			children = (
+				605DA0CC2C070A0300CC9450 /* Camera.swift */,
+				605DA0D02C0711CA00CC9450 /* CameraView.swift */,
+				605DA0D22C0711E900CC9450 /* CameraViewModel.swift */,
+				605DA0C82C07097F00CC9450 /* ImagePreviewButton.swift */,
+			);
+			path = Camera;
+			sourceTree = "<group>";
+		};
 		607FCBD22BFA645100BB2D04 /* Router */ = {
 			isa = PBXGroup;
 			children = (
@@ -117,7 +151,9 @@
 				60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */,
 				607FCBE82BFE418600BB2D04 /* QuestViewModel.swift */,
 				607FCBE32BFD124900BB2D04 /* QuestItemView.swift */,
+				605DA0CE2C07118900CC9450 /* SubmitRouterView.swift */,
 				607FCC322C01AA7300BB2D04 /* SubmitAlertView.swift */,
+				6060B2EB2C08D0C80083944D /* Camera */,
 			);
 			path = Quest;
 			sourceTree = "<group>";
@@ -247,6 +283,7 @@
 		60B8BA132BF9F07D005F6DE3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				605DA0D42C07122200CC9450 /* Extension */,
 				607FCBE02BFA6A6100BB2D04 /* Component */,
 				607FCBDF2BFA69E600BB2D04 /* Global */,
 				607FCBDE2BFA693F00BB2D04 /* Views */,
@@ -386,16 +423,23 @@
 			buildActionMask = 2147483647;
 			files = (
 				607FCBE22BFA6A8300BB2D04 /* Buttons.swift in Sources */,
+				605DA0CF2C07118900CC9450 /* SubmitRouterView.swift in Sources */,
 				607FCBD82BFA681500BB2D04 /* ApprovalView.swift in Sources */,
 				A1BB60262BFE05B000AAADD4 /* MyPageSegmenet.swift in Sources */,
+				605DA0D62C07123400CC9450 /* View++.swift in Sources */,
 				A1BB602E2C022A9900AAADD4 /* UserData.swift in Sources */,
+				605DA0C92C07097F00CC9450 /* ImagePreviewButton.swift in Sources */,
+				605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */,
+				6060B2EA2C08947B0083944D /* Image++.swift in Sources */,
 				607FCBE42BFD124900BB2D04 /* QuestItemView.swift in Sources */,
 				607FCBD42BFA648000BB2D04 /* Tab.swift in Sources */,
 				60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */,
 				60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */,
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,
 				A1BB60282BFE129000AAADD4 /* MyPageList.swift in Sources */,
+				605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */,
 				607FCBD62BFA660C00BB2D04 /* MainTabView.swift in Sources */,
+				605DA0D12C0711CA00CC9450 /* CameraView.swift in Sources */,
 				A1BB602C2BFF145100AAADD4 /* MyPageProfile.swift in Sources */,
 				607FCBE92BFE418600BB2D04 /* QuestViewModel.swift in Sources */,
 				607FCBE72BFD12B100BB2D04 /* Quest.swift in Sources */,
@@ -568,6 +612,9 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 권한을 허용해주세요";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 권한을 허용해주세요";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 권한을 허용해주세요";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -603,6 +650,9 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 권한을 허용해주세요";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 권한을 허용해주세요";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 권한을 허용해주세요";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ILSANG/Sources/Extension/Image++.swift
+++ b/ILSANG/Sources/Extension/Image++.swift
@@ -1,0 +1,16 @@
+//
+//  Image++.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/30/24.
+//
+
+import SwiftUI
+
+extension Image {
+    @MainActor func getUIImage(scale displayScale: CGFloat = 1.0) -> UIImage? {
+        let renderer = ImageRenderer(content: self)
+        renderer.scale = displayScale        
+        return renderer.uiImage
+    }
+}

--- a/ILSANG/Sources/Extension/View++.swift
+++ b/ILSANG/Sources/Extension/View++.swift
@@ -1,0 +1,24 @@
+//
+//  View++.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/29/24.
+//
+
+import SwiftUI
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+    
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/ILSANG/Sources/Global/Model/Quest.swift
+++ b/ILSANG/Sources/Global/Model/Quest.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 struct Quest {
+    let id: String
     let missionImage: UIImage
     let missionTitle: String
     let missionCompany: String
@@ -17,6 +18,7 @@ struct Quest {
 
 extension Quest {
     static let mockData: Quest = Quest(
+        id: "11",
         missionImage: .checkmark,
         missionTitle: "아메리카노 15잔 마시기",
         missionCompany: "이디야커피",
@@ -26,6 +28,7 @@ extension Quest {
     
     static let mockDataList: [Quest] = [
         Quest(
+            id: "12",
             missionImage: .checkmark,
             missionTitle: "아메리카노 15잔 마시기",
             missionCompany: "이디야커피",
@@ -33,6 +36,7 @@ extension Quest {
             status: .ACTIVE
         ),
         Quest(
+            id: "13",
             missionImage: .checkmark,
             missionTitle: "카페라떼 1잔 마시기",
             missionCompany: "투썸플레이스",

--- a/ILSANG/Sources/Views/Quest/Camera/Camera.swift
+++ b/ILSANG/Sources/Views/Quest/Camera/Camera.swift
@@ -1,0 +1,154 @@
+//
+//  Camera.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/29/24.
+//
+
+import SwiftUI
+import AVFoundation
+
+class Camera: NSObject, ObservableObject {
+    var session = AVCaptureSession()
+    var videoDeviceInput: AVCaptureDeviceInput!
+    let output = AVCapturePhotoOutput()
+    var photoData = Data(count: 0)
+    var isSilentModeOn = false
+    var flashMode: AVCaptureDevice.FlashMode = .off
+    
+    @Published var recentImage: UIImage?
+    @Published var isCameraBusy = false
+    
+    // 카메라 셋업 과정을 담당하는 메서드
+    func setUpCamera() {
+        if let device = AVCaptureDevice.default(.builtInWideAngleCamera,for: .video, position: .back) {
+            do { // 카메라가 사용 가능하면 세션에 input과 output을 연결
+                videoDeviceInput = try AVCaptureDeviceInput(device: device)
+                if session.canAddInput(videoDeviceInput) {
+                    session.addInput(videoDeviceInput)
+                }
+                
+                if session.canAddOutput(output) {
+                    session.addOutput(output)
+                    output.maxPhotoQualityPrioritization = .quality
+                }
+                Task {
+                    session.startRunning()
+                }
+            } catch {
+                print(error)
+            }
+        }
+    }
+    
+    func capturePhoto() {
+        // 사진 옵션 세팅
+        let photoSettings = AVCapturePhotoSettings()
+        photoSettings.flashMode = self.flashMode
+        
+        self.output.capturePhoto(with: photoSettings, delegate: self)
+        print("[Camera]: Photo's taken")
+    }
+    
+    func savePhoto(_ imageData: Data) {
+        guard let image = UIImage(data: imageData) else { return }
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+        print("[Camera]: Photo's saved")
+    }
+    
+    func zoom(_ zoom: CGFloat){
+        let factor = zoom < 1 ? 1 : zoom
+        let device = self.videoDeviceInput.device
+        
+        do {
+            try device.lockForConfiguration()
+            device.videoZoomFactor = factor
+            device.unlockForConfiguration()
+        }
+        catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+    func changeCamera() {
+        let currentPosition = self.videoDeviceInput.device.position
+        let preferredPosition: AVCaptureDevice.Position
+        
+        switch currentPosition {
+        case .unspecified, .front:
+            print("후면카메라로 전환합니다.")
+            preferredPosition = .back
+            
+        case .back:
+            print("전면카메라로 전환합니다.")
+            preferredPosition = .front
+            
+        @unknown default:
+            print("알 수 없는 포지션. 후면카메라로 전환합니다.")
+            preferredPosition = .back
+        }
+        
+        if let videoDevice = AVCaptureDevice
+            .default(.builtInWideAngleCamera,
+                     for: .video, position: preferredPosition) {
+            do {
+                let videoDeviceInput = try AVCaptureDeviceInput(device: videoDevice)
+                self.session.beginConfiguration()
+                
+                if let inputs = session.inputs as? [AVCaptureDeviceInput] {
+                    for input in inputs {
+                        session.removeInput(input)
+                    }
+                }
+                if self.session.canAddInput(videoDeviceInput) {
+                    self.session.addInput(videoDeviceInput)
+                    self.videoDeviceInput = videoDeviceInput
+                } else {
+                    self.session.addInput(self.videoDeviceInput)
+                }
+                
+                if let connection =
+                    self.output.connection(with: .video) {
+                    if connection.isVideoStabilizationSupported {
+                        connection.preferredVideoStabilizationMode = .auto
+                    }
+                }
+                
+                output.maxPhotoQualityPrioritization = .quality
+                
+                self.session.commitConfiguration()
+            } catch {
+                print("Error occurred: \(error)")
+            }
+        }
+    }
+}
+
+extension Camera: AVCapturePhotoCaptureDelegate {
+    func photoOutput(_ output: AVCapturePhotoOutput, willBeginCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+        self.isCameraBusy = true
+    }
+    
+    func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+        if isSilentModeOn {
+            print("[Camera]: Silent sound activated")
+            AudioServicesDisposeSystemSoundID(1108)
+        }
+    }
+    
+    func photoOutput(_ output: AVCapturePhotoOutput, didCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+        if isSilentModeOn {
+            AudioServicesDisposeSystemSoundID(1108)
+        }
+    }
+    
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        guard let imageData = photo.fileDataRepresentation() else { return }
+        print("[CameraModel]: Capture routine's done")
+        
+        self.photoData = imageData
+        self.recentImage = UIImage(data: imageData)
+        self.savePhoto(imageData)
+        self.isCameraBusy = false
+    }
+}

--- a/ILSANG/Sources/Views/Quest/Camera/CameraView.swift
+++ b/ILSANG/Sources/Views/Quest/Camera/CameraView.swift
@@ -1,0 +1,112 @@
+//
+//  CameraView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/29/24.
+//
+
+import SwiftUI
+import AVFoundation
+
+struct CameraView: View {
+    @StateObject var viewModel = CameraViewModel()
+    @Binding var selectedImage: Image?
+    
+    var body: some View {
+        viewModel.cameraPreview
+            .overlay(alignment: .bottom) {
+                bottomView
+            }
+            .ignoresSafeArea()
+            .opacity(viewModel.shutterEffect ? 0 : 1)
+            .task {
+                viewModel.configure()
+            }
+            .gesture(
+                MagnificationGesture()
+                    .onChanged { val in
+                        viewModel.zoom(factor: val)
+                    }
+                    .onEnded { _ in
+                        viewModel.zoomInitialize()
+                    }
+            )
+            .alert(Text("현재 카메라 사용에 대한 접근 권한이 없습니다."), isPresented: $viewModel.showPermissionErrorAlert, actions: {
+                Button("설정", role: .none) {
+                    guard let settingURL = URL(string: UIApplication.openSettingsURLString),
+                          UIApplication.shared.canOpenURL(settingURL)
+                    else { return }
+                    UIApplication.shared.open(settingURL, options: [:])
+                }
+                Button("취소", role: .cancel) {
+                    viewModel.showPermissionErrorAlert.toggle()
+                }
+            }, message: { Text("설정 > \"일상\"에서 접근을 활성화 할 수 있습니다")})
+    }
+    
+    private var bottomView: some View {
+        HStack {
+            /// 이미지 프리뷰 - 앨범 선택
+            ImagePreviewButton(selectedImage: $selectedImage)
+             
+            Spacer()
+            
+            /// 사진찍기 버튼
+            Button {
+                viewModel.capturePhoto()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    if let myImage = viewModel.recentImage {
+                        selectedImage = Image(uiImage: myImage)
+                    }
+                }
+            } label: {
+                Circle()
+                    .stroke(lineWidth: 5)
+                    .frame(width: 75, height: 75)
+                    .foregroundColor(.white)
+            }
+            
+            Spacer()
+            
+            /// 양쪽 비율 맞춰주기 위한 Spacer
+            Spacer().frame(width: 50, height: 50)
+        }
+        .padding(.horizontal, 30)
+        .padding(.bottom, 75)
+    }
+}
+
+
+struct CameraPreviewView: UIViewRepresentable {
+    class VideoPreviewView: UIView {
+        override class var layerClass: AnyClass {
+            AVCaptureVideoPreviewLayer.self
+        }
+        
+        var videoPreviewLayer: AVCaptureVideoPreviewLayer {
+            return layer as! AVCaptureVideoPreviewLayer
+        }
+    }
+    
+    let session: AVCaptureSession
+    
+    func makeUIView(context: Context) -> VideoPreviewView {
+        let view = VideoPreviewView()
+        
+        view.videoPreviewLayer.session = session
+        view.backgroundColor = .black
+        view.videoPreviewLayer.videoGravity = .resizeAspectFill
+        view.videoPreviewLayer.cornerRadius = 0
+        view.videoPreviewLayer.connection?.videoOrientation = .portrait
+        
+        return view
+    }
+    
+    func updateUIView(_ uiView: VideoPreviewView, context: Context) {
+        
+    }
+}
+
+#Preview {
+    CameraView(selectedImage: .constant(Image(.arrowDown)))
+}

--- a/ILSANG/Sources/Views/Quest/Camera/CameraViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/Camera/CameraViewModel.swift
@@ -1,0 +1,115 @@
+//
+//  CameraViewModel.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/29/24.
+//
+
+import SwiftUI
+import AVFoundation
+import Combine
+
+class CameraViewModel: ObservableObject {
+    private let model: Camera
+    private let session: AVCaptureSession
+    private var subscriptions = Set<AnyCancellable>()
+    private var isCameraBusy = false
+    
+    let cameraPreview: AnyView
+    let hapticImpact = UIImpactFeedbackGenerator()
+    
+    var currentZoomFactor: CGFloat = 1.0
+    var lastScale: CGFloat = 1.0
+    
+    @Published var showPreview = false
+    @Published var shutterEffect = false
+    @Published var recentImage: UIImage?
+    @Published var isFlashOn = false
+    @Published var isSilentModeOn = false
+    @Published var showPermissionErrorAlert = false
+    
+    init() {
+        model = Camera()
+        session = model.session
+        cameraPreview = AnyView(CameraPreviewView(session: session))
+        
+        model.$recentImage.sink { [weak self] (photo) in
+            guard let pic = photo else { return }
+            self?.recentImage = pic
+        }
+        .store(in: &self.subscriptions)
+        
+        model.$isCameraBusy.sink { [weak self] (result) in
+            self?.isCameraBusy = result
+        }
+        .store(in: &self.subscriptions)
+    }
+    
+    /// 초기 세팅
+    func configure() {
+        requestAndCheckPermissions()
+    }
+    
+    /// 플래시 온오프
+    func switchFlash() {
+        isFlashOn.toggle()
+        model.flashMode = isFlashOn == true ? .on : .off
+    }
+    
+    /// 무음모드 온오프
+    func switchSilent() {
+        isSilentModeOn.toggle()
+        model.isSilentModeOn = isSilentModeOn
+    }
+    
+    /// 사진 촬영
+    func capturePhoto() {
+        if isCameraBusy == false {
+            hapticImpact.impactOccurred()
+            withAnimation(.easeInOut(duration: 0.1)) {
+                shutterEffect = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                withAnimation(.easeInOut(duration: 0.1)) {
+                    self.shutterEffect = false
+                }
+            }
+            
+            model.capturePhoto()
+            print("[CameraViewModel]: Photo captured!")
+        } else {
+            print("[CameraViewModel]: Camera's busy.")
+        }
+    }
+    
+    func zoom(factor: CGFloat) {
+        let delta = factor / lastScale
+        lastScale = factor
+        
+        let newScale = min(max(currentZoomFactor * delta, 1), 5)
+        model.zoom(newScale)
+        currentZoomFactor = newScale
+    }
+    
+    func zoomInitialize() {
+        lastScale = 1.0
+    }
+    
+    /// 전후면 카메라 스위칭
+    func changeCamera() {
+        model.changeCamera()
+        print("[CameraViewModel]: Camera changed!")
+    }
+    
+    /// 카메라 권한 상태 확인
+    func requestAndCheckPermissions() {
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] isAuthorized in
+            guard isAuthorized else {
+                self?.showPermissionErrorAlert = true
+                return
+            }
+            
+            self?.model.setUpCamera()
+        }
+    }
+}

--- a/ILSANG/Sources/Views/Quest/Camera/ImagePreviewButton.swift
+++ b/ILSANG/Sources/Views/Quest/Camera/ImagePreviewButton.swift
@@ -1,0 +1,78 @@
+//
+//  ImagePreviewButton.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/29/24.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct ImagePreviewButton: View {
+    private let imageSize = 50.0
+    
+    enum PreviewLoadState {
+        case unknown, loading, loaded, failed
+    }
+    
+    @State private var previewImage : UIImage?
+    @State private var loadState = PreviewLoadState.unknown
+    
+    @State var selectedItem: PhotosPickerItem?
+    @Binding var selectedImage: Image?
+
+    var body: some View {
+        PhotosPicker(selection: $selectedItem, matching: .images,photoLibrary: .shared()) {
+            switch loadState {
+            case .loaded:
+                if let previewImage = previewImage {
+                    Image(uiImage: previewImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: imageSize, height: imageSize)
+                        .clipped()
+                        .cornerRadius(10)
+                }
+            case .loading:
+                ProgressView()
+            case .unknown, .failed:
+                RoundedRectangle(cornerRadius: 10)
+                    .frame(width: imageSize, height: imageSize)
+                    .foregroundStyle(.grayDD)
+            }
+        }
+        .task {
+            setPreviewImage()
+        }
+        .onChange(of: selectedItem) { newItem in
+            Task {
+                if let image = try? await newItem?.loadTransferable(type: Image.self) {
+                    selectedImage = image
+                }
+            }
+        }
+    }
+    
+    @MainActor
+    private func setPreviewImage() {
+        loadState = .loading
+
+        let fetchOption = PHFetchOptions()
+        fetchOption.fetchLimit = 1
+        fetchOption.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+
+        let fetchPhotos = PHAsset.fetchAssets(with: fetchOption)
+        if let photo = fetchPhotos.firstObject {
+            PHImageManager().requestImage(for: photo, targetSize: CGSize(width: imageSize, height: imageSize), contentMode: .aspectFill, options: .none) { image, _ in
+                self.previewImage = image
+                loadState = .loaded
+            }
+        } else {
+            loadState = .failed
+        }
+    }
+}
+
+#Preview {
+    ImagePreviewButton(selectedImage: .constant(Image(.arrowDown)))
+}

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -87,8 +87,8 @@ struct QuestItemView: View {
 
 #Preview {
     VStack {
-        QuestItemView(quest: Quest(missionImage: .checkmark, missionTitle: "아메리카노 5잔 마시기", missionCompany: "이디야커피", reward: 50, status: .ACTIVE))
-        QuestItemView(quest: Quest(missionImage: .checkmark, missionTitle: "아메리카노 15잔 마시기", missionCompany: "이디야커피", reward: 50, status: .INACTIVE))
+        QuestItemView(quest: Quest(id: "12", missionImage: .checkmark, missionTitle: "아메리카노 5잔 마시기", missionCompany: "이디야커피", reward: 50, status: .ACTIVE))
+        QuestItemView(quest: Quest(id: "13", missionImage: .checkmark, missionTitle: "아메리카노 15잔 마시기", missionCompany: "이디야커피", reward: 50, status: .INACTIVE))
     }
 }
 

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -22,6 +22,9 @@ struct QuestView: View {
                 .presentationDetents([.height(540)])
                 .presentationDragIndicator(.visible)
         }
+        .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
+            SubmitRouterView(selectedQuestId: vm.selectedQuest.id)
+        }
     }
 }
 
@@ -92,8 +95,7 @@ extension QuestView {
                 .padding(.bottom, 26)
 
             PrimaryButton(title: "퀘스트 인증하기") {
-                // TODO: 카메라 연결
-                print("tapped")
+                vm.tappedQuestApprovalBtn()
             }
         }
         .foregroundStyle(.gray400)

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -12,9 +12,15 @@ class QuestViewModel: ObservableObject {
     @Published var questList: [Quest] = Quest.mockDataList
     @Published var showQuestSheet: Bool = false
     @Published var selectedQuest: Quest = Quest.mockData
+    @Published var showSubmitRouterView: Bool = false
 
     func tappedQuestBtn(quest: Quest) {
         selectedQuest = quest
+        showQuestSheet.toggle()
+    }
+    
+    func tappedQuestApprovalBtn() {
+        showSubmitRouterView.toggle()
         showQuestSheet.toggle()
     }
 }

--- a/ILSANG/Sources/Views/Quest/SubmitRouterView.swift
+++ b/ILSANG/Sources/Views/Quest/SubmitRouterView.swift
@@ -1,0 +1,76 @@
+//
+//  SubmitRouterView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/29/24.
+//
+
+import SwiftUI
+import Photos
+
+struct SubmitRouterView: View {
+    
+    @Environment(\.dismiss) var dismiss
+    
+    @State private var showPhotoLibraryAlert = false
+    @State var selectedImage: Image?
+    
+    let selectedQuestId: String
+    
+    var body: some View {
+        Group {
+            if let myImage = selectedImage {
+                myImage
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(.bottom, 90)
+                    .overlay(alignment: .bottom) {
+                        buttonView
+                    }
+                    .ignoresSafeArea(edges: .bottom)
+            } else {
+                CameraView(selectedImage: $selectedImage)
+            }
+        }
+        .background(Color.white)
+    }
+}
+
+extension SubmitRouterView {
+    private var buttonView: some View {
+        HStack(spacing: 12) {
+            Button {
+                selectedImage = nil
+            } label: {
+                Text("다시찍기")
+            }
+            .frame(height: 50)
+            .frame(maxWidth: .infinity)
+            .foregroundStyle(.gray400)
+            .background(Color.gray100)
+            .cornerRadius(12)
+            
+            PrimaryButton(title: "제출하기") {
+                Task { await submitImage() }
+            }
+        }
+        .padding([.bottom,.horizontal], 20)
+        .frame(height: 110)
+        .background(Color.white)
+        .cornerRadius(24, corners: [.topLeft, .topRight])
+    }
+    
+    private func submitImage() async {
+        // TODO: 에러처리 및 SubmitAlertView 띄우기
+        guard let selectedImage = selectedImage else { return }
+        Task {
+            await postChallengeWithImage(selectedImage)
+            dismiss()
+        }
+    }
+
+    private func postChallengeWithImage(_ selectedImage: Image) async {
+        // TODO: 퀘스트 인증 이미지 POST
+    }
+}


### PR DESCRIPTION
#### close #22

### ✏️ 개요
이미지를 제출하여 퀘스트 인증을 하기 위한 카메라 촬영, 앨범 이미지 불러오는 기능을 구현하였습니다.
카메라 관련해서 주요 로직은 이전과 동일하며, 사용하지 않는 부분은 일부 정리하였습니다.

### 💻 작업 사항
- [x] View Extension 추가 (cornerRadius를 일부 코너에만 주는 메소드)
- [x] Image Extension 추가 (Image to UIImage메소드)
- [x] 카메라 권한 설정 로직 추가
- [x] 카메라 촬영 기능 구현(최근 앨범 사진 불러오는 기능 구현)

### 📄 리뷰 노트
이해 안가는 부분 있으면 남겨주세요!

### 📱결과 화면(optional)
| SubmitRouterView | CameraView |
|--------|--------|
| <img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/2fb323d8-3d8b-4791-a3dc-d9102a22a0e9" width = "300">  | <img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/835b167a-bd34-4052-ac4a-5d0738bfcacb" width = "300">  | 


### 📚 ETC(optional)
작업하다보니 수정사항이 많아졌네요. 다음엔 꼭 PR을 나눠서 올려보겠습니다..

해당 PR에서 다루지 않은 내용들입니다.
- [ ] 앨범 접근 권한 승인 안했을 경우 로직 추가
- [ ] 하위 뷰들에 대한 View, ViewModel 분리 작업