### PR TITLE
[Feat/#123] 도전내역 신고 디자인&기능 구현

### DIFF
--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -38,4 +38,9 @@ final class ChallengeNetwork {
         }
         return await Network.requestData(url: url+"challenge", method: .post, parameters: nil, body: jsonData, withToken: true)
     }
+    
+    func patchChallenge(challengeId: String) async -> Result<ResponseWithEmpty, Error> {
+        let parameters: Parameters = ["challengeId": challengeId, "status": "REPORTED"]
+        return await Network.requestData(url: url+"report", method: .patch, parameters: parameters, withToken: true)
+    }
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -28,6 +28,7 @@ final class ApprovalViewModel: ObservableObject {
     }
     @Published var isScrolling = false
     @Published var emoji: Emoji?
+    @Published var showReportAlert = false
     
     private let imageNetwork: ImageNetwork
     private let emojiNetwork: EmojiNetwork
@@ -190,6 +191,17 @@ final class ApprovalViewModel: ObservableObject {
             self.emoji = model.data
         case .failure:
             self.emoji = nil
+        }
+    }
+    
+    func reportChallenge() async {
+        let challengeId = self.itemList[currentIdx].id
+        let result = await challengeNetwork.patchChallenge(challengeId: challengeId)
+        switch result {
+        case .success:
+            await getData()
+        case .failure(let err):
+            Log("챌린지 신고 실패 \(challengeId) \(err.localizedDescription)")
         }
     }
     

--- a/ILSANG/Sources/Views/Setting/SettingAlertView.swift
+++ b/ILSANG/Sources/Views/Setting/SettingAlertView.swift
@@ -61,6 +61,7 @@ enum AlertType {
     case NickName
     case Logout
     case Withdrawal
+    case Report
     
     var title: String {
         switch self {
@@ -70,6 +71,8 @@ enum AlertType {
             "로그아웃 하시겠어요?"
         case .Withdrawal:
             "정말 탈퇴하시겠어요?"
+        case .Report:
+            "신고하시겠습니까?"
         }
     }
     
@@ -81,12 +84,14 @@ enum AlertType {
             nil
         case .Withdrawal:
             "확인 시 일상 계정이 영구적으로 삭제되며,\n모든 데이터는 복구가 불가능합니다."
+        case .Report:
+            "확인 후 빠른 시일 내 조치하도록 하겠습니다"
         }
     }
     
     var disagree: String {
         switch self {
-        case .NickName,.Withdrawal:
+        case .NickName,.Withdrawal, .Report:
             "취소"
         case .Logout:
             "아니요"
@@ -95,7 +100,7 @@ enum AlertType {
     
     var agree: String {
         switch self {
-        case .NickName,.Withdrawal:
+        case .NickName,.Withdrawal, .Report:
             "확인"
         case .Logout:
             "예"


### PR DESCRIPTION
#### close #123 

### ✏️ 개요
도전내역 신고 기능을 구현했습니다.

### 💻 작업 사항
- 도전내역 신고를 위한 디자인구현
- 도전내역 신고 API 연결

### 📄 리뷰 노트
신고 실패시 다른 피드백 없이 로그만 찍히도록 해두었습니다-ㅠ

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/949da8af-9bc6-4e18-836c-1c927cc11038" width = "300"> 
