### PR TITLE
[Design/#109] 인증탭 이미지 배경색 설정

### DIFF
--- a/ILSANG/Sources/Views/Approval/ApprovalImageView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalImageView.swift
@@ -28,6 +28,7 @@ struct ApprovalImageView: View {
                 )
                 .frame(height: 268)
             }
+            .background(Color.white)
             .cornerRadius(12)
             .overlay(alignment: .bottomLeading) {
                 if showProfile {


### PR DESCRIPTION
#### close #109 

### ✏️ 개요
사용자가 png를 넣으면 뒤에 챌린지까지 겹쳐보여 배경색을 흰색으로 적용합니다.

### 💻 작업 사항
- [x] 인증탭 이미지 배경색 적용

### 📄 리뷰 노트
없습니다.