### PR TITLE
[Bug/#96] XP 표시와 다르게 오르는 현상, 프로그레스 바 수치 불일치

### DIFF
--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -28,7 +28,7 @@ struct MyPageProfile: View {
                     
                     HStack {
                         // 프로그레스 바
-                        ProgressBar(userXP: vm.userData?.xpPoint ?? 0, levelXP: vm.xpForNextLv(XP: vm.userData?.xpPoint ?? 100))
+                        vm.ProgressBar(userXP: vm.userData?.xpPoint ?? 0)
                             .frame(height: 10)
                         
                         // 경험치 Text
@@ -38,7 +38,7 @@ struct MyPageProfile: View {
                             .foregroundColor(.accentColor)
                     }
                     
-                    Text("다음 레벨까지 \(vm.xpForNextLv(XP:  vm.userData?.xpPoint ?? 50))XP 남았어요!")
+                    Text("다음 레벨까지 \(vm.xpForNextLv(XP: vm.userData?.xpPoint ?? 50))XP 남았어요!")
                         .font(.system(size: 13))
                         .foregroundColor(.gray500)
                 }
@@ -50,6 +50,7 @@ struct MyPageProfile: View {
             )
             .task {
                 await vm.getUser()
+                Log(vm.userData)
             }
         }
     }
@@ -108,15 +109,14 @@ struct ProfileImageView: View {
     }
 }
 
-//MARK: 공용으로 이동?
 struct ProgressBar: View {
     
     var userXP : Int
     var levelXP : Int
     
     //소수 2자리로 변경합니다.
-    private var progress: CGFloat {
-        CGFloat(userXP) / CGFloat(levelXP)
+    private var progress: Double {
+        Double(userXP / levelXP)
     }
     
     var body: some View {
@@ -129,14 +129,15 @@ struct ProgressBar: View {
                     .foregroundColor(.gray100)
                 
                 Rectangle()
-                    .frame(
-                        width: min(progress * geometry.size.width,
-                                   geometry.size.width),
-                        height: 10
-                    )
+                    .frame(width: progress * geometry.size.width, height: 10)
                     .cornerRadius(6)
-                //MARK: 게이지 별 디자인 요청
                     .foregroundColor(.accentColor)
+            }
+            .onTapGesture {
+                Log(progress)
+                Log(userXP)
+                Log(levelXP)
+                Log(progress * geometry.size.width)
             }
         }
     }

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -109,41 +109,6 @@ struct ProfileImageView: View {
     }
 }
 
-struct ProgressBar: View {
-    
-    var userXP : Int
-    var levelXP : Int
-    
-    //소수 2자리로 변경합니다.
-    private var progress: Double {
-        Double(userXP / levelXP)
-    }
-    
-    var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                Rectangle()
-                    .frame(width: geometry.size.width, height: 11)
-                    .cornerRadius(6)
-                    .opacity(0.3)
-                    .foregroundColor(.gray100)
-                
-                Rectangle()
-                    .frame(width: progress * geometry.size.width, height: 10)
-                    .cornerRadius(6)
-                    .foregroundColor(.accentColor)
-            }
-            .onTapGesture {
-                Log(progress)
-                Log(userXP)
-                Log(levelXP)
-                Log(progress * geometry.size.width)
-            }
-        }
-    }
-}
-
-
 #Preview {
     MyPageProfile()
 }

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UIKit
+import SwiftUI
 
 class MypageViewModel: ObservableObject {
     @Published var userData: User?
@@ -70,6 +71,7 @@ class MypageViewModel: ObservableObject {
         }
     }
     
