### PR TITLE
[Design/#115] 인증탭 기본이미지 수정

### DIFF
--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -99,7 +99,7 @@ struct ApprovalView: View {
     
     private func imageView(for item: ApprovalViewModelItem, diff: Int) -> some View {
         ApprovalImageView(
-            image: item.image ?? .loginLogo,
+            image: item.image ?? .logo,
             width: abs(viewWidth - 40 * CGFloat(diff)),
             height: (viewHeight / 2) - CGFloat(diff) * 26,
             nickname: item.nickname,


### PR DESCRIPTION
  #### close #115

### ✏️ 개요
인증탭의 기본이미지 비율이 이상해서, 다른 이미지로 수정했습니다ㅎㅎ,,

### 💻 작업 사항
- [x] 랜덤도전내역 기본이미지 수정(.loginLogo > logo)

### 📄 리뷰 노트
이미지가 흰색이면 배경도 흰색이 돼서 아래 이모지 버튼이 안보이는데, 사용자가 실제로 이미지를 올릴때는 로고처럼 흰색(#FFFFFF)으로 올라올 가능성이 적어 따로 대응해두진 않은 상태입니다. 

### 📱결과 화면(optional)
| 수정 전 | 수정 후 |
|--------|--------|
| <img src = "https://github.com/user-attachments/assets/88ee76ae-0ad9-47d8-a2f6-446ba628b5bc" width = "270"> | <img src = "https://github.com/user-attachments/assets/dc66addd-9583-49fa-bc32-f1842953eca9" width = "270"> | 
