### PR TITLE
[Feat/#81] 애플 로그인 구현, 로그인 API 연결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		600211EA2C1EEE6D000CC02E /* APITarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211E92C1EEE6D000CC02E /* APITarget.swift */; };
 		600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211EB2C1EEED7000CC02E /* APIManager.swift */; };
 		600211EE2C1EEF91000CC02E /* EmojiNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */; };
+		6011891D2C3E8B3B0070F2AD /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6011891C2C3E8B3B0070F2AD /* UserService.swift */; };
+		6011891F2C3E94380070F2AD /* AuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6011891E2C3E94380070F2AD /* AuthUser.swift */; };
+		601189212C3E94A60070F2AD /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189202C3E94A60070F2AD /* AuthService.swift */; };
+		601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189222C3E95D40070F2AD /* AuthNetwork.swift */; };
+		601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189262C3F00FB0070F2AD /* AuthChannel.swift */; };
 		603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F040A2C2416D2008A2332 /* ImageNetwork.swift */; };
 		603F04132C26ADC6008A2332 /* CommonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F04122C26ADC6008A2332 /* CommonResponse.swift */; };
 		6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B71C2C32B6A4002C13A0 /* UIImage++.swift */; };
@@ -106,6 +111,12 @@
 		600211E92C1EEE6D000CC02E /* APITarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITarget.swift; sourceTree = "<group>"; };
 		600211EB2C1EEED7000CC02E /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiNetwork.swift; sourceTree = "<group>"; };
+		601189182C3E84720070F2AD /* ILSANG.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ILSANG.entitlements; sourceTree = "<group>"; };
+		6011891C2C3E8B3B0070F2AD /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		6011891E2C3E94380070F2AD /* AuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUser.swift; sourceTree = "<group>"; };
+		601189202C3E94A60070F2AD /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		601189222C3E95D40070F2AD /* AuthNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNetwork.swift; sourceTree = "<group>"; };
+		601189262C3F00FB0070F2AD /* AuthChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthChannel.swift; sourceTree = "<group>"; };
 		603F040A2C2416D2008A2332 /* ImageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetwork.swift; sourceTree = "<group>"; };
 		603F04122C26ADC6008A2332 /* CommonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResponse.swift; sourceTree = "<group>"; };
 		6044B71C2C32B6A4002C13A0 /* UIImage++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage++.swift"; sourceTree = "<group>"; };
@@ -220,6 +231,7 @@
 				60C6B4D62C2C569800926C0E /* Challenge.swift */,
 				A18EB9B32C26B6C200405D56 /* Logout.swift */,
 				A18EB9B52C26B6D100405D56 /* Withdraw.swift */,
+				6011891E2C3E94380070F2AD /* AuthUser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -234,6 +246,15 @@
 				603F04122C26ADC6008A2332 /* CommonResponse.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		6011891B2C3E8B2B0070F2AD /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				6011891C2C3E8B3B0070F2AD /* UserService.swift */,
