### PR TITLE
[Feat/#117] 이미지 POST 시 파일 크기 초과에 대응하도록 로직 수정 

### DIFF
--- a/ILSANG/Sources/Extension/UIImage++.swift
+++ b/ILSANG/Sources/Extension/UIImage++.swift
@@ -25,4 +25,14 @@ extension UIImage {
 
         return UIImage(cgImage: scaledImage, scale: self.scale, orientation: self.imageOrientation)
     }
+    
+    func resizeImage(newWidth: CGFloat) -> UIImage {
+        let scale = newWidth / self.size.width
+        let newHeight = self.size.height * scale
+        UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))
+        self.draw(in: CGRectMake(0, 0, newWidth, newHeight))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        return newImage
+    }
 }

--- a/ILSANG/Sources/Extension/UIImage++.swift
+++ b/ILSANG/Sources/Extension/UIImage++.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 extension UIImage {
-    func downSample(scale: CGFloat) -> UIImage? {
+    func downSample() -> UIImage? {
+        let scale = self.calculateDownsamplingScale()
         let maxPixel = max(self.size.width, self.size.height) * scale
         let options: [CFString: Any] = [
             kCGImageSourceThumbnailMaxPixelSize: maxPixel,
@@ -34,5 +35,24 @@ extension UIImage {
         let newImage = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
         return newImage
+    }
+    
+    func calculateDownsamplingScale() -> CGFloat {
+        let initialImageData = self.jpegData(compressionQuality: 1.0) ?? Data()
+        let imageSizeKB = initialImageData.kilobytes
+        
+        var downSamplingScale: CGFloat = 1.0
+        
+        if imageSizeKB > 5000 {
+            downSamplingScale = 0.4
+        } else if imageSizeKB > 2500 {
+            downSamplingScale = 0.5
+        } else if imageSizeKB > 2000 {
+            downSamplingScale = 0.65
+        } else {
+            downSamplingScale = 0.8
+        }
+        
+        return downSamplingScale
     }
 }

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -112,8 +112,7 @@ final class Network {
         urlRequest.timeoutInterval = requestTimeout
         
         // MARK: 이미지 다운 샘플링
-        let downsamplingScale = calculateDownsamplingScale(for: image)
-        guard let downsampledImage = image.downSample(scale: downsamplingScale) else {
+        guard let downsampledImage = image.downSample() else {
             return .failure(NetworkError.invalidImageData)
         }
         
@@ -158,25 +157,6 @@ final class Network {
         case .failure(let error):
             return .failure(NetworkError.requestFailed(error.localizedDescription))
         }
-    }
-    
-    private static func calculateDownsamplingScale(for image: UIImage) -> CGFloat {
-        let initialImageData = image.jpegData(compressionQuality: 1.0) ?? Data()
-        let imageSizeKB = initialImageData.kilobytes
-        
-        var downSamplingScale: CGFloat = 1.0
-        
-        if imageSizeKB > 5000 {
-            downSamplingScale = 0.4
-        } else if imageSizeKB > 2500 {
-            downSamplingScale = 0.5
-        } else if imageSizeKB > 2000 {
-            downSamplingScale = 0.65
-        } else {
-            downSamplingScale = 0.8
-        }
-        
-        return downSamplingScale
     }
     
     private static func handleStatusCode<T>(_ statusCode: Int, data: T?) -> Result<T, Error> {

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -157,6 +157,25 @@ final class Network {
         }
     }
     
+    private static func calculateDownsamplingScale(for image: UIImage) -> CGFloat {
+        let initialImageData = image.jpegData(compressionQuality: 1.0) ?? Data()
+        let imageSizeKB = initialImageData.kilobytes
+        
+        var downSamplingScale: CGFloat = 1.0
+        
+        if imageSizeKB > 5000 {
+            downSamplingScale = 0.4
+        } else if imageSizeKB > 2500 {
+            downSamplingScale = 0.5
+        } else if imageSizeKB > 2000 {
+            downSamplingScale = 0.65
+        } else {
+            downSamplingScale = 0.8
+        }
+        
+        return downSamplingScale
+    }
+    
     private static func handleStatusCode<T>(_ statusCode: Int, data: T?) -> Result<T, Error> {
         switch statusCode {
         case 200..<300:


### PR DESCRIPTION
#### close #117
#### relate #118 

### ✏️ 개요
사용자가 갤러리에서 불러온 사진이 약 1.2MB 이상인 경우 대응하지 못해 수정했습니다.

### 💻 작업 사항
- 이미지 가로세로가 아닌 파일 크기에 따라 다운샘플링하도록 수정(메서드 분리 및 UIImage++로 코드 이동)
- JPEG 압축 시 최대한 100kb에 가깝도록 하기 위해 0.05로 감소 수치 조정
- JPEG 압축 시 0.1로 압축하더라도 100kb가 아니라면 이미지 리사이즈

### 📄 리뷰 노트
이해 안가는 부분있으시면 말해주세요 !
downSamplingScale을 작게할수록 이미지가 깨진게 잘보이는데, 메모리를 적당히 사용하는 선에서 현재는 이게 최선이라고 생각합니다..ㅎㅠ
여유있을 때 while문 내부 동작들 더 최적화해볼 수 있을 것 같긴 합니다.