### PR TITLE
[Feat/#46] 이미지 조회 API 연결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		600211EA2C1EEE6D000CC02E /* APITarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211E92C1EEE6D000CC02E /* APITarget.swift */; };
 		600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211EB2C1EEED7000CC02E /* APIManager.swift */; };
 		600211EE2C1EEF91000CC02E /* EmojiNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */; };
+		603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F040A2C2416D2008A2332 /* ImageNetwork.swift */; };
 		605DA0C92C07097F00CC9450 /* ImagePreviewButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0C82C07097F00CC9450 /* ImagePreviewButton.swift */; };
 		605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0CC2C070A0300CC9450 /* Camera.swift */; };
 		605DA0CF2C07118900CC9450 /* SubmitRouterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0CE2C07118900CC9450 /* SubmitRouterView.swift */; };
@@ -84,6 +85,7 @@
 		600211E92C1EEE6D000CC02E /* APITarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITarget.swift; sourceTree = "<group>"; };
 		600211EB2C1EEED7000CC02E /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiNetwork.swift; sourceTree = "<group>"; };
+		603F040A2C2416D2008A2332 /* ImageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetwork.swift; sourceTree = "<group>"; };
 		605DA0C82C07097F00CC9450 /* ImagePreviewButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewButton.swift; sourceTree = "<group>"; };
 		605DA0CC2C070A0300CC9450 /* Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
 		605DA0CE2C07118900CC9450 /* SubmitRouterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterView.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 			children = (
 				600211EF2C1EF3F5000CC02E /* Base */,
 				600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */,
+				603F040A2C2416D2008A2332 /* ImageNetwork.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -614,6 +617,7 @@
 				605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */,
 				600211EE2C1EEF91000CC02E /* EmojiNetwork.swift in Sources */,
 				607FCBD62BFA660C00BB2D04 /* MainTabView.swift in Sources */,
+				603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */,
 				605DA0D12C0711CA00CC9450 /* CameraView.swift in Sources */,
 				A1BB602C2BFF145100AAADD4 /* MyPageProfile.swift in Sources */,
 				607FCBE92BFE418600BB2D04 /* QuestViewModel.swift in Sources */,

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -7,10 +7,11 @@
 
 import Alamofire
 import Foundation
+import UIKit
 
