### PR TITLE
[Feat/#49] 도전내역 조회, 도전내역 랜덤 조회 API 연결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		60B8BA022BF9EEF3005F6DE3 /* ILSANGUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8BA012BF9EEF3005F6DE3 /* ILSANGUITests.swift */; };
 		60B8BA042BF9EEF3005F6DE3 /* ILSANGUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8BA032BF9EEF3005F6DE3 /* ILSANGUITestsLaunchTests.swift */; };
 		60B8BA112BF9EF50005F6DE3 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60B8BA102BF9EF50005F6DE3 /* Launch Screen.storyboard */; };
+		60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4D42C2C565700926C0E /* ChallengeNetwork.swift */; };
+		60C6B4D72C2C569800926C0E /* Challenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4D62C2C569800926C0E /* Challenge.swift */; };
 		A1868C442C09B6C50020BF16 /* DetailQuestview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1868C432C09B6C50020BF16 /* DetailQuestview.swift */; };
 		A19628622C0763F90037C53A /* ChangeNickNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19628612C0763F90037C53A /* ChangeNickNameView.swift */; };
 		A19628652C076D7B0037C53A /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19628642C076D7B0037C53A /* SettingView.swift */; };
@@ -121,6 +123,8 @@
 		60B8BA032BF9EEF3005F6DE3 /* ILSANGUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANGUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		60B8BA102BF9EF50005F6DE3 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		60B8BA142BF9F354005F6DE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		60C6B4D42C2C565700926C0E /* ChallengeNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeNetwork.swift; sourceTree = "<group>"; };
+		60C6B4D62C2C569800926C0E /* Challenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Challenge.swift; sourceTree = "<group>"; };
 		A1868C432C09B6C50020BF16 /* DetailQuestview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailQuestview.swift; sourceTree = "<group>"; };
 		A19628612C0763F90037C53A /* ChangeNickNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNickNameView.swift; sourceTree = "<group>"; };
 		A19628642C076D7B0037C53A /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
@@ -174,6 +178,7 @@
 			isa = PBXGroup;
 			children = (
 				600211E72C1EED40000CC02E /* Emoji.swift */,
+				60C6B4D62C2C569800926C0E /* Challenge.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -215,6 +220,7 @@
 				600211EF2C1EF3F5000CC02E /* Base */,
 				600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */,
 				603F040A2C2416D2008A2332 /* ImageNetwork.swift */,
+				60C6B4D42C2C565700926C0E /* ChallengeNetwork.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -610,8 +616,10 @@
 				A1868C442C09B6C50020BF16 /* DetailQuestview.swift in Sources */,
 				607FCBD42BFA648000BB2D04 /* Tab.swift in Sources */,
 				60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */,
+				60C6B4D72C2C569800926C0E /* Challenge.swift in Sources */,
 				60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */,
 				A1AB3D6C2C1142AA001EB9D8 /* LoginButton.swift in Sources */,
+				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				A19628652C076D7B0037C53A /* SettingView.swift in Sources */,
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,
 				606292D82C19E70A0098B6D2 /* Network.swift in Sources */,

--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -1,0 +1,33 @@
+//
+//  Challenge.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 6/26/24.
+//
+
+// TODO: ResponseWithPage와 응답 형식 통일 요청 후 수정
+// MARK: - ICH004 에서 사용되는 모델
+struct RandomChallengeList: Codable {
+    let content: [Challenge]
+    let last: Bool?
+}
+
+struct Challenge: Codable {
+    let challengeId, userNickName: String
+    let quest: QuestEntity
+    let receiptImageId, status: String
+    let likeCnt, hateCnt: Int
+}
+
+/// 서버에서 사용되는 Quest Entity
+struct QuestEntity: Codable {
+    let questId: String
+    let missions: [Mission]
+}
+
+struct Mission: Codable {
+    let content: String
+    let target: String?
+    let quantity: Int
+    let type, title: String
+}

