### PR TITLE
[Feat/#102] 도전내역 랜덤조회 응답 구조 변경

### DIFF
--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -7,18 +7,11 @@
 
 import Foundation
 
-// TODO: ResponseWithPage와 응답 형식 통일 요청 후 수정
-// MARK: - ICH004 에서 사용되는 모델
-struct RandomChallengeList: Codable {
-    let content: [Challenge]
-    let last: Bool?
-}
-
-// TODO: userNickName 옵셔널 해제
+// TODO: userNickName, quest 옵셔널 해제
 struct Challenge: Codable {
     let challengeId: String
     let userNickName: String?
-    let quest: QuestEntity
+    let quest: QuestEntity?
     let receiptImageId, status: String
     let createdAt: String
     let likeCnt, hateCnt: Int

--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -17,8 +17,8 @@ final class ChallengeNetwork {
         self.url = url
     }
     
-    func getRandomChallenges(page: Int) async -> Result<RandomChallengeList, Error> {
-        let parameters: Parameters = ["page": page, "size": "10"]
+    func getRandomChallenges(page: Int, size: Int = 10) async -> Result<ResponseWithPage<[Challenge]>, Error> {
+        let parameters: Parameters = ["page": page, "size": size]
         return await Network.requestData(url: url+"randomChallenge", method: .get, parameters: parameters, withToken: true)
     }
     

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -94,11 +94,11 @@ final class ApprovalViewModel: ObservableObject {
         }
     }
     
-    private func getRandomChallenges(page: Int) async -> [ApprovalViewModelItem] {
-        let res = await challengeNetwork.getRandomChallenges(page: page)
+    private func getRandomChallenges(page: Int, size: Int) async -> [ApprovalViewModelItem] {
+        let res = await challengeNetwork.getRandomChallenges(page: page, size: size)
         switch res {
-        case .success(let success):
-            return success.content.map { ApprovalViewModelItem.init(challenge: $0) }
+        case .success(let response):
+            return response.data.map { ApprovalViewModelItem.init(challenge: $0) }
         case .failure:
             return []
         }
@@ -263,7 +263,7 @@ struct ApprovalViewModelItem: Identifiable {
     
     init(challenge: Challenge) {
         self.id = challenge.challengeId
-        self.title = challenge.quest.missions.first?.title ?? ""
+        self.title = challenge.quest?.missions.first?.title ?? ""
         self.image = nil
         self.imageId = challenge.receiptImageId
         self.offset = 0

--- a/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
@@ -29,7 +29,7 @@ struct MyPageQuestList: View {
                 VStack(spacing: 12) {
                     ForEach(questData, id: \.challengeId) { Data in
                         NavigationLink(destination: DetailQuestview(QuestData: Data)) {
-                            ListStruct(title: Data.quest.missions.first?.title ?? "챌린지명", detail: Data.createdAt.timeAgoCreatedAt(), point: nil)
+                            ListStruct(title: Data.quest?.missions.first?.title ?? "챌린지명", detail: Data.createdAt.timeAgoCreatedAt(), point: nil)
                         }
                     }
                 }

--- a/ILSANG/Sources/Views/Quest/DetailQuestview.swift
+++ b/ILSANG/Sources/Views/Quest/DetailQuestview.swift
@@ -43,7 +43,7 @@ struct DetailQuestview: View {
                     
                     HStack() {
                         VStack (alignment: .leading) {
-                            Text(QuestData.quest.missions.first?.title ?? "")
+                            Text(QuestData.quest?.missions.first?.title ?? "")
                                 .font(.headline)
                                 .padding(.bottom, 1)
                             


### PR DESCRIPTION
#### close #102

### ✏️ 개요
도전내역 랜덤조회 API의 응답 구조 변경에 따라 수정했습니다.

### 💻 작업 사항
- [x] quest 옵셔널 설정
- [x] 응답 구조 변경
 
### 📄 리뷰 노트
없습니다-!!

### 📱결과 화면(optional)
리뷰어의 이해를 위해 스크린샷을 추가해주세요