### PR TITLE
[Bug/#124] 퀘스트 이미지 꼬임 현상 해결

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -71,31 +71,20 @@ class QuestViewModel: ObservableObject {
     
     @MainActor
     func loadQuestListWithImage(page: Int, status: QuestStatus) async {
-        var questList = await getQuestList(page: page, status: status)
-        var itemList = itemListByStatus[status, default: []]
+        var newQuestList = await getQuestList(page: page, status: status)
+        var currentQuestList = itemListByStatus[status, default: []]
         
         if page == 0 {
-            itemList = questList
+            currentQuestList = newQuestList
         } else {
-            itemList += questList
-            
             // MARK: 중복된 퀘스트 제거, 서버 에러 해결시 제거
-            var seenIDs = Set<String>()
-            itemList = itemList.filter { quest in
-                if seenIDs.contains(quest.id) {
-                    if let idx = questList.lastIndex(where: { $0.id == quest.id }) {
-                        questList.remove(at: idx)
-                    }
-                    return false
-                } else {
-                    seenIDs.insert(quest.id)
-                    return true
-                }
-            }
+            var uniqueQuestIDs = Set(currentQuestList.map { $0.id })
+            newQuestList = newQuestList.filter { uniqueQuestIDs.insert($0.id).inserted }
+            currentQuestList += newQuestList
         }
         
         await withTaskGroup(of: (Int, UIImage?).self) { group in
-            for (index, quest) in questList.enumerated() {
+            for (index, quest) in newQuestList.enumerated() {
                 group.addTask {
                     guard let imageId = quest.imageId else {
                         return (index, nil)
@@ -108,14 +97,14 @@ class QuestViewModel: ObservableObject {
             for await (index, image) in group {
                 if let image = image {
                     if page == 0 {
-                        itemList[index].image = image
+                        currentQuestList[index].image = image
                     } else {
-                        itemList[itemList.count - questList.count + index].image = image
+                        currentQuestList[currentQuestList.count - newQuestList.count + index].image = image
                     }
                 }
             }
         }
-        itemListByStatus[status] = itemList
+        itemListByStatus[status] = currentQuestList
     }
     
     private func getQuestList(page: Int, status: QuestStatus) async -> [QuestViewModelItem] {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -71,7 +71,7 @@ class QuestViewModel: ObservableObject {
     
     @MainActor
     func loadQuestListWithImage(page: Int, status: QuestStatus) async {
-        let questList = await getQuestList(page: page, status: status)
+        var questList = await getQuestList(page: page, status: status)
         var itemList = itemListByStatus[status, default: []]
         
         if page == 0 {
@@ -83,6 +83,9 @@ class QuestViewModel: ObservableObject {
             var seenIDs = Set<String>()
             itemList = itemList.filter { quest in
                 if seenIDs.contains(quest.id) {
+                    if let idx = questList.lastIndex(where: { $0.id == quest.id }) {
+                        questList.remove(at: idx)
+                    }
                     return false
                 } else {
                     seenIDs.insert(quest.id)


### PR DESCRIPTION
#### close #124

### ✏️ 개요
퀘스트 목록 조회할 때 백에서 중복값을 보내줘서 필터링을 해줬었는데, 
퀘스트 아이템에 이미지를 연결하는 작업에서 필터링된 갯수를 고려하지 못해 꼬이는 문제가 있었습니다.
[JIRA](https://chad0909.atlassian.net/browse/ISPR-153?atlOrigin=eyJpIjoiM2YzYzg4YjA4ZmIzNGUyZTg0ODgxN2I4MzM5ZjIwNzAiLCJwIjoiaiJ9)

### 💻 작업 사항
- 퀘스트 중복 시 questList에서 삭제하도록 수정
- 변수명 수정

### 📄 리뷰 노트
이미지 값 할당할 때 questList(새로 조회한 아이템)의 숫자로 인덱스 찾기 때문에 questList에서 삭제해주었습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/c7a4d401-ac8a-4edf-92cf-1285bd66db8e" width = "300"> 