### PR TITLE
[Bug/#160] 미완료퀘스트 페이지네이션 & 스탯분리 로직 수정

### DIFF
--- a/ILSANG/Sources/Network/QuestNetwork.swift
+++ b/ILSANG/Sources/Network/QuestNetwork.swift
@@ -16,13 +16,13 @@ final class QuestNetwork {
         self.questUrl = questUrl
     }
     
-    func getUncompletedQuest(page: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
-        let parameters: Parameters = ["page": page, "size": "10"]
+    func getUncompletedQuest(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
+        let parameters: Parameters = ["page": page, "size": size]
         return await Network.requestData(url: questUrl+"uncompletedQuest", method: .get, parameters: parameters, withToken: true)
     }
     
-    func getCompletedQuest(page: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
-        let parameters: Parameters = ["page": page, "size": "10"]
+    func getCompletedQuest(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
+        let parameters: Parameters = ["page": page, "size": size]
         return await Network.requestData(url: questUrl+"completedQuest", method: .get, parameters: parameters, withToken: true)
     }
 }

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -105,14 +105,6 @@ extension QuestView {
                             QuestItemView(quest: quest, status: .uncompleted)
                         }
                     }
-                    if vm.hasMorePage(status: .uncompleted) {
-                        ProgressView()
-                            .onAppear {
-                                Task {
-                                    await vm.uncompletedPaginationManager.loadData(isRefreshing: false)
-                                }
-                            }
-                    }
                     
                 case .completed:
                     ForEach(vm.itemListByStatus[.completed, default: []], id: \.id) { quest in

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -30,6 +30,9 @@ struct QuestView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.background)
+        .task {
+            await vm.loadInitialData()
+        }
         .sheet(isPresented: $vm.showQuestSheet) {
             questSheetView
                 .presentationDetents([.height(558)])

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -71,10 +71,6 @@ class QuestViewModel: ObservableObject {
     init(imageNetwork: ImageNetwork, questNetwork: QuestNetwork) {
         self.imageNetwork = imageNetwork
         self.questNetwork = questNetwork
-        
-        Task {
-            await loadInitialData()
-        }
     }
     
     func loadInitialData() async {
@@ -99,8 +95,9 @@ class QuestViewModel: ObservableObject {
             currentQuestList = newQuestList
         } else {
             // MARK: 중복된 퀘스트 제거, 서버 에러 해결시 제거
-            var uniqueQuestIDs = Set(currentQuestList.map { $0.id })
-            newQuestList = newQuestList.filter { uniqueQuestIDs.insert($0.id).inserted }
+            newQuestList = newQuestList.filter { quest in
+                !currentQuestList.contains { $0.id == quest.id }
+            }
             currentQuestList += newQuestList
         }
         

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -136,6 +136,8 @@ class QuestViewModel: ObservableObject {
     /// uncompleted 상태의 퀘스트 목록을 XpStat별로 분류하여 uncompletedQuestListByXpStat 딕셔너리에 매핑합니다.
     private func mapUncompletedQuestByXpStat() {
         guard let uncompletedQuestList = itemListByStatus[.uncompleted] else { return }
+        self.uncompletedQuestListByXpStat = self.uncompletedQuestListByXpStat.mapValues { _ in [] } // 초기화
+        
         for item in uncompletedQuestList {
             for reward in item.rewardDic {
                 uncompletedQuestListByXpStat[reward.key]?.append(item)

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -52,7 +52,7 @@ class QuestViewModel: ObservableObject {
         threshold: 98,
         loadPage: { [weak self] page in
             guard let self = self else { return ([], 0) }
-            return await loadQuestListWithImage(page: page, status: .uncompleted)
+            return await loadQuestListWithImage(page: page, size: 100, status: .uncompleted)
         }
     )
     
@@ -61,7 +61,7 @@ class QuestViewModel: ObservableObject {
         threshold: 8,
         loadPage: { [weak self] page in
             guard let self = self else { return ([], 0) }
-            return await loadQuestListWithImage(page: page, status: .completed)
+            return await loadQuestListWithImage(page: page, size: 10, status: .completed)
         }
     )
     
@@ -90,8 +90,8 @@ class QuestViewModel: ObservableObject {
     }
     
     @discardableResult @MainActor
-    func loadQuestListWithImage(page: Int, status: QuestStatus) async -> ([QuestViewModelItem], Int) {
-        let getQuestList = await getQuestList(page: page, status: status)
+    func loadQuestListWithImage(page: Int, size: Int, status: QuestStatus) async -> ([QuestViewModelItem], Int) {
+        let getQuestList = await getQuestList(page: page, size: size, status: status)
         var newQuestList = getQuestList.data
         var currentQuestList = itemListByStatus[status, default: []]
         
@@ -143,14 +143,14 @@ class QuestViewModel: ObservableObject {
         }
     }
     
-    private func getQuestList(page: Int, status: QuestStatus) async -> (data: [QuestViewModelItem], total: Int) {
+    private func getQuestList(page: Int, size: Int, status: QuestStatus) async -> (data: [QuestViewModelItem], total: Int) {
         let result: Result<ResponseWithPage<[Quest]>, Error>
         
         switch status {
         case .uncompleted:
-            result = await questNetwork.getUncompletedQuest(page: page)
+            result = await questNetwork.getUncompletedQuest(page: page, size: size)
         case .completed:
-            result = await questNetwork.getCompletedQuest(page: page)
+            result = await questNetwork.getCompletedQuest(page: page, size: size)
         }
         
         switch result {


### PR DESCRIPTION
#### close #160 

### ✏️ 개요
아래 버그들을 해결하였으며, 일부 리팩토링했습니다.
- 미완료 퀘스트를 리프레시할 경우 데이터 초기화되지 않고 쌓임
- 100개 요청하는 부분 사이즈 미적용됨

### 💻 작업 사항
- 미완료 퀘스트 사이즈값 100 적용
- 미완료 퀘스트 스탯 분리 전에 초기화하도록 수정

### 📄 리뷰 노트
서버가 배포되어 앱스토어 배포하기전에 빌드해서 확인해봤는데 문제가 있어서,
로직 수정해서 심사제출&배포완료한 상태입니다.