### PR TITLE
[Design/#148] 퀘스트시트뷰 XP 스탯 디자인 추가 및 리워드 관련 응답구조 변경

### DIFF
--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -33,5 +33,6 @@ struct Mission: Codable {
 
 struct Reward: Codable {
     let quantity: Int
+    let content: String?
     let type: String
 }

--- a/ILSANG/Sources/Model/Quest.swift
+++ b/ILSANG/Sources/Model/Quest.swift
@@ -8,9 +8,9 @@
 struct Quest: Codable {
     let questId: String
     let writer: String
-    let quantity: Int
     let missionTitle: String
     let status: String
     let creatorRole: String
     let imageId: String?
+    let rewardList: [Reward]
 }

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -23,7 +23,7 @@ struct QuestItemView: View {
                 .padding(.leading, 20)
                 .padding(.trailing, 16)
                 .overlay(alignment: .top) {
-                    Text(String(quest.reward) + "XP")
+                    Text(String(quest.totalRewardXP()) + "XP")
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 5)

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -32,7 +32,7 @@ struct QuestView: View {
         .background(Color.background)
         .sheet(isPresented: $vm.showQuestSheet) {
             questSheetView
-                .presentationDetents([.height(540)])
+                .presentationDetents([.height(558)])
                 .presentationDragIndicator(.visible)
         }
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
@@ -172,39 +172,39 @@ extension QuestView {
         VStack(spacing: 0) {
             Text("퀘스트 정보")
                 .font(.system(size: 17, weight: .bold))
+                .padding(.bottom, 22)
+                .padding(.top, 4)
             
             Image(uiImage: vm.selectedQuest.image ?? .logo)
                 .resizable()
                 .scaledToFill()
                 .frame(width: 122, height: 122)
                 .clipShape(Circle())
-                .padding(20)
+                .padding(.bottom, 20)
             
             Text(vm.selectedQuest.writer)
                 .font(.system(size: 15, weight: .regular))
-                .padding(.bottom, 9)
+                .padding(.bottom, 5)
             
             Text(vm.selectedQuest.missionTitle)
                 .font(.system(size: 18, weight: .bold))
-                .padding(.bottom, 22)
+                .padding(.bottom, 18)
             
-            Text("+" + String(vm.selectedQuest.reward) + "XP")
+            Text("+" + String(vm.selectedQuest.totalRewardXP()) + "XP")
                 .font(.system(size: 30, weight: .semibold))
-                .padding(.horizontal, 38)
-                .padding(.vertical, 31)
                 .foregroundStyle(.primaryPurple)
-                .background(
-                    RoundedRectangle(cornerRadius: 14)
-                        .foregroundStyle(.primary100.opacity(0.5))
-                )
-                .padding(.bottom, 15)
+                .padding(.bottom, 19)
+            
+            StatView(dic: vm.selectedQuest.rewardDic)
+                .padding(.bottom, 17)
             
             Text("퀘스트를 수행하셨나요?\n인증 후 포인트를 적립받으세요")
                 .font(.system(size: 14, weight: .regular))
                 .multilineTextAlignment(.center)
                 .lineSpacing(4)
-                .padding(.bottom, 26)
-
+            
+            Spacer(minLength: 0)
+            
             PrimaryButton(title: "퀘스트 인증하기") {
                 vm.tappedQuestApprovalBtn()
             }
@@ -216,4 +216,37 @@ extension QuestView {
 
 #Preview {
     QuestView(vm: QuestViewModel(imageNetwork: ImageNetwork(), questNetwork: QuestNetwork()))
+}
+
+struct StatView: View {
+    let columns = [GridItem(.flexible(minimum: 60)), GridItem(.flexible(minimum: 60)), GridItem(.flexible(minimum: 60))]
+    let stats: [XpStat] = [.strength, .intellect, .sociability, .charm, .fun]
+    let dic: [XpStat: Int]
+    
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(stats, id: \.self) { stat in
+                HStack {
+                    Text("\(stat.headerText) : \(dic[stat] ?? 0)P")
+                        .frame(height: 22, alignment: .leading)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.primaryPurple)
+                    Spacer(minLength: 0)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.leading, 8)
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 84)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .foregroundStyle(.primary100.opacity(0.5))
+        )
+    }
+}
+
+#Preview {
+    StatView(dic: [.charm: 225, .fun: 392, .sociability: 0])
+        .padding(.horizontal, 20)
 }

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -93,6 +93,10 @@ struct QuestViewModelItem {
         }
     }
     
+    func totalRewardXP() -> Int {
+        self.rewardDic.values.reduce(0, +)
+    }
+    
     static let mockImageId = "IMQU2024071520500801"
     
     static let mockData: QuestViewModelItem = QuestViewModelItem(

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -68,15 +68,15 @@ struct QuestViewModelItem {
     let imageId: String?
     let missionTitle: String
     let writer: String
-    let reward: Int
+    var rewardDic: [XpStat: Int]
     
-    init(id: String, image: UIImage? = nil, imageId: String, missionTitle: String, writer: String, reward: Int) {
+    init(id: String, image: UIImage? = nil, imageId: String, missionTitle: String, writer: String, rewardDic: [XpStat: Int]) {
         self.id = id
         self.image = image
         self.imageId = imageId
         self.missionTitle = missionTitle
         self.writer = writer
-        self.reward = reward
+        self.rewardDic = rewardDic
     }
     
     init(quest: Quest) {
@@ -85,7 +85,12 @@ struct QuestViewModelItem {
         self.imageId = quest.imageId
         self.missionTitle = quest.missionTitle
         self.writer = quest.writer
-        self.reward = quest.quantity
+        self.rewardDic = [:]
+        for reward in quest.rewardList {
+            if reward.type == "XP" , let content = reward.content {
+                self.rewardDic[XpStat(rawValue: content.lowercased()) ?? .strength] = reward.quantity
+            }
+        }
     }
     
     static let mockImageId = "IMQU2024071520500801"
@@ -96,7 +101,7 @@ struct QuestViewModelItem {
         imageId: mockImageId,
         missionTitle: "아메리카노 15잔 마시기",
         writer: "이디야커피",
-        reward: 50
+        rewardDic: [:]
     )
     
     static let mockQuestList: [QuestViewModelItem] = [
@@ -106,7 +111,7 @@ struct QuestViewModelItem {
             imageId: mockImageId,
             missionTitle: "아메리카노 15잔 마시기",
             writer: "이디야커피",
-            reward: 50
+            rewardDic: [:]
         ),
         QuestViewModelItem(
             id: "13",
@@ -114,7 +119,7 @@ struct QuestViewModelItem {
             imageId: mockImageId,
             missionTitle: "카페라떼 1잔 마시기",
             writer: "투썸플레이스",
-            reward: 150
+            rewardDic: [:]
         )
     ]
 }


### PR DESCRIPTION
#### close #148

### ✏️ 개요
퀘스트뷰의 questSheetView 에 5가지의 XP 스탯을 보여주도록 UI를 수정합니다.

### 💻 작업 사항 
- 퀘스트조회 API의 리워드 응답 구조 변경
- 스트뷰의 questSheetView에 XP 스탯 디자인 추가


### 📄 리뷰 노트
questSheetView 디테일을 수정했는데, 피그마에서 컴포넌트 프레임이 이상하게 잡혀있어서 캡쳐해서 비교하면서 맞췄습니다..,,
스탯 레이아웃도 피그마에는 레이아웃에 규칙이 없어서 최대한 미관상 이상하지 않고, 규칙이 있도록,, 구현해두었습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/7e4c871c-b6d9-4e66-b825-af46ab3464b0" width = "300"> 
<img src = "https://github.com/user-attachments/assets/cd398d9d-55f8-45fe-b411-ba8fa712224c" width = "300"> 

