### PR TITLE
[Ref/#170] 퀘스트 탭 throttle 적용, 뷰모델 초기화 시 데이터 불러오도록 로직 수정

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -30,9 +30,6 @@ struct QuestView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.background)
-        .task {
-            await vm.loadInitialData()
-        }
         .sheet(isPresented: $vm.showQuestSheet) {
             questSheetView
                 .presentationDetents([.height(558)])

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -128,12 +128,7 @@ extension QuestView {
         }
         .frame(maxWidth: .infinity)
         .refreshable {
-            switch vm.selectedHeader {
-            case .uncompleted:
-                await vm.uncompletedPaginationManager.loadData(isRefreshing: true)
-            case .completed:
-                await vm.completedPaginationManager.loadData(isRefreshing: true)
-            }
+            await vm.refreshData()
         }
         .overlay {
             if vm.isCurrentListEmpty {

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct QuestView: View {
-    @StateObject var vm: QuestViewModel = QuestViewModel(imageNetwork: ImageNetwork(), questNetwork: QuestNetwork())
+    @StateObject var vm: QuestViewModel = QuestViewModel(questNetwork: QuestNetwork())
     @Namespace private var namespace
 
     var body: some View {
@@ -201,7 +201,7 @@ extension QuestView {
 }
 
 #Preview {
-    QuestView(vm: QuestViewModel(imageNetwork: ImageNetwork(), questNetwork: QuestNetwork()))
+    QuestView(vm: QuestViewModel(questNetwork: QuestNetwork()))
 }
 
 struct StatView: View {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -75,6 +75,9 @@ class QuestViewModel: ObservableObject {
     init(imageNetwork: ImageNetwork, questNetwork: QuestNetwork) {
         self.imageNetwork = imageNetwork
         self.questNetwork = questNetwork
+        Task {
+            await loadInitialData()
+        }
     }
     
     func loadInitialData() async {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -65,15 +65,13 @@ class QuestViewModel: ObservableObject {
         }
     )
     
-    private let imageNetwork: ImageNetwork
     // MARK: throttle 관련
     let throttleInterval: TimeInterval = 2.0
     var lastRefreshTime: Date? = nil
     
     private let questNetwork: QuestNetwork
     
-    init(imageNetwork: ImageNetwork, questNetwork: QuestNetwork) {
-        self.imageNetwork = imageNetwork
+    init(questNetwork: QuestNetwork) {
         self.questNetwork = questNetwork
         Task {
             await loadInitialData()


### PR DESCRIPTION
#### close #170 

### ✏️ 개요
퀘스트 탭에서 이루어지는 네트워크 요청을 최소화합니다.

### 💻 작업 사항
- 데이터 리프레시에 2초간 throttle 적용
- QuestViewModel에 ImageNetwork 의존성 제거 
(이전 pr에서 작업한 이미지캐시서비스 내부에서 ImageNetwork 생성하기 때문 #169 )
- 초기 데이터(완료/미완료 퀘스트)를 불러오는 로직 호출부 이동
(기존 로직이 뷰의.task에 있어서 탭 변경시 불필요하게 계속 호출되는 문제 >> 뷰모델 초기화될 때 불러오도록 수정)

### 📄 리뷰 노트
뷰모델이 초기화될 때 실행하도록 수정해서 데이터 로딩 중에 다른 탭으로의 전환이 불가능하다는 단점이 있습니다.
추후에..퀘스트 목록 조회 API가 수정돼서(스탯별로 조회&페이지네이션 재적용).. 처음에 호출하는 데이터량이 줄어든다면.. 큰 문제가 되지 않을 거란 생각에.. 초기화부분에서 호출하도록 작업해두었습니다