### PR TITLE
[Feat/#69] 도전내역 등록 API 연결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F040A2C2416D2008A2332 /* ImageNetwork.swift */; };
 		603F04132C26ADC6008A2332 /* CommonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F04122C26ADC6008A2332 /* CommonResponse.swift */; };
 		6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B71C2C32B6A4002C13A0 /* UIImage++.swift */; };
+		6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B7342C3442E6002C13A0 /* NetworkError.swift */; };
 		605DA0C92C07097F00CC9450 /* ImagePreviewButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0C82C07097F00CC9450 /* ImagePreviewButton.swift */; };
 		605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0CC2C070A0300CC9450 /* Camera.swift */; };
 		605DA0CF2C07118900CC9450 /* SubmitRouterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0CE2C07118900CC9450 /* SubmitRouterView.swift */; };
@@ -104,6 +105,7 @@
 		603F040A2C2416D2008A2332 /* ImageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetwork.swift; sourceTree = "<group>"; };
 		603F04122C26ADC6008A2332 /* CommonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResponse.swift; sourceTree = "<group>"; };
 		6044B71C2C32B6A4002C13A0 /* UIImage++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage++.swift"; sourceTree = "<group>"; };
+		6044B7342C3442E6002C13A0 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		605DA0C82C07097F00CC9450 /* ImagePreviewButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewButton.swift; sourceTree = "<group>"; };
 		605DA0CC2C070A0300CC9450 /* Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
 		605DA0CE2C07118900CC9450 /* SubmitRouterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterView.swift; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 			isa = PBXGroup;
 			children = (
 				606292D72C19E70A0098B6D2 /* Network.swift */,
+				6044B7342C3442E6002C13A0 /* NetworkError.swift */,
 				600211EB2C1EEED7000CC02E /* APIManager.swift */,
 				600211E92C1EEE6D000CC02E /* APITarget.swift */,
 				603F04122C26ADC6008A2332 /* CommonResponse.swift */,
@@ -650,6 +653,7 @@
 				A19628752C08648C0037C53A /* NavigationTitleView.swift in Sources */,
 				A1AB3D5D2C113A70001EB9D8 /* LoginView.swift in Sources */,
 				A196286F2C0859910037C53A /* DeleteAccountView.swift in Sources */,
+				6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */,
 				A1AB3D6A2C1141B3001EB9D8 /* AppleLoginButtonView.swift in Sources */,
 				600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */,
 				A1FF916E2C250C3B00F03E4B /* UserNetwork.swift in Sources */,

