### PR TITLE
[Design/#97] 탭바 디자인 불일치 수정(기본 Appearance 지정, 배경 흰색 고정)

### DIFF
--- a/ILSANG/Sources/Views/ILSANGApp.swift
+++ b/ILSANG/Sources/Views/ILSANGApp.swift
@@ -41,9 +41,10 @@ struct ILSANGApp: App {
     
     func setTabBarAppearance() {
         let appearance = UITabBarAppearance()
-        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor(.white)
         appearance.shadowColor = UIColor(.grayDD)
         appearance.stackedItemPositioning = .centered
+        UITabBar.appearance().standardAppearance = appearance
         UITabBar.appearance().scrollEdgeAppearance = appearance
     }
 }


### PR DESCRIPTION
#### close #97 

### ✏️ 개요
탭바 디자인이 초기 화면의 영역이 탭바까지 차지하면 지정해둔 여백과 다르게 표시되던 문제[(JIRA 티켓)](https://chad0909.atlassian.net/browse/ISPR-137?atlOrigin=eyJpIjoiMmVmNTVmYzM4MWI1NDQ0M2E2ZGY1MzBjZWE0YzVlOTIiLCJwIjoiaiJ9)를 해결했습니다.

### 💻 작업 사항
- [x] standardAppearance 탭바 스타일에도 "흰 배경/아이템간 간격" 적용
- [x] 탭바 appearance에 배경 흰색 설정

### 📄 리뷰 노트
없습니다 -!!

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/555a0da5-0d01-49ca-b2d8-95934cf1399a" width = "240"> 
<img src = "https://github.com/user-attachments/assets/88097496-c11c-46d5-b7a8-e56cef64b3dd" width = "240"> 
<img src = "https://github.com/user-attachments/assets/bc1e5962-5cc4-4279-a8c9-5a8f8b6ce5f9" width = "240"> 