### PR TITLE
[Design/#105] 퀘스트 이미지 레이아웃(사이즈) 수정

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -14,34 +14,26 @@ struct QuestItemView: View {
     
     var body: some View {
         HStack(spacing: 0) {
-            Group {
-                if let uiImage = quest.image {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .frame(width: 36, height: 36)
-                } else {
-                    Image(uiImage: .logo)
-                        .resizable()
-                        .scaledToFit()
+            Image(uiImage: quest.image ?? .logo)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 60, height: 60)
+                .background(Color.badgeBlue)
+                .clipShape(Circle())
+                .padding(.leading, 20)
+                .padding(.trailing, 16)
+                .overlay(alignment: .top) {
+                    Text(String(quest.reward) + "XP")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .foregroundStyle(.primaryPurple)
+                        )
+                        .offset(x: 20, y: 2)
                 }
-            }
-            .frame(width: 60, height: 60)
-            .background(Color.badgeBlue)
-            .clipShape(Circle())
-            .padding(.leading, 20)
-            .padding(.trailing, 16)
-            .overlay(alignment: .top) {
-                Text(String(quest.reward) + "XP")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 4)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .foregroundStyle(.primaryPurple)
-                    )
-                    .offset(x: 20, y: 2)
-            }
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(quest.missionTitle)

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -133,24 +133,12 @@ extension QuestView {
             Text("퀘스트 정보")
                 .font(.system(size: 17, weight: .bold))
             
-            Group {
-                if let uiImage = vm.selectedQuest.image {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .frame(width: 80, height: 80)
-                        .frame(width: 122, height: 122)
-                        .background(
-                            Circle().foregroundColor(.badgeBlue)
-                        )
-                        .padding(20)
-                } else {
-                    Image(uiImage: .logo)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 122, height: 122)
-                        .clipShape(Circle())
-                }
-            }
+            Image(uiImage: vm.selectedQuest.image ?? .logo)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 122, height: 122)
+                .clipShape(Circle())
+                .padding(20)
             
             Text(vm.selectedQuest.writer)
                 .font(.system(size: 15, weight: .regular))


### PR DESCRIPTION
#### close #105 

### ✏️ 개요
관리자앱에서 퀘스트 이미지 등록기능을 구현함에 따라, 커스터머앱에서 퀘스트 이미지가 잘리지 않도록 수정합니다.

### 💻 작업 사항
- [x] 퀘스트 이미지 레이아웃 수정

### 📄 리뷰 노트
없습니다-!!

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/7a277a3b-953a-417b-b514-d524694dba93" width = "300">