+				601189202C3E94A60070F2AD /* AuthService.swift */,
+			);
+			path = Service;
 			sourceTree = "<group>";
 		};
 		605DA0D42C07122200CC9450 /* Extension */ = {
@@ -263,6 +284,7 @@
 			isa = PBXGroup;
 			children = (
 				600211EF2C1EF3F5000CC02E /* Base */,
+				601189222C3E95D40070F2AD /* AuthNetwork.swift */,
 				600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */,
 				A1FF916D2C250C3B00F03E4B /* UserNetwork.swift */,
 				A1FF916F2C25119200F03E4B /* XPNetwork.swift */,
@@ -360,6 +382,7 @@
 				A1BB602D2C022A9900AAADD4 /* UserData.swift */,
 				A19628682C0775A70037C53A /* Setting.swift */,
 				A1AB3D6B2C1142AA001EB9D8 /* LoginButton.swift */,
+				601189262C3F00FB0070F2AD /* AuthChannel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -388,6 +411,7 @@
 		60B8B9E52BF9EEF1005F6DE3 /* ILSANG */ = {
 			isa = PBXGroup;
 			children = (
+				601189182C3E84720070F2AD /* ILSANG.entitlements */,
 				60B8BA142BF9F354005F6DE3 /* Info.plist */,
 				60B8BA122BF9EF8B005F6DE3 /* Resources */,
 				60B8BA132BF9F07D005F6DE3 /* Sources */,
@@ -435,6 +459,7 @@
 		60B8BA132BF9F07D005F6DE3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				6011891B2C3E8B2B0070F2AD /* Service */,
 				600211E62C1EED2B000CC02E /* Model */,
 				606292D62C19E6C00098B6D2 /* Network */,
 				605DA0D42C07122200CC9450 /* Extension */,
@@ -666,6 +691,7 @@
 				607FCBD82BFA681500BB2D04 /* ApprovalView.swift in Sources */,
 				A1AB3D692C1141B3001EB9D8 /* KakaoLoginButtonView.swift in Sources */,
 				A142E0312C2D9F37004395F8 /* SettingAlertView.swift in Sources */,
+				601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */,
 				A1BB60262BFE05B000AAADD4 /* MyPageSegmenet.swift in Sources */,
 				605DA0D62C07123400CC9450 /* View++.swift in Sources */,
 				A1BB602E2C022A9900AAADD4 /* UserData.swift in Sources */,
@@ -674,6 +700,7 @@
 				A1AB3D5D2C113A70001EB9D8 /* LoginView.swift in Sources */,
 				A196286F2C0859910037C53A /* DeleteAccountView.swift in Sources */,
 				6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */,
+				601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */,
 				A1AB3D6A2C1141B3001EB9D8 /* AppleLoginButtonView.swift in Sources */,
 				600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */,
 				A1FF916E2C250C3B00F03E4B /* UserNetwork.swift in Sources */,
@@ -696,6 +723,7 @@
 				A1868C442C09B6C50020BF16 /* DetailQuestview.swift in Sources */,
 				6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */,
 				607FCBD42BFA648000BB2D04 /* Tab.swift in Sources */,
+				6011891F2C3E94380070F2AD /* AuthUser.swift in Sources */,
 				A1FF91722C257E9A00F03E4B /* User.swift in Sources */,
 				60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */,
 				60C6B4D72C2C569800926C0E /* Challenge.swift in Sources */,
@@ -710,10 +738,12 @@
 				608EBFA12C39C5BB00B862CC /* String++.swift in Sources */,
 				600211EA2C1EEE6D000CC02E /* APITarget.swift in Sources */,
 				A1BB60282BFE129000AAADD4 /* MyPageList.swift in Sources */,
+				6011891D2C3E8B3B0070F2AD /* UserService.swift in Sources */,
 				A196286D2C0859820037C53A /* TermsAndPolicyView.swift in Sources */,
 				A1F770642C2AABCE00DB24A0 /* MypageViewModel.swift in Sources */,
 				605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */,
 				600211EE2C1EEF91000CC02E /* EmojiNetwork.swift in Sources */,
+				601189212C3E94A60070F2AD /* AuthService.swift in Sources */,
 				607FCBD62BFA660C00BB2D04 /* MainTabView.swift in Sources */,
 				603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */,
 				605DA0D12C0711CA00CC9450 /* CameraView.swift in Sources */,
@@ -885,6 +915,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ILSANG/ILSANG.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";
@@ -924,6 +955,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ILSANG/ILSANG.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";

--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		601189212C3E94A60070F2AD /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189202C3E94A60070F2AD /* AuthService.swift */; };
 		601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189222C3E95D40070F2AD /* AuthNetwork.swift */; };
 		601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189262C3F00FB0070F2AD /* AuthChannel.swift */; };
+		601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189282C3F022D0070F2AD /* LoginViewModel.swift */; };
 		603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F040A2C2416D2008A2332 /* ImageNetwork.swift */; };
 		603F04132C26ADC6008A2332 /* CommonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F04122C26ADC6008A2332 /* CommonResponse.swift */; };
 		6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B71C2C32B6A4002C13A0 /* UIImage++.swift */; };
@@ -117,6 +118,7 @@
 		601189202C3E94A60070F2AD /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		601189222C3E95D40070F2AD /* AuthNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNetwork.swift; sourceTree = "<group>"; };
 		601189262C3F00FB0070F2AD /* AuthChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthChannel.swift; sourceTree = "<group>"; };
+		601189282C3F022D0070F2AD /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		603F040A2C2416D2008A2332 /* ImageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetwork.swift; sourceTree = "<group>"; };
 		603F04122C26ADC6008A2332 /* CommonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResponse.swift; sourceTree = "<group>"; };
 		6044B71C2C32B6A4002C13A0 /* UIImage++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage++.swift"; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 			isa = PBXGroup;
 			children = (
 				A1AB3D5C2C113A70001EB9D8 /* LoginView.swift */,