+    //XP를 레벨로 변경
     func convertXPtoLv(XP: Int) -> Int {
         var totalXP = 0
         var level = 0
@@ -82,6 +84,15 @@ class MypageViewModel: ObservableObject {
         return level - 1
     }
     
+    //이전,다음 레벨 XP
+    func xpGapBtwLevels(XP: Int) -> (currentLevelXP: Int, nextLevelXP: Int) {
+        let currentLevel = convertXPtoLv(XP: XP)
+        let currentLevelXP = 50 * currentLevel
+        let nextLevelXP = 50 * (currentLevel + 1)
+        return (currentLevelXP, nextLevelXP)
+    }
+    
+    //다음 레벨까지 남은 값
     func xpForNextLv(XP: Int) -> Int {
         let currentLevel = convertXPtoLv(XP: XP)
         let nextLevel = currentLevel + 1
@@ -103,6 +114,33 @@ class MypageViewModel: ObservableObject {
         case .failure:
             return nil
         }
+    }
+    
+    func ProgressBar(userXP: Int) -> some View {
+        let progress = calculateProgress(userXP: xpGapBtwLevels(XP: userXP).currentLevelXP, levelXP: xpGapBtwLevels(XP: userXP).nextLevelXP)
+        
+        return GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .frame(width: geometry.size.width, height: 11)
+                    .cornerRadius(6)
+                    .opacity(0.3)
+                    .foregroundColor(.gray100)
+                
+                Rectangle()
+                    .frame(width: CGFloat(progress) * geometry.size.width, height: 10)
+                    .cornerRadius(6)
+                    .foregroundColor(.accentColor)
+            }
+            .onAppear {
+                Log("Progress: \(progress)")
+            }
+        }
+    }
+    
+    func calculateProgress(userXP: Int, levelXP: Int) -> Double {
+        guard levelXP != 0 else { return 0 }
+        return Double(userXP) / Double(levelXP)
     }
 }
 

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -129,13 +129,12 @@ class MypageViewModel: ObservableObject {
         return GeometryReader { geometry in
             ZStack(alignment: .leading) {
                 Rectangle()
-                    .frame(width: geometry.size.width, height: 11)
+                    .frame(width: geometry.size.width, height: 8)
                     .cornerRadius(6)
-                    .opacity(0.3)
                     .foregroundColor(.gray100)
                 
                 Rectangle()
-                    .frame(width: CGFloat(progress) * geometry.size.width, height: 10)
+                    .frame(width: CGFloat(progress) * geometry.size.width, height: 8)
                     .cornerRadius(6)
                     .foregroundColor(.accentColor)
             }

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -87,9 +87,15 @@ class MypageViewModel: ObservableObject {
     //이전,다음 레벨 XP
     func xpGapBtwLevels(XP: Int) -> (currentLevelXP: Int, nextLevelXP: Int) {
         let currentLevel = convertXPtoLv(XP: XP)
-        let currentLevelXP = 50 * currentLevel
         let nextLevelXP = 50 * (currentLevel + 1)
-        return (currentLevelXP, nextLevelXP)
+        
+        var totalXP = 0
+        
+        for n in 1..<currentLevel + 1 {
+            totalXP += 50 * n
+        }
+        
+        return (XP - totalXP, nextLevelXP)
     }
     
     //다음 레벨까지 남은 값
@@ -101,7 +107,7 @@ class MypageViewModel: ObservableObject {
         for n in 1...nextLevel {
             totalXP += 50 * n
         }
-        
+        Log(totalXP)
         return totalXP - XP
     }
     
@@ -134,6 +140,8 @@ class MypageViewModel: ObservableObject {
             }
             .onAppear {
                 Log("Progress: \(progress)")
+                Log(self.xpGapBtwLevels(XP: userXP).currentLevelXP)
+                Log(self.xpGapBtwLevels(XP: userXP).nextLevelXP)
             }
         }
     }

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -123,7 +123,8 @@ class MypageViewModel: ObservableObject {
     }
     
     func ProgressBar(userXP: Int) -> some View {
-        let progress = calculateProgress(userXP: xpGapBtwLevels(XP: userXP).currentLevelXP, levelXP: xpGapBtwLevels(XP: userXP).nextLevelXP)
+        let levelData = xpGapBtwLevels(XP: userXP)
+        let progress = calculateProgress(userXP: levelData.currentLevelXP, levelXP: levelData.nextLevelXP)
         
         return GeometryReader { geometry in
             ZStack(alignment: .leading) {

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -98,7 +98,7 @@ class MypageViewModel: ObservableObject {
         return (XP - totalXP, nextLevelXP)
     }
     
-    //다음 레벨까지 남은 값
+    //다음 레벨까지 남은 값 
     func xpForNextLv(XP: Int) -> Int {
         let currentLevel = convertXPtoLv(XP: XP)
         let nextLevel = currentLevel + 1


### PR DESCRIPTION
#### close #96 

### ✏️ 개요
XP 표시와 다르게 오르는 현상, 프로그레스 바 수치 불일치

### 💻 작업 사항
- [x]  XP 표시와 다르게 오르는 현상
- [x]  프로그레스 바 수치 불일치

### 📄 리뷰 노트
XP와 다르게 오르는 현상은 프론트쪽에서 수정이 되었습니다만, 90xp가 50xp로 적용되는 것은 백에서 잘못 적용되는 것 같습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/6367ed70-a5c9-4040-9d70-46573d95a753" width = "300"> 
<img src = "https://github.com/user-attachments/assets/e101fa52-44bd-4c63-bbe5-d03feeb6298e" width = "300"> 




