### PR TITLE
[bug/#158] 레벨이 음수로 출력될때 예외 처리

### DIFF
--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -127,34 +127,40 @@ class MypageViewModel: ObservableObject {
             totalXP += 50 * level
         }
         
-        return level - 1
+        return max(0, level - 1)
     }
     
     //이전,다음 레벨 XP
     func xpGapBtwLevels(XP: Int) -> (currentLevelXP: Int, nextLevelXP: Int) {
-        let currentLevel = convertXPtoLv(XP: XP)
+        let sanitizedXP = max(0, XP)
+        
+        let currentLevel = convertXPtoLv(XP: sanitizedXP)
         let nextLevelXP = 50 * (currentLevel + 1)
         
         var totalXP = 0
         
-        for n in 1..<currentLevel + 1 {
-            totalXP += 50 * n
+        if currentLevel > 0 {
+            for n in 1..<currentLevel + 1 {
+                totalXP += 50 * n
+            }
         }
         
-        return (XP - totalXP, nextLevelXP)
+        return (sanitizedXP - totalXP, nextLevelXP)
     }
     
     //다음 레벨까지 남은 값 
     func xpForNextLv(XP: Int) -> Int {
-        let currentLevel = convertXPtoLv(XP: XP)
+        let sanitizedXP = max(0, XP)
+        let currentLevel = convertXPtoLv(XP: sanitizedXP)
         let nextLevel = currentLevel + 1
         var totalXP = 0
         
         for n in 1...nextLevel {
             totalXP += 50 * n
         }
+        
         Log(totalXP)
-        return totalXP - XP
+        return totalXP - sanitizedXP
     }
     
     @MainActor


### PR DESCRIPTION
#### close #158 

### ✏️ 개요
사용자 경험치 총합이 음수일시 앱이 튕기는 버그 수정

### 💻 작업 사항
0 이하의 값을 가지면 0으로 계산하도록 수정

### 📄 리뷰 노트
음수가 있다면 0으로 계산하도록 수정하였습니다.
