### PR TITLE
[Fix/#135] 삭제가 완료/미완료시 마이탭으로 돌아오도록 변경

### DIFF
--- a/ILSANG/Sources/Views/Quest/DetailQuestview.swift
+++ b/ILSANG/Sources/Views/Quest/DetailQuestview.swift
@@ -86,6 +86,10 @@ struct DetailQuestview: View {
                         Task {
                             if await vm.updateChallengeStatus(challengeId: ChallengeData.challengeId,ImageId: ChallengeData.receiptImageId) {
                                 vm.challengeDelete = false
+                                dismiss()
+                            } else {
+                                vm.challengeDelete = false
+                                dismiss()
                             }
                         }
                     }

--- a/ILSANG/Sources/Views/Quest/DetailQuestview.swift
+++ b/ILSANG/Sources/Views/Quest/DetailQuestview.swift
@@ -89,7 +89,6 @@ struct DetailQuestview: View {
                                 dismiss()
                             } else {
                                 vm.challengeDelete = false
-                                dismiss()
                             }
                         }
                     }


### PR DESCRIPTION
#### close #135 

### ✏️ 개요
챌린지 삭제 버튼을 누르면 삭제 요청 -> 응답을 받으면 마이탭로 이동

PM 측에서 추가적인 파업없이 바로 마이탭 이동으로 구현이 우선순위 이고  이후 디자인 변경시 팝업창이 구현될 수 있습니다.

### 💻 작업 사항
오류 팝업창 없이 삭제 요청시 마이탭으로 돌아옵니다.

### 📄 리뷰 노트
없습니다.