+				601189282C3F022D0070F2AD /* LoginViewModel.swift */,
 				A1AB3D672C1141B3001EB9D8 /* AppleLoginButtonView.swift */,
 				A1AB3D652C1141B3001EB9D8 /* GoogleLoginButtonView.swift */,
 				A1AB3D662C1141B3001EB9D8 /* KakaoLoginButtonView.swift */,
@@ -706,6 +709,7 @@
 				A1FF916E2C250C3B00F03E4B /* UserNetwork.swift in Sources */,
 				A1AB3D6E2C117569001EB9D8 /* Color.swift in Sources */,
 				A1AB3D682C1141B3001EB9D8 /* GoogleLoginButtonView.swift in Sources */,
+				601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */,
 				A19628622C0763F90037C53A /* ChangeNickNameView.swift in Sources */,
 				60C6B4DF2C2D053600926C0E /* SubmitRouterViewModel.swift in Sources */,
 				605DA0C92C07097F00CC9450 /* ImagePreviewButton.swift in Sources */,

--- a/ILSANG/ILSANG.entitlements
+++ b/ILSANG/ILSANG.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/ILSANG/Sources/Global/Model/AuthChannel.swift
+++ b/ILSANG/Sources/Global/Model/AuthChannel.swift
@@ -1,0 +1,36 @@
+//
+//  AuthChannel.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 7/11/24.
+//
+
+enum AuthChannel {
+    case Kakao
+    case Apple
+    case Google
+    
+    var stringValue: String {
+        switch self {
+        case .Kakao:
+            "KAKAO"
+        case .Apple:
+            "APPLE"
+        case .Google:
+            "GOOGLE"
+        }
+    }
+    
+    static func fromString(value: String) -> AuthChannel? {
+        switch value {
+        case "KAKAO":
+            return .Kakao
+        case "APPLE":
+            return .Apple
+        case "GOOGLE":
+            return .Google
+        default:
+            return nil
+        }
+    }
+}

--- a/ILSANG/Sources/Model/AuthUser.swift
+++ b/ILSANG/Sources/Model/AuthUser.swift
@@ -1,0 +1,17 @@
+//
+//  AuthUser.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 7/10/24.
+//
+
+struct AuthUser {
+    var email: String
+    var accessToken: String
+    var refreshToken: String
+}
+
+struct AuthResponse {
+    var authToken: String
+    var authUser: AuthUser
+}

