### PR TITLE
[Design/#146] 퀘스트뷰 상단 스탯 선택 영역 디자인 구현

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -9,10 +9,16 @@ import SwiftUI
 
 struct QuestView: View {
     @StateObject var vm: QuestViewModel = QuestViewModel(imageNetwork: ImageNetwork(), questNetwork: QuestNetwork())
-    
+    @Namespace private var namespace
+
     var body: some View {
         VStack(spacing: 0) {
             headerView
+                
+            if vm.selectedHeader == .uncompleted {
+                subHeaderView
+            }
+            
             switch vm.viewStatus {
             case .loading:
                 ProgressView().frame(maxHeight: .infinity)
@@ -53,6 +59,38 @@ extension QuestView {
         }
         .frame(height: 50)
         .padding(.horizontal, 20)
+    }
+    
+    private var subHeaderView: some View {
+        HStack(spacing: 0) {
+            ForEach(XpStat.allCases, id: \.headerText) { xpStat in
+                Button {
+                    withAnimation(.snappy) {
+                        vm.selectedXpStat = xpStat
+                    }
+                } label: {
+                    Text(xpStat.headerText)
+                        .foregroundColor(xpStat == vm.selectedXpStat ? .gray500 : .gray300)
+                        .font(.system(size: 16, weight: xpStat == vm.selectedXpStat ? .semibold : .medium))
+                        .frame(height: 30)
+                }
+                .padding(.horizontal, 6)
+                .overlay(alignment: .bottom) {
+                    if xpStat == vm.selectedXpStat {
+                        Rectangle()
+                            .frame(height: 3)
+                            .foregroundStyle(.primaryPurple)
+                            .matchedGeometryEffect(id: "XpStat", in: namespace)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .frame(height: 1)
+                .foregroundStyle(.gray100)
+        }
     }
     
     private var questListView: some View {
@@ -96,7 +134,7 @@ extension QuestView {
                     }
                 }
             }
-            .padding(.top, 6)
+            .padding(.top, 20)
             .padding(.bottom, 72)
         }
         .frame(maxWidth: .infinity)

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -18,6 +18,7 @@ class QuestViewModel: ObservableObject {
     
     @Published var viewStatus: ViewStatus = .loading
     @Published var selectedHeader: QuestStatus = .uncompleted
+    @Published var selectedXpStat: XpStat = .strength
     @Published var selectedQuest: QuestViewModelItem = .mockData
     @Published var showQuestSheet: Bool = false
     @Published var showSubmitRouterView: Bool = false {

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -39,6 +39,29 @@ enum QuestStatus: String, CaseIterable {
     }
 }
 
+enum XpStat: String, CaseIterable {
+    case strength
+    case intellect
+    case fun
+    case charm
+    case sociability
+    
+    var headerText: String {
+        switch self {
+        case .strength:
+            "체력"
+        case .intellect:
+            "지능"
+        case .fun:
+            "재미"
+        case .charm:
+            "매력"
+        case .sociability:
+            "사회성"
+        }
+    }
+}
+
 struct QuestViewModelItem {
     let id: String
     var image: UIImage?


### PR DESCRIPTION
#### close #146 

### ✏️ 개요
XP가 5가지로 분리됨에 따라, 원하는 스탯의 퀘스트만 선택해 볼 수 있도록 디자인을 수정했습니다.

### 💻 작업 사항
- 퀘스트 탭에서 완료하지 않은 퀘스트의 경우, 스탯을 선택할 수 있도록 상단 스탯 선택 영역 디자인 적용

### 📄 리뷰 노트
선택되었을 때 필터링하는 기능은 일요일에 마저 할 예정입니다!!

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/81f5e8d7-af47-496f-8d2b-924c5dd26da8" width = "300">
