### PR TITLE
[Feat/#149] 마이 탭 5가지 스텟 표 구현 

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DADF542C6B4EC7001A0B3A /* Data++.swift */; };
 		A10EF9392C87292C003D78A2 /* OpenSourceInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10EF9382C87292C003D78A2 /* OpenSourceInfoView.swift */; };
 		A11D88F72C916DE500846122 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D88F62C916DE500846122 /* Icon.swift */; };
+		A13BD3932CA182A0003FF9BE /* XpStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13BD3922CA1829A003FF9BE /* XpStats.swift */; };
 		A142E0312C2D9F37004395F8 /* SettingAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A142E0302C2D9F37004395F8 /* SettingAlertView.swift */; };
 		A1501B082C48C3C6001410E1 /* MyPageActiveList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1501B072C48C3C6001410E1 /* MyPageActiveList.swift */; };
 		A1501B0A2C48C3E5001410E1 /* MyPageBadgeList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1501B092C48C3E5001410E1 /* MyPageBadgeList.swift */; };
@@ -174,6 +175,7 @@
 		60DADF542C6B4EC7001A0B3A /* Data++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data++.swift"; sourceTree = "<group>"; };
 		A10EF9382C87292C003D78A2 /* OpenSourceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSourceInfoView.swift; sourceTree = "<group>"; };
 		A11D88F62C916DE500846122 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
+		A13BD3922CA1829A003FF9BE /* XpStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpStats.swift; sourceTree = "<group>"; };
 		A142E0302C2D9F37004395F8 /* SettingAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAlertView.swift; sourceTree = "<group>"; };
 		A1501B072C48C3C6001410E1 /* MyPageActiveList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageActiveList.swift; sourceTree = "<group>"; };
 		A1501B092C48C3E5001410E1 /* MyPageBadgeList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageBadgeList.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 		600211E62C1EED2B000CC02E /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				A13BD3922CA1829A003FF9BE /* XpStats.swift */,
 				60C6B4DB2C2D042700926C0E /* Image.swift */,
 				600211E72C1EED40000CC02E /* Emoji.swift */,
 				A1FF91712C257E9A00F03E4B /* User.swift */,
@@ -715,6 +718,7 @@
 				A1FF916E2C250C3B00F03E4B /* UserNetwork.swift in Sources */,
 				A1AB3D6E2C117569001EB9D8 /* Color.swift in Sources */,
 				A1501B082C48C3C6001410E1 /* MyPageActiveList.swift in Sources */,
+				A13BD3932CA182A0003FF9BE /* XpStats.swift in Sources */,
 				A1AB3D682C1141B3001EB9D8 /* GoogleLoginButtonView.swift in Sources */,
 				601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */,
 				A19628622C0763F90037C53A /* ChangeNickNameView.swift in Sources */,

--- a/ILSANG/Sources/Model/XpStats.swift
+++ b/ILSANG/Sources/Model/XpStats.swift
@@ -7,16 +7,14 @@
 
 import Foundation
 
