### PR TITLE
[Feat/#88] 도전내역 등록 시 퀘스트 목록 업데이트

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -19,8 +19,16 @@ class QuestViewModel: ObservableObject {
     @Published var selectedHeader: QuestStatus = .uncompleted
     @Published var selectedQuest: QuestViewModelItem = .mockData
     @Published var showQuestSheet: Bool = false
-    @Published var showSubmitRouterView: Bool = false
-    
+    @Published var showSubmitRouterView: Bool = false {
+        didSet {
+            // TODO: 도전내역 등록 완료시 리스트에서 퀘스트만 삭제/추가하도록 개선(퀘스트 조회 API 호출x)
+            if showSubmitRouterView == false {
+                Task {
+                    await loadInitialData()
+                }
+            }
+        }
+    }
     @Published var itemListByStatus: [QuestStatus: [QuestViewModelItem]] = [
         .uncompleted: [],
         .completed: []


### PR DESCRIPTION
#### close #88 

### ✏️ 개요
도전내역을 등록 완료하면 퀘스트 목록을 업데이트합니다.

### 💻 작업 사항
- [x] 도전내역 등록 완료 시 퀘스트 목록 업데이트

### 📄 리뷰 노트
없습니다.