### PR TITLE
[Ref/#153] Challenge 구조체 필드 변경(quest 삭제, missionTitle 추가) 및 관련 로직 수정

### DIFF
--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-// TODO: userNickName, quest 옵셔널 해제
+// TODO: userNickName 옵셔널 해제
 struct Challenge: Codable {
     let challengeId: String
     let userNickName: String?
-    let quest: QuestEntity?
+    let missionTitle: String?
     let receiptImageId, status: String
     let createdAt: String
     let likeCnt, hateCnt: Int

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -301,7 +301,7 @@ struct ApprovalViewModelItem: Identifiable {
     
     init(challenge: Challenge) {
         self.id = challenge.challengeId
-        self.title = challenge.quest?.missions.first?.title ?? ""
+        self.title = challenge.missionTitle ?? ""
         self.image = nil
         self.imageId = challenge.receiptImageId
         self.offset = 0

--- a/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
@@ -29,7 +29,7 @@ struct MyPageQuestList: View {
                 VStack(spacing: 12) {
                     ForEach(questData, id: \.challengeId) { Data in
                         NavigationLink(destination: DetailQuestview(ChallengeData: Data)) {
-                            ListStruct(title: Data.quest?.missions.first?.title ?? "챌린지명", detail: Data.createdAt.timeAgoCreatedAt(), point: nil)
+                            ListStruct(title: Data.missionTitle ?? "챌린지명", detail: Data.createdAt.timeAgoCreatedAt(), point: nil)
                         }
                     }
                 }

--- a/ILSANG/Sources/Views/Quest/DetailQuestview.swift
+++ b/ILSANG/Sources/Views/Quest/DetailQuestview.swift
@@ -51,7 +51,7 @@ struct DetailQuestview: View {
                     
                     HStack() {
                         VStack (alignment: .leading) {
-                            Text(ChallengeData.quest?.missions.first?.title ?? "")
+                            Text(ChallengeData.missionTitle ?? "")
                                 .font(.headline)
                                 .padding(.bottom, 1)
                             


### PR DESCRIPTION
#### close #153

### ✏️ 개요
도전내역랜덤조회 & 도전내역조회 API의 응답 구조 변경에 따라 Challenge 모델을 수정합니다.

### 💻 작업 사항
- Challenge 구조체 수정 (quest 삭제, missionTitle 추가)
- Challenge 사용하는 부분 로직 수정

### 📄 리뷰 노트
도전내역랜덤조회 API 응답구조가 수정되어서 확인했는데, 도전내역 조회 API 응답 모델도 같은 거여서 둘 다 잘 표시되도록 수정되었습니다 !!
도전내역 이미지는 서버에서 삭제되어서 기본로고로 나옵니다 ㅎㅎ ;

<img src = "https://github.com/user-attachments/assets/f5b20553-57cd-48f1-b030-4e346574b547" width = "300"> 
<img src = "https://github.com/user-attachments/assets/8f6c9b97-292a-4b3a-b3a7-e0296ea66f1e" width = "300">