-final class Network<T: Decodable> {
+final class Network {
     
-    private static func buildURL(url: String, parameters: Parameters?, page: Int?, size: Int?) -> URL? {
+    private static func buildURL(url: String, parameters: Parameters? = nil, page: Int? = nil, size: Int? = nil) -> URL? {
         var components = URLComponents(string: url)
         var queryItems = [URLQueryItem]()
 
@@ -40,7 +41,7 @@ final class Network<T: Decodable> {
         return headers
     }
     
-    static func requestData(url: String, method: HTTPMethod, parameters: Parameters?, body: Data? = nil, withToken: Bool, page: Int? = nil, size: Int? = nil) async -> Result<T, Error> {
+    static func requestData<T: Decodable>(url: String, method: HTTPMethod, parameters: Parameters?, body: Data? = nil, withToken: Bool, page: Int? = nil, size: Int? = nil) async -> Result<T, Error> {
         guard let fullPath = buildURL(url: url, parameters: parameters, page: page, size: size) else {
             return .failure(NetworkError.invalidURL)
         }
@@ -70,7 +71,33 @@ final class Network<T: Decodable> {
         }
     }
     
+    static func requestImage(url: String, withToken: Bool) async -> Result<UIImage, Error> {
+        guard let fullPath = buildURL(url: url) else {
+            return .failure(NetworkError.invalidURL)
+        }
+        
+        let headers = buildHeaders(withToken: withToken)
+        
+        let request: DataRequest
+        request = AF.request(fullPath, method: .get, headers: headers)
+        
+        let response = await request.validate(statusCode: 200..<300)
+            .serializingData()
+            .response
+        
+        switch response.result {
+        case .success(let imageData):
+            guard let image = UIImage(data: imageData) else {
+                return .failure(NetworkError.invalidImageData)
+            }
+            return .success(image)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+    
     enum NetworkError: Error {
         case invalidURL
+        case invalidImageData
     }
 }

--- a/ILSANG/Sources/Network/ImageNetwork.swift
+++ b/ILSANG/Sources/Network/ImageNetwork.swift
@@ -1,0 +1,22 @@
+//
+//  ImageNetwork.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 6/20/24.
+//
+
+import Alamofire
+import UIKit
+
+final class ImageNetwork {
+    private let url = APIManager.makeURL(CustomerTarget(path: "image/"))
+    
+    func getImage(imageId: String) async -> Result<UIImage,Error> {
+        let url = url + imageId
+        return await Network.requestImage(url: url, withToken: true)
+    }
+    
+    func postImage() {
+        
+    }
+}

--- a/ILSANG/Sources/Views/Approval/ApprovalImageView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalImageView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ApprovalImageView: View {
-    let image: String
+    let image: UIImage
     let width: CGFloat
     let height: CGFloat
     let nickname: String
@@ -16,7 +16,7 @@ struct ApprovalImageView: View {
     let showProfile: Bool
     
     var body: some View {
-        Image(image)
+        Image(uiImage: image)
             .resizable()
             .scaledToFill()
             .frame(width: width, height: height)

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ApprovalView: View {
-    @StateObject var vm = ApprovalViewModel()
+    @StateObject var vm = ApprovalViewModel(imageNetwork: ImageNetwork(), emojiNetwork: EmojiNetwork())
         
     private let viewWidth = UIScreen.main.bounds.width - 40
     private let viewHeight = UIScreen.main.bounds.height
@@ -32,6 +32,7 @@ struct ApprovalView: View {
                 .background(Color.black.opacity(0.2))
         )
         .task {
+            await vm.getChallengesWithImage(page: 0)
             await vm.getEmoji(challengeId: "CH00000100")
         }
     }
@@ -53,16 +54,17 @@ struct ApprovalView: View {
             
             ZStack(alignment: .bottom) {
                 ForEach(vm.itemList.reversed(), id: \.id) { story in
-                    let diff: Int = abs(story.id - vm.idx)
+                    let idx = vm.itemList.firstIndex { $0.id == story.id }
+                    let diff: Int = abs(idx! - vm.currentIdx)
                     ApprovalImageView(
-                        image: story.image,
+                        image: story.image ?? .logo,
                         width: abs(viewWidth - 40 * CGFloat(diff)),
                         height: (viewHeight / 2) - CGFloat(diff) * 26,
                         nickname:story.nickname,
                         time: story.time,
                         showProfile: diff <= 1
                     )
-                    .opacity(vm.calculateOpacity(id: story.id))
+                    .opacity(vm.calculateOpacity(itemIndex: idx!))
                     .offset(y: diff <= 2 ? CGFloat(diff) * 26 : 50)
                     .offset(y: story.offset)
                 }

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -22,7 +22,7 @@ struct ApprovalView: View {
         .ignoresSafeArea()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
-            Image(vm.itemList[vm.idx].image)
+            Image(uiImage: vm.itemList[vm.currentIdx].image ?? .logo)
                 .resizable()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
@@ -39,7 +39,7 @@ struct ApprovalView: View {
     /// 퀘스트 타이틀  + 퀘스트 인증 이미지
     private var itemView: some View {
         VStack(spacing: 14) {
-            Text(vm.itemList[vm.idx].title)
+            Text(vm.itemList[vm.currentIdx].title)
                 .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(.gray400)
                 .frame(height: 45)

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 class ApprovalViewModel: ObservableObject {
     @Published var itemList = ApprovalViewModelItem.mockData
-    @Published var idx = 0
+    @Published var currentIdx = 0
     @Published var isScrolling = false
     
     private let emojiNetwork = EmojiNetwork()
@@ -29,44 +29,44 @@ class ApprovalViewModel: ObservableObject {
     }
     
     func handleDragChange(_ value: DragGesture.Value) {
-        if value.translation.height < 0 && idx != itemList.last!.id {
+        if value.translation.height < 0 && currentIdx != itemList.count-1 {
             isScrolling = true
             
-            itemList[idx].offset = value.translation.height
+            itemList[currentIdx].offset = value.translation.height
             
             /// 다음 이미지 y축 올리는 효과
-            if idx + 1 != itemList.last!.id {
-                itemList[idx + 1].offset = -12
+            if currentIdx + 1 != itemList.count-1 {
+                itemList[currentIdx + 1].offset = -12
             }
         }
     }
     
     func handleDragEnd(_ value: DragGesture.Value, _ viewHeight: CGFloat) {
         if value.translation.height < 0 {  /// 위로 스크롤
-            if idx != itemList.last!.id {
-                itemList[idx].offset = -viewHeight
-                if idx + 1 != itemList.last!.id {
-                    itemList[idx + 1].offset = 0
+            if currentIdx != itemList.count-1 {
+                itemList[currentIdx].offset = -viewHeight
+                if currentIdx + 1 != itemList.count-1 {
+                    itemList[currentIdx + 1].offset = 0
                 }
-                idx += 1
+                currentIdx += 1
             } else {
-                itemList[idx].offset = 0
+                itemList[currentIdx].offset = 0
             }
         } else {  /// 아래로 스크롤
-            if idx > 0 {
+            if currentIdx > 0 {
                 if value.translation.height > 0 {
-                    itemList[idx - 1].offset = 0
-                    idx -= 1
+                    itemList[currentIdx - 1].offset = 0
+                    currentIdx -= 1
                 } else {
-                    itemList[idx - 1].offset = -viewHeight
+                    itemList[currentIdx - 1].offset = -viewHeight
                 }
             }
         }
         isScrolling = false
     }
     
-    func calculateOpacity(id: Int) -> CGFloat {
-        switch abs(id - idx) {
+    func calculateOpacity(itemIndex: Int) -> CGFloat {
+        switch abs(itemIndex - currentIdx) {
         case 0:
             return isScrolling ? 0.5 : 1 /// 활성화된 아이템이 >> 화면 스크롤 중이면 0.5, 스크롤 중이 아니면 1
         case 1:
@@ -80,21 +80,22 @@ class ApprovalViewModel: ObservableObject {
 }
 
 struct ApprovalViewModelItem: Identifiable {
-    var id: Int
+    var id = UUID()
     var title: String
-    var image: String
+    var image: UIImage?
+    var imageId: String
     var offset: CGFloat
     var nickname: String
     var time: String
     
     static var mockData = [
-        ApprovalViewModelItem(id: 0,title: "바닐라라떼마시기", image: "img0", offset: 0, nickname: "일상1", time: "3시간 전"),
-        ApprovalViewModelItem(id: 1,title: "바닐라라떼마시기", image: "img1", offset: 0, nickname: "일상2", time: "1시간 전"),
-        ApprovalViewModelItem(id: 2,title: "바닐라라떼마시기", image: "img2", offset: 0, nickname: "일상3", time: "2시간 전"),
-        ApprovalViewModelItem(id: 3,title: "바닐라라떼마시기", image: "img3", offset: 0, nickname: "일상4", time: "2시간 전"),
-        ApprovalViewModelItem(id: 4,title: "바닐라라떼마시기", image: "img0", offset: 0, nickname: "일상5", time: "1시간 전"),
-        ApprovalViewModelItem(id: 5,title: "바닐라라떼마시기", image: "img1", offset: 0, nickname: "일상6", time: "3시간 전"),
-        ApprovalViewModelItem(id: 6,title: "바닐라라떼마시기", image: "img2", offset: 0, nickname: "일상7", time: "2시간 전"),
-        ApprovalViewModelItem(id: 7,title: "바닐라라떼마시기", image: "img3", offset: 0, nickname: "일상8", time: "3시간 전")
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상1", time: "3시간 전"),
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상2", time: "1시간 전"),
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상3", time: "2시간 전"),
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상4", time: "2시간 전"),
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상5", time: "1시간 전"),
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상6", time: "3시간 전"),
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상7", time: "2시간 전"),
+        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", offset: 0, nickname: "일상8", time: "3시간 전")
     ]
 }


### PR DESCRIPTION
#### close #46 

### ✏️ 개요
이미지 조회 API를 연결하고 ApprovalView에서 확인할 수 있도록 수정했습니다.

### 💻 작업 사항
- [x] 이미지 조회 API 연결
- [x] Network 클래스 수정(네트워크 클래스를 생성할 때 제네릭을 사용 >> 메서드에서 따로 제네릭으로 받을 수 있도록 수정)
- [x] ApprovalView에서 이미지 조회한 결과를 확인할 수 있도록 수정

### 📄 리뷰 노트
도전내역에 해당하는 이미지를 다 불러와서 화면에 그리는 방식이 아닌, 1) 도전내역 정보를 불러와 배열에 더하고 2) 비동기로 이미지 Get 요청하는 방식입니다.

지금은 기본값을 로고로 해두었고, 논의가 필요할 듯하여 지라에 [버그](https://chad0909.atlassian.net/browse/ISPR-99)로 생성해둔 상태입니다.

### 📱결과 화면(optional)
| 기본 이미지 | 서버에서 불러온 도전내역 이미지 |
|--------|--------|
| <img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/cdec14f2-7574-400a-8b92-452cd0f2471d" width = "300">  | <img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/95168a8b-6dc5-42de-b17f-a01769cfb858" width = "300">  | 


