### PR TITLE
[Fix/#130] 경험치가 양수일때 + 음수일때 - Nil일때 +0

### DIFF
--- a/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
@@ -68,7 +68,7 @@ struct ListStruct: View {
             } else {
                 Text("+0XP")
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(Color.gray)
+                    .foregroundColor(Color.accentColor)
             }
         }
         .padding(20)

--- a/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
@@ -65,10 +65,6 @@ struct ListStruct: View {
                 Text("\(point > 0 ? "+\(point)" : "\(point)")XP")
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(Color.accentColor)
-            } else {
-                Text("+0XP")
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(Color.accentColor)
             }
         }
         .padding(20)

--- a/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
@@ -61,10 +61,14 @@ struct ListStruct: View {
             
             Spacer()
             
-            if (point != nil) {
-                Text("+\(point ?? 0)XP")
+            if let point = point {
+                Text("\(point > 0 ? "+\(point)" : "\(point)")XP")
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(Color.accentColor)
+            } else {
+                Text("+0XP")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(Color.gray)
             }
         }
         .padding(20)


### PR DESCRIPTION
#### close #130 

### ✏️ 개요
XP에 "-"를 포함해서 들어오는 경우, UI에 "+"를 표시하지 않도록 처리

### 💻 작업 사항
- [x] 경험치가 양수, 음수일때 오류 처리
- [x] 경험치가 존재하지 않을 경우 처리

### 📄 리뷰 노트
없습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/95d589ea-cbfc-4c4c-a226-692b4e836fa7" width = "300"> 

### 📚 ETC(optional)
경험치가 존재한다면 
양수일때 "+" 음수일때 "-" 

경험치가 존재하지 않는다면 (Nil)
"+0XP" 로 표시