### PR TITLE
[Feat/#117] 이미지 등록 로직 수정(이미지 사이즈에 따라 다운샘플링 수치 조정, 100kb 미만일 때까지 JPEG 압축)

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		60C6B4DC2C2D042700926C0E /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DB2C2D042700926C0E /* Image.swift */; };
 		60C6B4DF2C2D053600926C0E /* SubmitRouterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */; };
 		60C6B4E12C2D1C0100926C0E /* SubmitAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4E02C2D1C0100926C0E /* SubmitAlertViewModel.swift */; };
+		60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DADF542C6B4EC7001A0B3A /* Data++.swift */; };
 		A142E0312C2D9F37004395F8 /* SettingAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A142E0302C2D9F37004395F8 /* SettingAlertView.swift */; };
 		A1501B082C48C3C6001410E1 /* MyPageActiveList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1501B072C48C3C6001410E1 /* MyPageActiveList.swift */; };
 		A1501B0A2C48C3E5001410E1 /* MyPageBadgeList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1501B092C48C3E5001410E1 /* MyPageBadgeList.swift */; };
@@ -168,6 +169,7 @@
 		60C6B4DB2C2D042700926C0E /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterViewModel.swift; sourceTree = "<group>"; };
 		60C6B4E02C2D1C0100926C0E /* SubmitAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitAlertViewModel.swift; sourceTree = "<group>"; };
+		60DADF542C6B4EC7001A0B3A /* Data++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data++.swift"; sourceTree = "<group>"; };
 		A142E0302C2D9F37004395F8 /* SettingAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAlertView.swift; sourceTree = "<group>"; };
 		A1501B072C48C3C6001410E1 /* MyPageActiveList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageActiveList.swift; sourceTree = "<group>"; };
 		A1501B092C48C3E5001410E1 /* MyPageBadgeList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageBadgeList.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 		605DA0D42C07122200CC9450 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				60DADF542C6B4EC7001A0B3A /* Data++.swift */,
 				608EBF9E2C39C17F00B862CC /* Dictionary++.swift */,
 				605DA0D52C07123400CC9450 /* View++.swift */,
 				6060B2E92C08947B0083944D /* Image++.swift */,
@@ -738,6 +741,7 @@
 				608EBF9F2C39C17F00B862CC /* Dictionary++.swift in Sources */,
 				A1C6422A2C33F55A004954CA /* QuestNetwork.swift in Sources */,
 				A1AB3D6C2C1142AA001EB9D8 /* LoginButton.swift in Sources */,
+				60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				A19628652C076D7B0037C53A /* SettingView.swift in Sources */,
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,

--- a/ILSANG/Sources/Extension/Data++.swift
+++ b/ILSANG/Sources/Extension/Data++.swift
@@ -1,0 +1,26 @@
+//
+//  Data++.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 8/13/24.
+//
+
+import Foundation
+
+extension Data {
+    var bytes: Int64 {
+        .init(self.count)
+    }
+    
+    public var kilobytes: Double {
+        return Double(bytes) / 1_024
+    }
+    
+    public var megabytes: Double {
+        return kilobytes / 1_024
+    }
+    
+    public var gigabytes: Double {
+        return megabytes / 1_024
+    }
+}


### PR DESCRIPTION
#### close #117 

### ✏️ 개요
서버에서 제한해둔 이미지 파일사이즈 최댓값에 맞게, 이미지를 등록할 수 있도록 로직을 수정했습니다.

### 💻 작업 사항
- [x] 파일 사이즈 계산 로직 추가
- [x] 이미지 파일사이즈 최댓값(100kb) 미만일 때까지 JPEG 압축하여 이미지 등록

### 📄 리뷰 노트
기존 로직은 서버에 등록하고 실패하면 3번 재시도하는 로직이었는데, 이것보다는 클라이언트에서 100kb 사이즈까지 줄이고 post 하는게 서버 비용 효율적(?)일 것 같아서 수정해두었습니다-!!

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/9804c952-bf22-4489-939d-2f01ecc43931" width = "260"> 
<img src = "https://github.com/user-attachments/assets/06474905-a709-4d71-84cc-977bf1c8596d" width = "260"> 