### PR TITLE
[Bug/#111] 인증뷰 데이터 조회시 인덱스 초기화, 랜덤도전내역 조회 사이즈 20 지정

### DIFF
--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -57,7 +57,7 @@ final class ApprovalViewModel: ObservableObject {
     
     @MainActor
     func getChallengesWithImage(page: Int) async {
-        var challenges = await getRandomChallenges(page: page)
+        var challenges = await getRandomChallenges(page: page, size: 20)
 
         // 중복된 id 제거
         var seenIDs = Set<String>()

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -39,13 +39,15 @@ final class ApprovalViewModel: ObservableObject {
         self.challengeNetwork = challengeNetwork
     }
     
+    @MainActor
     func getData() async {
-        await changeViewStatus(.loading)
+        changeViewStatus(.loading)
         await getChallengesWithImage(page: 0)
-        if !itemList.isEmpty {
-            await getEmoji(challengeId: itemList[currentIdx].id)
+        self.currentIdx = 0
+        if let challengeId = itemList.first?.id {
+            await getEmoji(challengeId: challengeId)
         }
-        await changeViewStatus(.loaded)
+        changeViewStatus(.loaded)
     }
     
     @MainActor


### PR DESCRIPTION
#### close #111

### ✏️ 개요
인증 탭 전환시 레이어 꼬이는 현상을 해결합니다.

### 💻 작업 사항
 - [x] getData() 내부에 인덱스 초기화 로직 추가
 - [x]  도전내역 조회 사이즈 지정

### 📄 리뷰 노트
에러뷰를 보여주는 트리거가 없는 상태입니다.
추후에 인증 뷰의 각 상황별로 상태를 보여줄 수 있도록 처리 로직을 추가할 예정입니다.
