### PR TITLE
[Ref/#144] 도전내역 상태변경 API 엔드포인트 수정 (report >> status)

### DIFF
--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -41,7 +41,7 @@ final class ChallengeNetwork {
     
     func patchChallenge(challengeId: String) async -> Result<ResponseWithEmpty, Error> {
         let parameters: Parameters = ["challengeId": challengeId, "status": "REPORTED"]
-        return await Network.requestData(url: url+"report", method: .patch, parameters: parameters, withToken: true)
+        return await Network.requestData(url: url+"status", method: .patch, parameters: parameters, withToken: true)
     }
     
     func deleteChallenge(challengeId: String) async -> Bool {


### PR DESCRIPTION
#### close #144

### ✏️ 개요
도전내역 상태변경 API 엔드포인트 변경에 따라 수정사항을 반영했습니다.

### 💻 작업 사항
- [x] 도전내역 상태변경 API 엔드포인트 수정 (report > status)
`http://43.202.229.190:9090/api/customer/status?challengeId=CH10000004&status=REPORTED`


### 📄 리뷰 노트
없습니다 !!