--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -1,0 +1,32 @@
+//
+//  ChallengeNetwork.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 6/26/24.
+//
+
+import Alamofire
+
+final class ChallengeNetwork {
+    private let network: Network
+    private let url: String
+
+    init(network: Network = Network(), url: String =  APIManager.makeURL(CustomerTarget(path: ""))) {
+        self.network = network
+        self.url = url
+    }
+    
+    func getRandomChallenges(page: Int) async -> Result<RandomChallengeList, Error> {
+        let parameters: Parameters = ["page": page, "size": "10"]
+        return await Network.requestData(url: url+"randomChallenge", method: .get, parameters: parameters, withToken: true)
+    }
+    
+    func postChallenge(questId: String, imageId: String) async -> Bool {
+       return true
+    }
+    
+    func getChallenges(page: Int) async -> Result<ResponseWithPage<[Challenge]>, Error> {
+        let parameters: Parameters = ["userDataOnly": true, "page": page, "size": "10"]
+        return await Network.requestData(url: url+"challenge", method: .get, parameters: parameters, withToken: true)
+    }
+}

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct ApprovalView: View {
-    @StateObject var vm = ApprovalViewModel(imageNetwork: ImageNetwork(), emojiNetwork: EmojiNetwork())
+    @StateObject var vm = ApprovalViewModel(
+        imageNetwork: ImageNetwork(),
+        emojiNetwork: EmojiNetwork(),
+        challengeNetwork: ChallengeNetwork()
+    )
         
     private let viewWidth = UIScreen.main.bounds.width - 40
     private let viewHeight = UIScreen.main.bounds.height
@@ -22,59 +26,67 @@ struct ApprovalView: View {
         .ignoresSafeArea()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
-            Image(uiImage: vm.itemList[vm.currentIdx].image ?? .logo)
-                .resizable()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .ignoresSafeArea()
-                .scaledToFill()
-                .scaleEffect(1.4)
-                .blur(radius: 30, opaque: true)
-                .background(Color.black.opacity(0.2))
+            Group {
+                if !vm.itemList.isEmpty {
+                    Image(uiImage: vm.itemList[vm.currentIdx].image ?? .logo)
+                        .resizable()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .ignoresSafeArea()
+                        .scaledToFill()
+                        .scaleEffect(1.4)
+                        .blur(radius: 30, opaque: true)
+                        .background(Color.black.opacity(0.2))
+                }
+            }
         )
         .task {
-            await vm.getChallengesWithImage(page: 1)
+            await vm.getChallengesWithImage(page: 0)
             await vm.getEmoji(challengeId: "86efe988-2acc-4add-99a5-06e414d04dfa")
         }
     }
     
     /// 퀘스트 타이틀  + 퀘스트 인증 이미지
     private var itemView: some View {
-        VStack(spacing: 14) {
-            Text(vm.itemList[vm.currentIdx].title)
-                .font(.system(size: 16, weight: .bold))
-                .foregroundStyle(.gray400)
-                .frame(height: 45)
-                .frame(width: viewWidth - 20, alignment: .leading)
-                .padding(.leading, 16)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .foregroundStyle(.white)
-                )
-                .zIndex(1)
-            
-            ZStack(alignment: .bottom) {
-                ForEach(vm.itemList.reversed(), id: \.id) { story in
-                    let idx = vm.itemList.firstIndex { $0.id == story.id }
-                    let diff: Int = abs(idx! - vm.currentIdx)
-                    ApprovalImageView(
-                        image: story.image ?? .logo,
-                        width: abs(viewWidth - 40 * CGFloat(diff)),
-                        height: (viewHeight / 2) - CGFloat(diff) * 26,
-                        nickname:story.nickname,
-                        time: story.time,
-                        showProfile: diff <= 1
-                    )
-                    .opacity(vm.calculateOpacity(itemIndex: idx!))
-                    .offset(y: diff <= 2 ? CGFloat(diff) * 26 : 50)
-                    .offset(y: story.offset)
+        Group {
+            if !vm.itemList.isEmpty {
+                VStack(spacing: 14) {
+                    Text(vm.itemList[vm.currentIdx].title)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundStyle(.gray400)
+                        .frame(height: 45)
+                        .frame(width: viewWidth - 20, alignment: .leading)
+                        .padding(.leading, 16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .foregroundStyle(.white)
+                        )
+                        .zIndex(1)
+                    
+                    ZStack(alignment: .bottom) {
+                        ForEach(vm.itemList.reversed(), id: \.id) { story in
+                            let idx = vm.itemList.firstIndex { $0.id == story.id }
+                            let diff: Int = abs(idx! - vm.currentIdx)
+                            ApprovalImageView(
+                                image: story.image ?? .logo,
+                                width: abs(viewWidth - 40 * CGFloat(diff)),
+                                height: (viewHeight / 2) - CGFloat(diff) * 26,
+                                nickname:story.nickname,
+                                time: story.time,
+                                showProfile: diff <= 1
+                            )
+                            .opacity(vm.calculateOpacity(itemIndex: idx!))
+                            .offset(y: diff <= 2 ? CGFloat(diff) * 26 : 50)
+                            .offset(y: story.offset)
+                        }
+                        .gesture(dragGesture)
+                    }
+                    .mask(alignment: .top) {
+                        maskArea
+                    }
                 }
-                .gesture(dragGesture)
-            }
-            .mask(alignment: .top) {
-                maskArea
+                .shadow(color: .shadowFF.opacity(0.25), radius: 20, x: 0, y: 12)
             }
         }
-        .shadow(color: .shadowFF.opacity(0.25), radius: 20, x: 0, y: 12)
     }
     
     /// 이미지 스크롤 시 상단 마스크


### PR DESCRIPTION
#### close #49 

### ✏️ 개요
도전내역 조회, 도전내역 랜덤 조회 API를 연결했습니다.

### 💻 작업 사항
- 도전내역 조회는 Network부분만 연결해둔 상태입니다.
- 도전내역 랜덤 조회는 연결해두었으나, 응답값과 페이지 처리에 필요한 파라미터들이 다른 api들과 달라 나중에 통일되면 재수정될 것 같습니다.(data가 아닌 content.. 등등)
- 또한 랜덤조회에 들어오는 도전내역들의 id가 모두 동일한 상태여서 지금 상태로 스와이프하면 이상하게 보여집니다. 백에서 로직이 수정되면 문제 없을 것 같습니다!?!..

### 📄 리뷰 노트
없습니다-!!

### 📱결과 화면(optional)
<img src = "https://github.com/TeamFair/ILSANG-iOS/assets/100195563/a8047105-9991-4522-a17b-93cb8af9b415" width = "300"> 