--- a/ILSANG/Sources/Global/Model/Quest.swift
+++ b/ILSANG/Sources/Global/Model/Quest.swift
@@ -28,7 +28,7 @@ extension Quest {
     
     static let mockActiveDataList: [Quest] = [
         Quest(
-            id: "12",
+            id: "9f8aacc9-a221-491b-98c1-f9d7d35a67fb",
             missionImage: .checkmark,
             missionTitle: "아메리카노 15잔 마시기",
             missionCompany: "이디야커피",

--- a/ILSANG/Sources/Network/Base/APIManager.swift
+++ b/ILSANG/Sources/Network/Base/APIManager.swift
@@ -17,7 +17,7 @@ final class APIManager {
     #endif
     
     ///개발용 토큰
-    static let authDevelopToken = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJkNTg5MjQ3MC01ZDY5LTQ5NDctOGE4Ny1mMDY0OWRlNmVkOWMiLCJ1c2VyVHlwZSI6IkNVU1RPTUVSIn0.lsxRIl6u0WF0dUdHulTTS3HrPyo8D_2w5Bva3-tnAw8"
+    static let authDevelopToken =  "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJjODc3NzlkNi01YTc4LTQ2OTUtOGYxMy1lMDMxZjk1NTVkOTYiLCJ1c2VyVHlwZSI6IkNVU1RPTUVSIn0.DKQYepBPsqstv6nmeQPOvPjwAHdbtnFlASqrhd20uh4"
     
     static func makeURL(_ target: APITarget) -> String {
         baseURL + ":" + port + "/api/" + target.type + "/" + target.path

--- a/ILSANG/Sources/Network/Base/CommonResponse.swift
+++ b/ILSANG/Sources/Network/Base/CommonResponse.swift
@@ -5,6 +5,8 @@
 //  Created by Lee Jinhee on 6/22/24.
 //
 
+import Alamofire
+
 struct Response<T: Decodable>: Decodable {
     let data: T
     let errorStatus: String?
@@ -42,5 +44,12 @@ struct ResponseWithoutData: Decodable {
         self.errMessage = errMessage
         self.status = status
         self.message = message
+    }
+}
+
+/// 200번 코드에 서버 응답값이 없는 경우 사용
+struct ResponseWithEmpty: Decodable, EmptyResponse {
+    static func emptyValue() -> ResponseWithEmpty {
+        return ResponseWithEmpty.init()
     }
 }

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -185,14 +185,4 @@ extension Network {
             }
         }
     }
-    
-    enum NetworkError: Error {
-        case invalidURL
-        case invalidImageData
-        case clientError
-        case serverError
-        case requestFailed(String)
-        case unknownError
-        case unknownStatusCode(Int)
-    }
 }

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -63,7 +63,7 @@ final class Network {
         }
         
         let response = await request.validate(statusCode: 200..<300)
-            .serializingDecodable(T.self)
+            .serializingDecodable(T.self, emptyResponseCodes: [200])
             .response
         
         switch response.result {

--- a/ILSANG/Sources/Network/Base/NetworkError.swift
+++ b/ILSANG/Sources/Network/Base/NetworkError.swift
@@ -1,0 +1,17 @@
+//
+//  NetworkError.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 7/2/24.
+//
+
+enum NetworkError: Error {
+    case invalidURL
+    case invalidImageData
+    case clientError
+    case serverError
+    case requestFailed(String)
+    case unknownError
+    case unknownStatusCode(Int)
+    case emptyResponse
+}

--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import Foundation
 
 final class ChallengeNetwork {
     private let network: Network
@@ -21,12 +22,31 @@ final class ChallengeNetwork {
         return await Network.requestData(url: url+"randomChallenge", method: .get, parameters: parameters, withToken: true)
     }
     
-    func postChallenge(questId: String, imageId: String) async -> Bool {
-       return true
-    }
-    
     func getChallenges(page: Int) async -> Result<ResponseWithPage<[Challenge]>, Error> {
         let parameters: Parameters = ["userDataOnly": true, "page": page, "size": "10"]
         return await Network.requestData(url: url+"challenge", method: .get, parameters: parameters, withToken: true)
+    }
+    
+    func postChallenge(questId: String, imageId: String) async -> Result<ResponseWithEmpty, Error> {
+        let bodyData: [String: Any] = [
+            "questId": questId,
+            "receiptImageId": imageId
+        ]
+        
+        guard let jsonData = convertToJsonData(dictionary: bodyData) else {
+            return .failure(NetworkError.requestFailed("Fail to convert data"))
+        }
+        return await Network.requestData(url: url+"challenge", method: .post, parameters: nil, body: jsonData, withToken: true)
+    }
+    
+    /// Dictionary를 JSON 데이터로 변환하는 함수
+    func convertToJsonData(dictionary: [String: Any]) -> Data? {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+            return jsonData
+        } catch {
+            print("JSON Convert Error: \(error.localizedDescription)")
+            return nil
+        }
     }
 }

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitAlertViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitAlertViewModel.swift
@@ -13,13 +13,15 @@ class SubmitAlertViewModel: ObservableObject {
     @Published var showSubmitAlertView: Bool
     
     private let imageNetwork: ImageNetwork
+    private let challengeNetwork: ChallengeNetwork
 
     let selectedQuestId: String
     
-    init(selectedImage: UIImage? = nil, selectedQuestId: String, imageNetwork: ImageNetwork, showSubmitAlertView: Bool) {
+    init(selectedImage: UIImage? = nil, selectedQuestId: String, imageNetwork: ImageNetwork, challengeNetwork: ChallengeNetwork, showSubmitAlertView: Bool) {
         self.selectedImage = selectedImage
         self.selectedQuestId = selectedQuestId
         self.imageNetwork = imageNetwork
+        self.challengeNetwork = challengeNetwork
         self.showSubmitAlertView = showSubmitAlertView
     }
     
@@ -56,7 +58,12 @@ class SubmitAlertViewModel: ObservableObject {
     }
     
     private func postChallenge(imageId: String) async -> Bool {
-        // TODO: 도전내역 POST API 연결
-        return true
+        let res = await challengeNetwork.postChallenge(questId: selectedQuestId, imageId: imageId)
+        switch res {
+        case .success:
+            return true
+        case .failure:
+            return false
+        }
     }
 }

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitRouterView.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitRouterView.swift
@@ -40,7 +40,7 @@ struct SubmitRouterView: View {
         }
         .background(Color.white)
         .overlay {
-            SubmitAlertView(vm: SubmitAlertViewModel(selectedImage: vm.selectedImage, selectedQuestId: vm.selectedQuestId, imageNetwork: ImageNetwork(), showSubmitAlertView: vm.showSubmitAlertView))
+            SubmitAlertView(vm: SubmitAlertViewModel(selectedImage: vm.selectedImage, selectedQuestId: vm.selectedQuestId, imageNetwork: ImageNetwork(), challengeNetwork: ChallengeNetwork(), showSubmitAlertView: vm.showSubmitAlertView))
         }
     }
 }


### PR DESCRIPTION
#### close #69

### ✏️ 개요
도전내역 등록 API 연결하고 사용부를 구현하였습니다.

### 💻 작업 사항
- [x] ChallengeNetwork에 도전내역 등록 API 요청 메서드 구현
- [x] SubmitAlertViewModel에서 ChallengeNetwork를 사용하도록 구현
- [x] 개발 토큰 변경

### 📄 리뷰 노트
서버 api에 요청은 200번으로 성공하였지만, 응답값이 없는 경우 `ResponseWithEmpty` 모델을 사용하도록 구조체를 생성해두었습니다.
