### PR TITLE
[Feat/#151] 미완료 퀘스트의 XpStat별 분류 로직 추가 및 페이지네이션 로직 리팩토링

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -46,9 +46,10 @@ class QuestViewModel: ObservableObject {
         }
     }
     
+    // TODO: 현재 0페이지만 불러오며, 임시로 100개 로딩. 스탯 분류와 관련해서 기획 & API 수정에 따라 페이지네이션 로직 수정 필요
     lazy var uncompletedPaginationManager = PaginationManager<QuestViewModelItem>(
         size: 100,
-        threshold: 8,
+        threshold: 98,
         loadPage: { [weak self] page in
             guard let self = self else { return ([], 0) }
             return await loadQuestListWithImage(page: page, status: .uncompleted)


### PR DESCRIPTION
#### close #151 

### ✏️ 개요
퀘스트 보상 방식이 5개로 분리됨에 따라 미완료 퀘스트 조회 API 로딩 후 리워드의 스탯에 따라 분류합니다.

### 💻 작업 사항
- 선택된 스탯이 포함된 퀘스트를 볼 수 있도록 기능 요구사항을 반영했습니다.

### 📄 리뷰 노트
미완료 퀘스트 조회 API를 요청하는 방식이 스탯에 따라 API를 요청하는 방식이 아니고 API를 요청한 후 응답값으로 스탯을 분류하는 방식입니다.
따라서, 현재 API로는 기존대로 페이지네이션을 구현할 효율적인 방법이 떠오르지 않아, 미완료 퀘스트 API는 일단 100개를 불러오는 방식으로 하기로 채드와 얘기했습니다..


### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/9f0bbddb-b1fe-4b24-bc7c-f54989bb58d2" width = "300"> 
<img src = "https://github.com/user-attachments/assets/4c1c7671-72d2-42f3-a8ac-d27ff79596b3" width = "300"> 
