### PR TITLE
[Feat/#162] 이미지 메모리 캐시 적용

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189262C3F00FB0070F2AD /* AuthChannel.swift */; };
 		601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189282C3F022D0070F2AD /* LoginViewModel.swift */; };
 		60299E312CBFFF160039663F /* TransferableUIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60299E302CBFFF160039663F /* TransferableUIImage.swift */; };
+		60299E392CC13DEC0039663F /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60299E382CC13DEC0039663F /* ImageCacheService.swift */; };
 		603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F040A2C2416D2008A2332 /* ImageNetwork.swift */; };
 		603F04132C26ADC6008A2332 /* CommonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F04122C26ADC6008A2332 /* CommonResponse.swift */; };
 		6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B71C2C32B6A4002C13A0 /* UIImage++.swift */; };
@@ -131,6 +132,7 @@
 		601189262C3F00FB0070F2AD /* AuthChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthChannel.swift; sourceTree = "<group>"; };
 		601189282C3F022D0070F2AD /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		60299E302CBFFF160039663F /* TransferableUIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferableUIImage.swift; sourceTree = "<group>"; };
+		60299E382CC13DEC0039663F /* ImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheService.swift; sourceTree = "<group>"; };
 		603F040A2C2416D2008A2332 /* ImageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetwork.swift; sourceTree = "<group>"; };
 		603F04122C26ADC6008A2332 /* CommonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResponse.swift; sourceTree = "<group>"; };
 		6044B71C2C32B6A4002C13A0 /* UIImage++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage++.swift"; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 			children = (
 				6011891C2C3E8B3B0070F2AD /* UserService.swift */,
 				601189202C3E94A60070F2AD /* AuthService.swift */,
+				60299E382CC13DEC0039663F /* ImageCacheService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -738,6 +741,7 @@
 				9FE63D722CB3AB4F00CA7940 /* RankingItemView.swift in Sources */,
 				9FE63D702CB3AAF100CA7940 /* RankingViewModel.swift in Sources */,
 				605DA0D62C07123400CC9450 /* View++.swift in Sources */,
+				60299E392CC13DEC0039663F /* ImageCacheService.swift in Sources */,
 				A1BB602E2C022A9900AAADD4 /* UserData.swift in Sources */,
 				A19628752C08648C0037C53A /* NavigationTitleView.swift in Sources */,
 				A1AB3D5D2C113A70001EB9D8 /* LoginView.swift in Sources */,

