### PR TITLE
[Bug/#93] 애플로그인 성공 시 userEmail에 애플 이메일 할당

### DIFF
--- a/ILSANG/Sources/Service/UserService.swift
+++ b/ILSANG/Sources/Service/UserService.swift
@@ -43,10 +43,13 @@ final class UserService: ObservableObject {
         
         if authResult.authUser.email != "" {
             self.appleEmail = authResult.authUser.email
+            self.userEmail = authResult.authUser.email
         }
-        await fetchUserInfo()
         
-        self.isLogin = true
+        await fetchUserInfo()
+        if self.currentUser != nil {
+            self.isLogin = true
+        }
     }
     
     @MainActor


### PR DESCRIPTION
#### close #93 

### ✏️ 개요
[타 계정 조회이력 현상 - ISPR132](https://chad0909.atlassian.net/browse/ISPR-132)
ILSANGApp.handleLogin에서 userEmail로 로그인 API를 요청하는데, 
애플로그인을 성공했을 경우 userEmail에 값을 할당해주지 않아 이메일을 ""로 요청하던 버그입니다.

### 💻 작업 사항
- [x] 애플로그인 성공 시 userEmail에 애플 이메일 할당

### 📄 리뷰 노트
없습니다.