### PR TITLE
[Feat/#127] 페이지네이션 매니저 구현, 인증 탭 사용부 구현

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		600211EA2C1EEE6D000CC02E /* APITarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211E92C1EEE6D000CC02E /* APITarget.swift */; };
 		600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211EB2C1EEED7000CC02E /* APIManager.swift */; };
 		600211EE2C1EEF91000CC02E /* EmojiNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */; };
+		600D83A42C7B1FA4005C93E2 /* PaginationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */; };
 		6011891D2C3E8B3B0070F2AD /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6011891C2C3E8B3B0070F2AD /* UserService.swift */; };
 		6011891F2C3E94380070F2AD /* AuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6011891E2C3E94380070F2AD /* AuthUser.swift */; };
 		601189212C3E94A60070F2AD /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189202C3E94A60070F2AD /* AuthService.swift */; };
@@ -116,6 +117,7 @@
 		600211E92C1EEE6D000CC02E /* APITarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITarget.swift; sourceTree = "<group>"; };
 		600211EB2C1EEED7000CC02E /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiNetwork.swift; sourceTree = "<group>"; };
+		600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationManager.swift; sourceTree = "<group>"; };
 		601189182C3E84720070F2AD /* ILSANG.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ILSANG.entitlements; sourceTree = "<group>"; };
 		6011891C2C3E8B3B0070F2AD /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
 		6011891E2C3E94380070F2AD /* AuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUser.swift; sourceTree = "<group>"; };
@@ -257,6 +259,14 @@
 				603F04122C26ADC6008A2332 /* CommonResponse.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		600D83A22C7B1F7E005C93E2 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 		6011891B2C3E8B2B0070F2AD /* Service */ = {
@@ -472,6 +482,7 @@
 		60B8BA132BF9F07D005F6DE3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				600D83A22C7B1F7E005C93E2 /* Manager */,
 				6011891B2C3E8B2B0070F2AD /* Service */,
 				600211E62C1EED2B000CC02E /* Model */,
 				606292D62C19E6C00098B6D2 /* Network */,
@@ -741,6 +752,7 @@
 				608EBF9F2C39C17F00B862CC /* Dictionary++.swift in Sources */,
 				A1C6422A2C33F55A004954CA /* QuestNetwork.swift in Sources */,
 				A1AB3D6C2C1142AA001EB9D8 /* LoginButton.swift in Sources */,
+				600D83A42C7B1FA4005C93E2 /* PaginationManager.swift in Sources */,
 				60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				A19628652C076D7B0037C53A /* SettingView.swift in Sources */,
@@ -952,7 +964,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ilsang240615;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -993,7 +1005,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ilsang240615;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/ILSANG/Sources/Manager/PaginationManager.swift
+++ b/ILSANG/Sources/Manager/PaginationManager.swift
@@ -1,0 +1,78 @@
+//
+//  PaginationManager.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 8/25/24.
+//
+
+/// 서버에서 응답으로 보내주는 TotalCount를 기반으로 남은 페이지를 계산하여 데이터를 불러옵니다.
+/// PaginationManager 내부에서 totalCount 변수를 사용하기 위해 loadPageData에서 totalCount를 반환합니다.
+final class PaginationManager<T> {
+    let size: Int
+    private let threshold: Int
+    
+    /// 페이지 번호를 인자로 받아 해당 페이지의 데이터를 비동기적으로 로드하는 메서드. 데이터 배열과 전체 항목 수를 반환해야 합니다.
+    private let loadPageData: (Int) async -> (data: [T], totalCount: Int)
+    
+    private var currentPage: Int = 0
+    private var totalPage: Int = 0
+    private var totalCount: Int = 0
+    private var isLoading = false
+    
+    init(size: Int, threshold: Int, loadPage: @escaping (Int) async -> (data: [T], totalCount: Int)) {
+        self.size = size
+        self.threshold = threshold
+        self.loadPageData = loadPage
+    }
+    
+    /// 인덱스 없이 데이터를 로드할 수 있는지 확인하는 메서드
+    func canLoadMoreData() -> Bool {
+        let canLoadMorePages = currentPage < totalPage
+        return canLoadMorePages
+    }
+    
+    // TODO: 필터로 걸러진 값 있을 경우 고려하여 로직 수정 필요
+    /// 인덱스로 데이터를 로드할 수 있는지 확인하는 메서드
+    func canLoadMoreData(index: Int, currentCount: Int) -> Bool {
+        if currentPage == totalPage {
+            return false
+        }
+        let canLoadMorePages = currentPage < totalPage // 전체페이지와 비교하여 더 불러올 수 있는지 확인
+        let shouldLoadMore = (index == currentCount - threshold) // 현재 페이지에 대한 임계값에 도달했는지 확인
+        
+        return canLoadMorePages && shouldLoadMore
+    }
+    
+    /// loadPageData 반환값인 ([T], 서버에서 응답으로 보내주는 total)을 정확히 매핑하여 반환해야 합니다.
+    func loadData(isRefreshing: Bool) async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        
+        if isRefreshing {
+            resetPagination()
+        } else {
+            incrementPage()
+        }
+        
+        let (_, totalCount) = await loadPageData(currentPage)
+        updatePaginationState(totalCount: totalCount)
+    }
+    
+    private func resetPagination() {
+        currentPage = 0
+        totalPage = 0
+    }
+    
+    private func incrementPage() {
+        currentPage += 1
+    }
+    
+    private func updatePaginationState(totalCount: Int) {
+        self.totalCount = totalCount
+        
+        if totalPage == 0 && size > 0 {
+            totalPage = Int(totalCount / size)
+        }
+    }
+}


### PR DESCRIPTION
#### close #127 127

### ✏️ 개요
페이지네이션관련 로직을 분리하기 위해 페이지네이션 매니저를 구현하였습니다.

### 💻 작업 사항
- [x] 페이지네이션 매니저 구현
- [x] 인증탭 사용부 구현
- [ ] 필터링될 경우 로직 구현

### 📄 리뷰 노트
로직이나 주석 설명 필요한 부분 있으시면 말해주세요 !

** 두 커밋만 확인
[cf5ef5c](https://github.com/TeamFair/ILSANG-iOS/pull/128/commits/cf5ef5c09c36063341fdeaaa1de1a6cd0ac6cd34)
[3e2fefd](https://github.com/TeamFair/ILSANG-iOS/pull/128/commits/3e2fefd43d60809f1f93fa6dc0c8789d51edddea)