--- a/ILSANG/Sources/Service/ImageCacheService.swift
+++ b/ILSANG/Sources/Service/ImageCacheService.swift
@@ -1,0 +1,47 @@
+//
+//  ImageCacheService.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 10/17/24.
+//
+
+import UIKit
+
+final class ImageCacheService {
+    public static let shared = ImageCacheService(imageNetwork: ImageNetwork())
+    
+    private let imageNetwork: ImageNetwork
+    private let cachedImages = NSCache<NSString, UIImage>()
+    
+    private init(imageNetwork: ImageNetwork) {
+        self.imageNetwork = imageNetwork
+    }
+    
+    /// 이미지를 불러오는 함수
+    func loadImageAsync(imageId: String) async -> UIImage? {
+        // Cache에 저장된 이미지가 있는 경우 바로 반환
+        if let cachedImage = image(imageId: imageId) {
+            return cachedImage
+        }
+        
+        // Cache에 저장된 이미지가 없는 경우 서버에서 이미지 불러오기
+        let res = await imageNetwork.getImage(imageId: imageId)
+        switch res {
+        case .success(let uiImage):
+            setCachedImage(imageId: imageId, image: uiImage)
+            return uiImage
+        case .failure:
+            return nil
+        }
+    }
+    
+    /// Cache에 저장된 이미지가 있는지 확인
+    private final func image(imageId: String) -> UIImage? {
+        return cachedImages.object(forKey: imageId as NSString)
+    }
+    
+    /// Cache에 이미지를 저장하는 함수
+    private func setCachedImage(imageId: String, image: UIImage) {
+        cachedImages.setObject(image, forKey: imageId as NSString)
+    }
+}

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -102,7 +102,7 @@ final class ApprovalViewModel: ObservableObject {
         await withTaskGroup(of: (Int, UIImage?).self) { group in
             for (index, challenge) in challenges.enumerated() {
                 group.addTask {
-                    let image = await self.getImage(imageId: challenge.imageId)
+                    let image = await ImageCacheService.shared.loadImageAsync(imageId: challenge.imageId)
                     return (index, image)
                 }
             }
@@ -128,16 +128,6 @@ final class ApprovalViewModel: ObservableObject {
             return (response.data.map { ApprovalViewModelItem.init(challenge: $0) }, response.total)
         case .failure:
             return ([], 0)
-        }
-    }
-    
-    private func getImage(imageId: String) async -> UIImage? {
-        let res = await imageNetwork.getImage(imageId: imageId)
-        switch res {
-        case .success(let uiImage):
-            return uiImage
-        case .failure:
-            return nil
         }
     }
     

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -163,16 +163,9 @@ class MypageViewModel: ObservableObject {
         return totalXP - sanitizedXP
     }
     
-    @MainActor
     func getImage(imageId: String) async -> UIImage? {
-    let res = await imageNetwork.getImage(imageId: imageId)
-    switch res {
-    case .success(let uiImage):
-        return uiImage
-    case .failure:
-        return nil
+        await ImageCacheService.shared.loadImageAsync(imageId: imageId)
     }
-}
     
     func ProgressBar(userXP: Int) -> some View {
         let levelData = xpGapBtwLevels(XP: userXP)

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -107,7 +107,7 @@ class QuestViewModel: ObservableObject {
                     guard let imageId = quest.imageId else {
                         return (index, nil)
                     }
-                    let image = await self.getImage(imageId: imageId)
+                    let image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
                     return (index, image)
                 }
             }
@@ -166,16 +166,6 @@ class QuestViewModel: ObservableObject {
             return uncompletedPaginationManager.canLoadMoreData()
         case .completed:
             return completedPaginationManager.canLoadMoreData()
-        }
-    }
-    
-    private func getImage(imageId: String) async -> UIImage? {
-        let res = await imageNetwork.getImage(imageId: imageId)
-        switch res {
-        case .success(let uiImage):
-            return uiImage
-        case .failure:
-            return nil
         }
     }
     


### PR DESCRIPTION
#### close #162 

### ✏️ 개요
네트워크 요청 수를 줄이기 위해, 메모리 캐시를 적용했습니다.

충분히 구조를 고민하고 논의해서 적용하기에는 현재 (개인적으로) 시간이 부족하나, 아래와 같은 문제들이 눈에 밟혀서 ㅎㅎ.. 임시로 조금이나마 개선하기 위해 도입했습니다. 10월말 ~ 11월초 안으로 "캐시 정책"에 대해서 한 번 논의해보면 좋을 것 같습니다 !!
- 퀘스트탭에서 한번에 이미지를 전부 불러오기 때문에 로딩이 길다는 점.
- 퀘스트이미지id가 동일함에도 여러번 서버에 요청하는 점.
- (서버에 요청이 많아지면 서버가 터지는 점..)

### 💻 작업 사항
- 이미지 캐시 적용

### 📄 리뷰 노트
이미지를 요청할 때 캐시에 이미지가 있다면 해당 이미지를 사용하고, 없다면 서버에 요청하는 방식입니다.
디스크 캐시를 적용하면 다음에 고려할 부분이 추가로 생겨서 수정이 더 번거로워질 것 같아 메모리 캐시 방식으로 구현하였습니다.


### 📱결과 화면(optional)
<img width="220" alt="image" src="https://github.com/user-attachments/assets/92fe6fa2-acaf-4fc7-a32b-447e3b20132b">