-struct XpStatModel: Decodable {
-    let data: XpStat
+struct XpstatModel: Decodable {
+    let data: Xpstats
 }
 
-
-struct XpStat: Decodable {
-    let strength_stat: Int
-    let intellect_stat: Int
-    let fun_stat: Int
-    let charm_stat: Int
-    let sociability_stat: Int
+struct Xpstats: Decodable {
+    let strengthStat: Int
+    let intellectStat: Int
+    let funStat: Int
+    let charmStat: Int
+    let sociabilityStat: Int
 }
-

--- a/ILSANG/Sources/Model/XpStats.swift
+++ b/ILSANG/Sources/Model/XpStats.swift
@@ -17,4 +17,12 @@ struct Xpstats: Decodable {
     let funStat: Int
     let charmStat: Int
     let sociabilityStat: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case strengthStat = "strength_stat"
+        case intellectStat = "intellect_stat"
+        case funStat = "fun_stat"
+        case charmStat = "charm_stat"
+        case sociabilityStat = "sociability_stat"
+    }
 }

--- a/ILSANG/Sources/Model/XpStats.swift
+++ b/ILSANG/Sources/Model/XpStats.swift
@@ -1,0 +1,22 @@
+//
+//  XpStats.swift
+//  ILSANG
+//
+//  Created by Kim Andrew on 9/23/24.
+//
+
+import Foundation
+
+struct XpStatModel: Decodable {
+    let data: XpStat
+}
+
+
+struct XpStat: Decodable {
+    let strength_stat: Int
+    let intellect_stat: Int
+    let fun_stat: Int
+    let charm_stat: Int
+    let sociability_stat: Int
+}
+

--- a/ILSANG/Sources/Network/XPNetwork.swift
+++ b/ILSANG/Sources/Network/XPNetwork.swift
@@ -17,7 +17,7 @@ final class XPNetwork {
         return await Network.requestData(url: HistoryUrl + "", method: .get, parameters: parameters, withToken: true)
     }
     
-    func getXpStats() async -> Result<XpStats,Error> {
-        return await Network.requestData(url: StatsUrl, method: .get, withToken: true)
+    func getXpStats() async -> Result<XpstatModel,Error> {
+        return await Network.requestData(url: StatsUrl, method: .get, parameters: nil, withToken: true)
     }
 }

--- a/ILSANG/Sources/Network/XPNetwork.swift
+++ b/ILSANG/Sources/Network/XPNetwork.swift
@@ -9,10 +9,15 @@ import Foundation
 import Alamofire
 
 final class XPNetwork {
-    private let url = APIManager.makeURL(CustomerTarget(path: "xpHistory"))
+    private let HistoryUrl = APIManager.makeURL(CustomerTarget(path: "xpHistory"))
+    private let StatsUrl = APIManager.makeURL(CustomerTarget(path: "xpStats"))
     
     func getXP(page: Int, size: Int) async -> Result<XP,Error> {
         let parameters: Parameters = ["page": page, "size": size]
-        return await Network.requestData(url: url + "", method: .get, parameters: parameters, withToken: true)
+        return await Network.requestData(url: HistoryUrl + "", method: .get, parameters: parameters, withToken: true)
+    }
+    
+    func getXpStats() async -> Result<XpStats,Error> {
+        return await Network.requestData(url: StatsUrl, method: .get, withToken: true)
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyPageActiveList: View {
     
-    @ObservedObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(),xpNetwork: XPNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork())
+    @ObservedObject var vm = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
     
     @Binding var activeData: [XPContent]
     

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -48,12 +48,13 @@ struct MyPageProfile: View {
                 }
                 .padding(18)
                 .background(Color.white)
+                .cornerRadius(12, corners: [.topLeft, .topRight])
                 .task {
                     await vm.getUser()
                     Log(vm.userData)
                 }
                 
-                VStack {
+                VStack (spacing: 8){
                     //스텟
                     HStack (alignment: .center, spacing: 18) {
                         ProfileStatView(StatName: "체력", StatPoint: vm.xpStats?.strengthStat ?? 0)
@@ -70,17 +71,16 @@ struct MyPageProfile: View {
                         
                     }
                 }
-                .padding(.vertical, 14)
+                .padding(.top, 7)
+                .padding(.bottom, 14)
                 .padding(.horizontal, 8)
                 .task {
                     await vm.getXpStat()
                     Log(vm.xpStats)
                 }
             }
-            .background(
-                RoundedRectangle(cornerRadius: 14)
-                    .foregroundColor(Color.primary100)
-            )
+            .background(Color.primary100)
+            .cornerRadius(12)
         }
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -72,6 +72,7 @@ struct MyPageProfile: View {
                 }
                 .padding(.vertical, 14)
                 .padding(.horizontal, 8)
+                .task { await vm.getXpStat() }
             }
             .background(
                 RoundedRectangle(cornerRadius: 14)

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -55,6 +55,7 @@ struct MyPageProfile: View {
                 }
                 
                 StatView(dic: vm.xpStats)
+                    .frame(height: 70)
                     .task {
                         await vm.getXpStat()
                         Log(vm.xpStats)

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyPageProfile: View {
     
-    @StateObject var vm = MypageViewModel(userNetwork: UserNetwork(),xpNetwork: XPNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork())
+    @StateObject var vm = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
     
     var body: some View {
         NavigationLink(destination: ChangeNickNameView()) {

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -58,7 +58,6 @@ struct MyPageProfile: View {
                     .frame(height: 70)
                     .task {
                         await vm.getXpStat()
-                        Log(vm.xpStats)
                     }
             }
             .background(Color.primary100)

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -54,30 +54,11 @@ struct MyPageProfile: View {
                     Log(vm.userData)
                 }
                 
-                VStack (spacing: 8){
-                    //스텟
-                    HStack (alignment: .center, spacing: 18) {
-                        ProfileStatView(StatName: "체력", StatPoint: vm.xpStats?.strengthStat ?? 0)
-                        ProfileStatView(StatName: "지능", StatPoint: vm.xpStats?.intellectStat ?? 0)
-                        ProfileStatView(StatName: "사회성", StatPoint: vm.xpStats?.funStat ?? 0)
-                        
+                StatView(dic: vm.xpStats)
+                    .task {
+                        await vm.getXpStat()
+                        Log(vm.xpStats)
                     }
-                    
-                    HStack (alignment: .center, spacing: 18) {
-                        ProfileStatView(StatName: "매력", StatPoint: vm.xpStats?.charmStat ?? 0)
-                        ProfileStatView(StatName: "재미", StatPoint: vm.xpStats?.sociabilityStat ?? 0)
-                        
-                        Spacer().frame(maxWidth: 95)
-                        
-                    }
-                }
-                .padding(.top, 7)
-                .padding(.bottom, 14)
-                .padding(.horizontal, 8)
-                .task {
-                    await vm.getXpStat()
-                    Log(vm.xpStats)
-                }
             }
             .background(Color.primary100)
             .cornerRadius(12)

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -56,15 +56,15 @@ struct MyPageProfile: View {
                 VStack {
                     //스텟
                     HStack (alignment: .center, spacing: 18) {
-                        ProfileStatView(StatName: "stat1", StatPoint: 0)
-                        ProfileStatView(StatName: "stat1", StatPoint: 0)
-                        ProfileStatView(StatName: "stat1", StatPoint: 0)
+                        ProfileStatView(StatName: "체력", StatPoint: vm.xpStats?.strengthStat ?? 0)
+                        ProfileStatView(StatName: "지능", StatPoint: vm.xpStats?.intellectStat ?? 0)
+                        ProfileStatView(StatName: "사회성", StatPoint: vm.xpStats?.funStat ?? 0)
                         
                     }
                     
                     HStack (alignment: .center, spacing: 18) {
-                        ProfileStatView(StatName: "stat1", StatPoint: 0)
-                        ProfileStatView(StatName: "stat1", StatPoint: 0)
+                        ProfileStatView(StatName: "매력", StatPoint: vm.xpStats?.charmStat ?? 0)
+                        ProfileStatView(StatName: "재미", StatPoint: vm.xpStats?.sociabilityStat ?? 0)
                         
                         Spacer().frame(maxWidth: 95)
                         
@@ -72,7 +72,10 @@ struct MyPageProfile: View {
                 }
                 .padding(.vertical, 14)
                 .padding(.horizontal, 8)
-                .task { await vm.getXpStat() }
+                .task {
+                    await vm.getXpStat()
+                    Log(vm.xpStats)
+                }
             }
             .background(
                 RoundedRectangle(cornerRadius: 14)

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -13,6 +13,7 @@ struct MyPageProfile: View {
     
     var body: some View {
         NavigationLink(destination: ChangeNickNameView()) {
+            
             VStack {
                 //기본 프로필
                 HStack {
@@ -46,21 +47,36 @@ struct MyPageProfile: View {
                     }
                 }
                 .padding(18)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .foregroundColor(Color.white)
-                )
+                .background(Color.white)
                 .task {
                     await vm.getUser()
                     Log(vm.userData)
                 }
                 
-                //스텟
-                HStack (alignment: .center, spacing: 18) {
-                    ProfileStatView(StatName: "stat1", StatPoint: 0)
+                VStack {
+                    //스텟
+                    HStack (alignment: .center, spacing: 18) {
+                        ProfileStatView(StatName: "stat1", StatPoint: 0)
+                        ProfileStatView(StatName: "stat1", StatPoint: 0)
+                        ProfileStatView(StatName: "stat1", StatPoint: 0)
+                        
+                    }
+                    
+                    HStack (alignment: .center, spacing: 18) {
+                        ProfileStatView(StatName: "stat1", StatPoint: 0)
+                        ProfileStatView(StatName: "stat1", StatPoint: 0)
+                        
+                        Spacer().frame(maxWidth: 95)
+                        
+                    }
                 }
+                .padding(.vertical, 14)
                 .padding(.horizontal, 8)
             }
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .foregroundColor(Color.primary100)
+            )
         }
     }
 }
@@ -129,7 +145,9 @@ struct ProfileStatView: View {
     
     var body: some View {
         Text("\(StatName) : \(StatPoint)P")
+            .foregroundColor(.accent)
             .font(.system(size: 15, weight: .semibold))
+            .frame(maxWidth: 95)
     }
 }
 

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -13,44 +13,53 @@ struct MyPageProfile: View {
     
     var body: some View {
         NavigationLink(destination: ChangeNickNameView()) {
-            HStack {
-                //프로필
-                ProfileImageView(profileImage: nil, level: vm.convertXPtoLv(XP: vm.userData?.xpPoint ?? 9))
-                
-                // 프로필 상세
-                VStack (alignment: .leading) {
-                    //유저 이름
-                    Text(vm.userData?.nickname ?? "일상73079405")
-                        .font(.system(size: 16, weight: .bold))
-                        .underline(true, color: .gray300)
-                        .foregroundStyle(.gray500)
-                        .multilineTextAlignment(.leading)
+            VStack {
+                //기본 프로필
+                HStack {
+                    //프로필
+                    ProfileImageView(profileImage: nil, level: vm.convertXPtoLv(XP: vm.userData?.xpPoint ?? 9))
                     
-                    HStack {
-                        // 프로그레스 바
-                        vm.ProgressBar(userXP: vm.userData?.xpPoint ?? 0)
-                            .frame(height: 10)
+                    // 프로필 상세
+                    VStack (alignment: .leading) {
+                        //유저 이름
+                        Text(vm.userData?.nickname ?? "일상73079405")
+                            .font(.system(size: 16, weight: .bold))
+                            .underline(true, color: .gray300)
+                            .foregroundStyle(.gray500)
+                            .multilineTextAlignment(.leading)
                         
-                        // 경험치 Text
-                        Text(String(vm.userData?.xpPoint ?? 0)+"XP")
+                        HStack {
+                            // 프로그레스 바
+                            vm.ProgressBar(userXP: vm.userData?.xpPoint ?? 0)
+                                .frame(height: 10)
+                            
+                            // 경험치 Text
+                            Text(String(vm.userData?.xpPoint ?? 0)+"XP")
+                                .font(.system(size: 13))
+                                .fontWeight(.bold)
+                                .foregroundColor(.accentColor)
+                        }
+                        
+                        Text("다음 레벨까지 \(vm.xpForNextLv(XP: vm.userData?.xpPoint ?? 50))XP 남았어요!")
                             .font(.system(size: 13))
-                            .fontWeight(.bold)
-                            .foregroundColor(.accentColor)
+                            .foregroundColor(.gray500)
                     }
-                    
-                    Text("다음 레벨까지 \(vm.xpForNextLv(XP: vm.userData?.xpPoint ?? 50))XP 남았어요!")
-                        .font(.system(size: 13))
-                        .foregroundColor(.gray500)
                 }
-            }
-            .padding(18)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .foregroundColor(Color.white)
-            )
-            .task {
-                await vm.getUser()
-                Log(vm.userData)
+                .padding(18)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundColor(Color.white)
+                )
+                .task {
+                    await vm.getUser()
+                    Log(vm.userData)
+                }
+                
+                //스텟
+                HStack (alignment: .center, spacing: 18) {
+                    ProfileStatView(StatName: "stat1", StatPoint: 0)
+                }
+                .padding(.horizontal, 8)
             }
         }
     }
@@ -106,6 +115,21 @@ struct ProfileImageView: View {
             }
         }
         .frame(height: 68)
+    }
+}
+
+struct ProfileStatView: View {
+    var StatName: String
+    var StatPoint: Int
+    
+    init(StatName: String, StatPoint: Int) {
+        self.StatName = StatName
+        self.StatPoint = StatPoint
+    }
+    
+    var body: some View {
+        Text("\(StatName) : \(StatPoint)P")
+            .font(.system(size: 15, weight: .semibold))
     }
 }
 

--- a/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageQuestList.swift
@@ -9,7 +9,7 @@ import SwiftUI
 //MARK: 색상 폰트 변경 요청
 struct MyPageQuestList: View {
     
-    @ObservedObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(),xpNetwork: XPNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork())
+    @ObservedObject var vm = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
     
     @Binding var questData: [Challenge]
     

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -15,7 +15,7 @@ struct MyPageView: View {
             XPContent(recordId: 3, title: "Quest Completed", xpPoint: 150, createDate: "2024-06-23")
         ]
     
-    @StateObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(),xpNetwork: XPNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork())
+    @StateObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
     
     @State var segmentSelect = 0
     @State private var isSettingsViewActive = false

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -21,6 +21,7 @@ struct MypageViewModelItem: Identifiable {
 class MypageViewModel: ObservableObject {
     @Published var userData: User?
     @Published var challengeList: [Challenge]?
+    @Published var xpStats: [XpStats]
     @Published var questXp: [XPContent]?
     @Published var challengeDelete = false
     
@@ -29,12 +30,16 @@ class MypageViewModel: ObservableObject {
     private let imageNetwork: ImageNetwork
     private let xpNetwork: XPNetwork
     
-    init(userData: User? = nil, userNetwork: UserNetwork, xpNetwork: XPNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork) {
+    init(userData: User? = nil, challengeList: [Challenge]? = nil, xpStats: [XpStats], questXp: [XPContent]? = nil, challengeDelete: Bool = false, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
         self.userData = userData
+        self.challengeList = challengeList
+        self.xpStats = xpStats
+        self.questXp = questXp
+        self.challengeDelete = challengeDelete
         self.userNetwork = userNetwork
-        self.xpNetwork = xpNetwork
         self.challengeNetwork = challengeNetwork
         self.imageNetwork = imageNetwork
+        self.xpNetwork = xpNetwork
     }
     
     @MainActor

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -21,7 +21,7 @@ struct MypageViewModelItem: Identifiable {
 class MypageViewModel: ObservableObject {
     @Published var userData: User?
     @Published var challengeList: [Challenge]?
-    @Published var xpStats: Xpstats?
+    @Published var xpStats: [XpStat: Int]
     @Published var questXp: [XPContent]?
     @Published var challengeDelete = false
     
@@ -30,7 +30,7 @@ class MypageViewModel: ObservableObject {
     private let imageNetwork: ImageNetwork
     private let xpNetwork: XPNetwork
     
-    init(userData: User? = nil, challengeList: [Challenge]? = nil, xpStats: Xpstats? = nil, questXp: [XPContent]? = nil, challengeDelete: Bool = false, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
+    init(userData: User? = nil, challengeList: [Challenge]? = nil, xpStats: [XpStat: Int] = [:], questXp: [XPContent]? = nil, challengeDelete: Bool = false, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
         self.userData = userData
         self.challengeList = challengeList
         self.xpStats = xpStats
@@ -78,11 +78,18 @@ class MypageViewModel: ObservableObject {
         
         switch res {
         case .success(let model):
-            self.xpStats = model.data
+            let xpData = model.data
+            self.xpStats = [
+                .strength: xpData.strengthStat,
+                .intellect: xpData.intellectStat,
+                .fun: xpData.funStat,
+                .charm: xpData.charmStat,
+                .sociability: xpData.sociabilityStat
+            ]
             Log(xpStats)
             
         case .failure:
-            self.xpStats = nil
+            self.xpStats = [:]
         }
     }
     

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -21,7 +21,7 @@ struct MypageViewModelItem: Identifiable {
 class MypageViewModel: ObservableObject {
     @Published var userData: User?
     @Published var challengeList: [Challenge]?
-    @Published var xpStats: [XpStats]
+    @Published var xpStats: Xpstats?
     @Published var questXp: [XPContent]?
     @Published var challengeDelete = false
     
@@ -30,7 +30,7 @@ class MypageViewModel: ObservableObject {
     private let imageNetwork: ImageNetwork
     private let xpNetwork: XPNetwork
     
-    init(userData: User? = nil, challengeList: [Challenge]? = nil, xpStats: [XpStats], questXp: [XPContent]? = nil, challengeDelete: Bool = false, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
+    init(userData: User? = nil, challengeList: [Challenge]? = nil, xpStats: Xpstats? = nil, questXp: [XPContent]? = nil, challengeDelete: Bool = false, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
         self.userData = userData
         self.challengeList = challengeList
         self.xpStats = xpStats
@@ -69,6 +69,20 @@ class MypageViewModel: ObservableObject {
         case .failure:
             self.questXp = nil
             Log(res)
+        }
+    }
+    
+    @MainActor
+    func getXpStat() async {
+        let res = await xpNetwork.getXpStats()
+        
+        switch res {
+        case .success(let model):
+            self.xpStats = model.data
+            Log(xpStats)
+            
+        case .failure:
+            self.xpStats = nil
         }
     }
     
@@ -137,15 +151,15 @@ class MypageViewModel: ObservableObject {
     }
     
     @MainActor
-     func getImage(imageId: String) async -> UIImage? {
-        let res = await imageNetwork.getImage(imageId: imageId)
-        switch res {
-        case .success(let uiImage):
-            return uiImage
-        case .failure:
-            return nil
-        }
+    func getImage(imageId: String) async -> UIImage? {
+    let res = await imageNetwork.getImage(imageId: imageId)
+    switch res {
+    case .success(let uiImage):
+        return uiImage
+    case .failure:
+        return nil
     }
+}
     
     func ProgressBar(userXP: Int) -> some View {
         let levelData = xpGapBtwLevels(XP: userXP)

--- a/ILSANG/Sources/Views/Quest/DetailQuestview.swift
+++ b/ILSANG/Sources/Views/Quest/DetailQuestview.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct DetailQuestview: View {
     
     @Environment(\.dismiss) var dismiss
-    @StateObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(),xpNetwork: XPNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork())
+    @StateObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
     
     @State private var missionImage: UIImage? = nil
     


### PR DESCRIPTION
#### close #149 

### ✏️ 개요
마이페이지 5가지 스텟 세부내역 조회 

### 💻 작업 사항
- [x] 5가지 스탯 총합 뷰 구현
- [x] Api 연동

### 📄 리뷰 노트
세부 디자인이 수 픽셀씩 맞지 않는 부분이 많아서 일단 통일된 디자인으로 구현하였습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/84c58808-bed0-472d-af5e-709f41a10f1e" width = "300"> 
