### PR TITLE
[Design/#36] 퀘스트/완료한 퀘스트 없을 경우 화면 디자인 적용

### DIFF
--- a/ILSANG/Sources/Global/Model/Quest.swift
+++ b/ILSANG/Sources/Global/Model/Quest.swift
@@ -26,7 +26,7 @@ extension Quest {
         status: .ACTIVE
     )
     
-    static let mockDataList: [Quest] = [
+    static let mockActiveDataList: [Quest] = [
         Quest(
             id: "12",
             missionImage: .checkmark,
@@ -34,6 +34,25 @@ extension Quest {
             missionCompany: "이디야커피",
             reward: 50,
             status: .ACTIVE
+        ),
+        Quest(
+            id: "13",
+            missionImage: .checkmark,
+            missionTitle: "카페라떼 1잔 마시기",
+            missionCompany: "투썸플레이스",
+            reward: 150,
+            status: .ACTIVE
+        )
+    ]
+    
+    static let mockInactiveDataList: [Quest] = [
+        Quest(
+            id: "12",
+            missionImage: .checkmark,
+            missionTitle: "아메리카노 15잔 마시기",
+            missionCompany: "이디야커피",
+            reward: 50,
+            status: .INACTIVE
         ),
         Quest(
             id: "13",
@@ -56,6 +75,24 @@ enum QuestStatus: String, CaseIterable {
             "퀘스트"
         case .INACTIVE:
             "완료"
+        }
+    }
+    
+    var emptyTitle: String {
+        switch self {
+        case .ACTIVE:
+            "퀘스트를 모두 완료하셨어요!"
+        case .INACTIVE:
+            "완료된 퀘스트가 없어요"
+        }
+    }
+    
+    var emptySubTitle: String {
+        switch self {
+        case .ACTIVE:
+            "상상할 수 없는 퀘스트를 준비 중이니\n다음 업데이트를 기대해 주세요!"
+        case .INACTIVE:
+            "퀘스트를 수행하러 가볼까요?"
         }
     }
 }

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -38,7 +38,7 @@ struct QuestItemView: View {
                         .offset(x: 20, y: 2)
                 }
             
-            VStack(alignment: .leading, spacing: 3){
+            VStack(alignment: .leading, spacing: 4){
                 Text(quest.missionTitle)
                     .font(.system(size: 15, weight: .bold))
                     .foregroundColor(.black)
@@ -48,6 +48,7 @@ struct QuestItemView: View {
                     .foregroundColor(.gray)
             }
             .opacity(quest.status == .ACTIVE ? 1.0 : 0.2)
+            .padding(.top, 6)
             
             Spacer()
             

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -20,7 +20,7 @@ struct QuestView: View {
         .background(Color.background)
         .overlay {
             if vm.isCurrentListEmpty {
-                emptyView
+                questListEmptyView
             }
         }
         .sheet(isPresented: $vm.showQuestSheet) {
@@ -74,7 +74,7 @@ extension QuestView {
         }
     }
     
-    private var emptyView: some View {
+    private var questListEmptyView: some View {
         VStack(spacing: 16) {
             Text(vm.selectedHeader.emptyTitle)
                 .foregroundStyle(.gray400)

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -53,7 +53,7 @@ extension QuestView {
     
     private var questListView: some View {
         ScrollView {
-            VStack(spacing: 14) {
+            VStack(spacing: 12) {
                 switch vm.selectedHeader {
                 case .ACTIVE:
                     ForEach(vm.activeQuestList, id: \.id) { quest in
@@ -70,7 +70,7 @@ extension QuestView {
                 }
             }
             .padding(.top, 17)
-            .padding(.bottom, 20)
+            .padding(.bottom, 72)
         }
     }
     

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -14,9 +14,15 @@ struct QuestView: View {
         VStack(alignment: .leading, spacing: 0) {
             headerView
             
-            scrollView
+            questListView
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.background)
+        .overlay {
+            if vm.isCurrentListEmpty {
+                emptyView
+            }
+        }
         .sheet(isPresented: $vm.showQuestSheet) {
             questSheetView
                 .presentationDetents([.height(540)])
@@ -37,7 +43,7 @@ extension QuestView {
                 } label: {
                     Text(status.headerText)
                         .foregroundColor(status == vm.selectedHeader ? .gray400 : .gray200)
-                        .font(.system(size: 21, weight: status == vm.selectedHeader ? .bold : .regular))
+                        .font(.system(size: 21, weight: .bold))
                         .frame(height: 30)
                 }
             }
@@ -45,19 +51,40 @@ extension QuestView {
         .padding(.horizontal, 20)
     }
     
-    private var scrollView: some View {
+    private var questListView: some View {
         ScrollView {
             VStack(spacing: 14) {
-                ForEach(vm.questList, id: \.missionTitle) { quest in
-                    Button {
-                        vm.tappedQuestBtn(quest: quest)
-                    } label: {
+                switch vm.selectedHeader {
+                case .ACTIVE:
+                    ForEach(vm.activeQuestList, id: \.id) { quest in
+                        Button {
+                            vm.tappedQuestBtn(quest: quest)
+                        } label: {
+                            QuestItemView(quest: quest)
+                        }
+                    }
+                case .INACTIVE:
+                    ForEach(vm.inactiveQuestList, id: \.id) { quest in
                         QuestItemView(quest: quest)
                     }
                 }
             }
             .padding(.top, 17)
+            .padding(.bottom, 20)
         }
+    }
+    
+    private var emptyView: some View {
+        VStack(spacing: 16) {
+            Text(vm.selectedHeader.emptyTitle)
+                .foregroundStyle(.gray400)
+                .font(.system(size: 21, weight: .bold))
+            Text(vm.selectedHeader.emptySubTitle)
+                .foregroundStyle(.gray300)
+                .font(.system(size: 17, weight: .medium))
+                .lineSpacing(6)
+        }
+        .multilineTextAlignment(.center)
     }
     
     private var questSheetView: some View {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -9,11 +9,21 @@ import Foundation
 
 class QuestViewModel: ObservableObject {
     @Published var selectedHeader: QuestStatus = .ACTIVE
-    @Published var questList: [Quest] = Quest.mockDataList
+    @Published var activeQuestList: [Quest] = Quest.mockActiveDataList
+    @Published var inactiveQuestList: [Quest] = Quest.mockInactiveDataList
     @Published var showQuestSheet: Bool = false
     @Published var selectedQuest: Quest = Quest.mockData
     @Published var showSubmitRouterView: Bool = false
 
+    var isCurrentListEmpty: Bool {
+        switch selectedHeader {
+        case .ACTIVE:
+            return activeQuestList.isEmpty
+        case .INACTIVE:
+            return inactiveQuestList.isEmpty
+        }
+    }
+    
     func tappedQuestBtn(quest: Quest) {
         selectedQuest = quest
         showQuestSheet.toggle()


### PR DESCRIPTION
#### close #36

### ✏️ 개요
퀘스트가 없을 경우의 각 화면 디자인을 적용하였습니다.

### 💻 작업 사항
- [x] QuestItemView 여백 수정
- [x] 퀘스트 리스트 하단 여백 적용(70) 
- [x] 퀘스트 빈 화면 디자인 적용
  - [x] Quest - mock data 수정(active, inactive 분리)
  - [x] QuestViewModel - activeQuestList, inactiveQuestList 분리
  - [x] QuestViewModel - isCurrentListEmpty 프로퍼티 추가
  - [x] QuestStatus - emptyTitle, emptySubTitle 프로퍼티 추가
  - [x] QuestView - emptyView 생성 및 디자인 적용

### 📄 리뷰 노트
궁금한 부분 있으면 남겨주세요 !

### 📱결과 화면(optional)
<img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/69d551eb-98a7-4a0c-9abe-aef9db0f96b6" width = "240"> 
<img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/3a6d16cd-d42f-4c8b-be4e-d1671f16497b" width = "240"> 
<img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/fc1db400-bc74-4683-9a6c-2ab1764f63b1" width = "240"> 