--- a/ILSANG/Sources/Network/AuthNetwork.swift
+++ b/ILSANG/Sources/Network/AuthNetwork.swift
@@ -1,0 +1,32 @@
+//
+//  AuthNetwork.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 7/10/24.
+//
+
+import Foundation
+
+final class AuthNetwork {
+    private let url = APIManager.makeURL(OpenTarget(path: "login"))
+    
+    func login(accessToken: String, refreshToken: String = "tokenString", email: String, channel: AuthChannel) async -> Result<String, NetworkError> {
+        let body = ["userType": "CUSTOMER",
+                    "accessToken": accessToken,
+                    "refreshToken": refreshToken,
+                    "email": email,
+                    "channel": channel.stringValue]
+        let bodyData = body.convertToJsonData()
+        let response: Result<Response<AwsAuth>, Error> = await Network.requestData(url: url, method: .post, parameters: nil, body: bodyData, withToken: false)
+        
+        switch response {
+        case .success(let res):
+            guard let auth = res.data.authorization else {
+                return .failure(NetworkError.requestFailed("Invalid Data"))
+            }
+            return .success(auth)
+        case .failure(let error):
+            return .failure(.requestFailed(error.localizedDescription))
+        }
+    }
+}

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -39,7 +39,8 @@ final class Network {
     private static func buildHeaders(withToken: Bool, contentType: ContentType = .json) -> HTTPHeaders {
         var headers: HTTPHeaders = ["accept": "application/json", "Content-Type": contentType.toString]
         if withToken {
-            headers.add(.authorization(APIManager.authDevelopToken))
+            let token = UserService.shared.authToken
+            headers.add(.authorization(token))
         }
         return headers
     }

--- a/ILSANG/Sources/Service/AuthService.swift
+++ b/ILSANG/Sources/Service/AuthService.swift
@@ -1,0 +1,80 @@
+//
+//  AuthService.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 7/10/24.
+//
+
+import AuthenticationServices
+import Alamofire
+
+class AuthService {
+    let authNetwork: AuthNetwork = AuthNetwork()
+    
+    // MARK: - LoginView에서 애플로그인 시 사용
+    func loginWithApple(credential: ASAuthorizationAppleIDCredential, storedEmail: String) async -> AuthResponse? {
+        guard let identityToken = credential.identityToken else {
+            Log("ERROR WITH IDENTITYTOKEN")
+            return nil
+        }
+        
+        guard let tokenString = String(data: identityToken, encoding: .utf8) else {
+            Log("ERROR WITH TOKEN ENCODING")
+            return nil
+        }
+        
+        var email = ""
+        if let credentialEmail = credential.email, credentialEmail != "" {
+            email = credentialEmail
+        } else {
+            // TODO: TokenString으로 email 받아오기
+            email = storedEmail
+        }
+        
+        let result = await authNetwork.login(accessToken: tokenString, email: email, channel: .Apple)
+        switch result {
+        case .success(let token):
+            // TODO: BE 로직 추가 시 refreshToken 관련 확인 필요
+            return AuthResponse(
+                authToken: token,
+                authUser: AuthUser(email: email, accessToken: tokenString, refreshToken: "")
+            )
+        case .failure(let error):
+            Log(error.localizedDescription)
+            return nil
+        }
+    }
+    
+    /// AuthChannel에 따라  재로그인 시 사용
+    func loginWithChannel(user: AuthUser, channel: AuthChannel) async -> AuthResponse? {
+        let result = await authNetwork.login(accessToken: user.accessToken, refreshToken: user.refreshToken, email: user.email, channel: channel)
+        
+        switch result {
+        case .success(let authToken):
+            return AuthResponse(authToken: authToken, authUser: user)
+        case .failure(let error):
+            Log(error.localizedDescription)
+            return nil
+        }
+    }
+    
+    #if DEBUG
+    func loginWithTest(email userEmail: String) async -> AuthResponse? {
+        let result = await authNetwork.login(accessToken: "", email: userEmail, channel: .Apple)
+        switch result {
+        case .success(let token):
+            return AuthResponse(
+                authToken: token,
+                authUser: AuthUser(email: userEmail, accessToken: "", refreshToken: "")
+            )
+        case .failure(let error):
+            Log(error.localizedDescription)
+            return nil
+        }
+    }
+    #endif
+}
+
+struct AwsAuth: Codable {
+    let authorization: String?
+}

--- a/ILSANG/Sources/Service/UserService.swift
+++ b/ILSANG/Sources/Service/UserService.swift
@@ -1,0 +1,117 @@
+//
+//  UserService.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 7/10/24.
+//
+
+import SwiftUI
+import AuthenticationServices
+
+final class UserService: ObservableObject {
+    let userNetwork: UserNetwork = UserNetwork()
+    let authService: AuthService = AuthService()
+    
+    @AppStorage("isLogin") var isLogin = Bool()
+    
+    @AppStorage("authToken") var authToken: String = ""
+    @AppStorage("accessToken") var accessToken: String = ""
+    @AppStorage("refreshToken") var refreshToken: String = ""
+    @AppStorage("userEmail") var userEmail: String = ""
+    @AppStorage("authChannel") var authChannel = ""
+    
+    /// Apple Login은 1번만 emai을 제공하기 때문에 따로 관리
+    @AppStorage("appleEmail") var appleEmail: String = ""
+    
+    @Published var currentUser: User?
+    
+    static var shared = UserService()
+    
+    private init() { }
+    
+    // MARK: - 로그인
+    /// 첫 애플 로그인하는 경우
+    @MainActor
+    func login(appleCredential: ASAuthorizationAppleIDCredential) async {
+        guard let authResult = await authService.loginWithApple(credential: appleCredential, storedEmail: appleEmail) else {
+            return
+        }
+        
+        // TODO: 애플 로그인 - 백이랑 상의해서 리프레시토큰 받아야함
+        self.authToken = authResult.authToken
+        self.authChannel = AuthChannel.Apple.stringValue
+        
+        if authResult.authUser.email != "" {
+            self.appleEmail = authResult.authUser.email
+        }
+        await fetchUserInfo()
+        
+        self.isLogin = true
+    }
+    
+    @MainActor
+    func fetchUserInfo() async {
+        let userInfo = await userNetwork.getUser()
+        switch userInfo {
+        case .success(let res):
+            self.currentUser = res.data
+        case .failure:
+            self.currentUser = nil
+        }
+    }
+    
+    /// 갖고 있는 토큰으로 로그인 시도
+    func login() async throws -> Bool {
+        let authUser = AuthUser(email: userEmail, accessToken: accessToken, refreshToken: refreshToken)
+        if authToken.isEmpty {
+            await updateLoginStatus(false)
+            return false
+        }
+        guard let user = await authService.loginWithChannel(user: authUser, channel: AuthChannel.fromString(value: authChannel)!) else {
+            // try await logout()
+            return false
+        }
+        await updateLoginStatus(true, authToken: user.authToken)
+        await fetchUserInfo()
+        return true
+    }
+    
+    /// 새로 발급 받는 토큰으로 로그인하는 경우, 아직사용하지 않음
+    func login(accessToken: String, refreshToken: String, channel: AuthChannel) async throws {
+        let authUser = AuthUser(email: userEmail, accessToken: accessToken, refreshToken: refreshToken)
+        
+        guard let user = await authService.loginWithChannel(user: authUser, channel: channel) else {
+            // try await logout()
+            await updateLoginStatus(false)
+            return
+        }
+        await updateLoginStatus(true, authToken: user.authToken)
+        await fetchUserInfo()
+    }
+    
+    @MainActor
+    private func updateLoginStatus(_ isLogin: Bool, authToken: String) {
+        if self.isLogin != isLogin {
+            self.isLogin = isLogin
+        }
+        self.authToken = authToken
+    }
+    
+    @MainActor
+    private func updateLoginStatus(_ isLogin: Bool) {
+        if self.isLogin != isLogin {
+            self.isLogin = isLogin
+        }
+    }
+    
+    #if DEBUG
+    func loginWithTest() async {
+        guard let res = await authService.loginWithTest(email: "text@naver.com") else { return }
+        self.authToken = res.authToken
+        self.userEmail = "text@naver.com"
+        self.authChannel = AuthChannel.Apple.stringValue
+        await fetchUserInfo()
+        self.isLogin = true
+    }
+    #endif
+}

--- a/ILSANG/Sources/Views/ILSANGApp.swift
+++ b/ILSANG/Sources/Views/ILSANGApp.swift
@@ -9,19 +9,33 @@ import SwiftUI
 
 @main
 struct ILSANGApp: App {
+    @AppStorage("isLogin") var isLogin = Bool()
+    
     init() {
         setTabBarAppearance()
     }
     
-    @State private var isLogin: Bool = false
-    
     var body: some Scene {
         WindowGroup {
             if !isLogin {
-                LoginView(isLogin: $isLogin)
+                LoginView(vm: LoginViewModel())
             } else {
                 MainTabView()
+                    .task {
+                        if isLogin {
+                            await handleLogin()
+                        }
+                    }
             }
+        }
+    }
+    
+    @MainActor
+    private func handleLogin() async {
+        do {
+            isLogin = try await UserService.shared.login()
+        } catch {
+            isLogin = false
         }
     }
     

--- a/ILSANG/Sources/Views/Login/AppleLoginButtonView.swift
+++ b/ILSANG/Sources/Views/Login/AppleLoginButtonView.swift
@@ -6,28 +6,21 @@
 //
 
 import SwiftUI
-import _AuthenticationServices_SwiftUI
+import AuthenticationServices
 
 struct AppleLoginButtonView: View {
+    @ObservedObject var vm: LoginViewModel
     
-    //@EnvironmentObject var userService: UserService
-            
     var body: some View {
-        SignInWithAppleButton { (request) in
+        SignInWithAppleButton { request in
             request.requestedScopes = [.email]
             request.nonce = sha256(randomNonceString())
-        } onCompletion: { (result) in
+        } onCompletion: { result in
             switch result {
-            case .success(let user):
-                Task {
-                    guard let credential = user.credential as? ASAuthorizationAppleIDCredential else {
-                        print("error with credential")
-                        return
-                    }
-                    //await userService.login(appleCredential: credential, email: userService.userEmail)
-                }
+            case .success(let authResult):
+                vm.loginWithApple(credential: authResult.credential)
             case .failure(let error):
-                print(error.localizedDescription)
+                Log(error.localizedDescription)
             }
         }
         .frame(width: 270, height: 50)

--- a/ILSANG/Sources/Views/Login/GoogleLoginButtonView.swift
+++ b/ILSANG/Sources/Views/Login/GoogleLoginButtonView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct GoogleLoginButtonView: View {
-    var buttonAction: () -> Void
+    var buttonAction:  () -> ()
     
     var body: some View {
         Button(action: buttonAction) {

--- a/ILSANG/Sources/Views/Login/LoginView.swift
+++ b/ILSANG/Sources/Views/Login/LoginView.swift
@@ -8,35 +8,22 @@
 import SwiftUI
 
 struct LoginView: View {
-    
-    @Binding var isLogin : Bool
-        
-    var kakaoButtonAction: () -> Void {
-        {
-            //MARK: 로그인 기능 구현
-        }
-    }
-    
-    var googleButtonAction: () -> Void {
-        {
-            //MARK: 로그인 기능 구현
-        }
-    }
+    @StateObject var vm: LoginViewModel
     
     var body: some View {
         VStack(spacing: 84) {
             Image(.loginLogo)
             
             VStack(spacing: 16) {
-                KakaoLoginButtonView(buttonAction: kakaoButtonAction)
-                GoogleLoginButtonView(buttonAction: googleButtonAction)
-                AppleLoginButtonView()
-                //.environmentObject(userService)
+                KakaoLoginButtonView(buttonAction: vm.kakaoButtonAction)
+                GoogleLoginButtonView(buttonAction: vm.googleButtonAction)
                 
-                //MARK: 실제 로그인이 아니고 뷰만 이동합니다.
-                //await userService.loginWithTest()
+                AppleLoginButtonView(vm: vm)
+                
+#if DEBUG
                 Text("테스트 로그인")
-                    .onTapGesture { isLogin.toggle() }
+                    .onTapGesture { vm.testLogin() }
+#endif
             }
         }
         .padding(.top, 90)
@@ -47,5 +34,5 @@ struct LoginView: View {
 }
 
 #Preview {
-    LoginView(isLogin: .constant(false))
+    LoginView(vm: LoginViewModel())
 }

--- a/ILSANG/Sources/Views/Login/LoginViewModel.swift
+++ b/ILSANG/Sources/Views/Login/LoginViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  LoginViewModel.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 7/11/24.
+//
+
+import Foundation
+import AuthenticationServices
+
+class LoginViewModel: ObservableObject {
+    
+    var kakaoButtonAction = {
+        //TODO: 로그인 기능 구현
+    }
+    
+    var googleButtonAction = {
+        //TODO: 로그인 기능 구현
+    }
+    
+    func testLogin() {
+        Task {
+            await UserService.shared.loginWithTest()
+        }
+    }
+    
+    func loginWithApple(credential: ASAuthorizationCredential) {
+        guard let credential = credential as? ASAuthorizationAppleIDCredential else { return }
+        
+        Task {
+            await UserService.shared.login(appleCredential: credential)
+        }
+    }
+}

--- a/ILSANG/Sources/Views/Setting/SettingView.swift
+++ b/ILSANG/Sources/Views/Setting/SettingView.swift
@@ -58,6 +58,8 @@ struct SettingView: View {
                             // 로그아웃 함수 호출
                             let result = await LogoutNetwork().getLogout()
                             print(result)
+                            // TODO: 로그아웃 로직 추가 확인 필요
+                            UserService.shared.isLogin = false
                         }
                     }
                 )


### PR DESCRIPTION
#### close #81

### ✏️ 개요
애플로그인을 구현하고, 로그인 API 연결을 같이 진행했습니다.

### 💻 작업 사항
- [x] 애플 로그인 구현
- [x] 로그인 API 구현
- [x] 로그아웃 임의 구현 (isLogin값만 변경) 

### 📄 리뷰 노트
구현 자체가 우선이라고 판단돼서, 이전 맛큐 로직이랑 거의 유사하게 구현했습니다.

UserService는 여러 곳에서 사용해서 싱글톤으로 일단 해두었습니다. 
AuthService는 UserService에서만 사용되기 때문에 UserService에서 초기화해두었습니다.

다른 주요 API 연결 먼저 하고, 로그인&토큰 관련해서 키체인 등등 정보 관리하는 방법을 더 찾아보고 수정해야할 듯 싶습니다.
서버에서 access, refresh 토큰 값에 대해 검증하지 않고, 그냥 jwt 토큰을 보내줬던 걸로 코드를 봤었어서ㅠ 어떤 방식으로 할지 주요 작업 끝나고 얘기해 봐야 할 듯 합니다.