### PR TITLE
[Ref/#172] 네트워크 관련 클래스 인스턴스 재생성 최소화 및 마이탭 뷰모델 최적화

### DIFF
--- a/ILSANG/Sources/Model/XP.swift
+++ b/ILSANG/Sources/Model/XP.swift
@@ -25,4 +25,10 @@ struct XPContent: Decodable {
     let title: String
     let xpPoint: Int
     let createDate: String
+    
+    static let mockDataList = [
+        XPContent(recordId: 1, title: "Mission Accomplished", xpPoint: 100, createDate: "2024-06-21"),
+        XPContent(recordId: 2, title: "Daily Login", xpPoint: 50, createDate: "2024-06-22"),
+        XPContent(recordId: 3, title: "Quest Completed", xpPoint: 150, createDate: "2024-06-23")
+    ]
 }

--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -9,11 +9,9 @@ import Alamofire
 import Foundation
 
 final class ChallengeNetwork {
-    private let network: Network
     private let url: String
 
-    init(network: Network = Network(), url: String =  APIManager.makeURL(CustomerTarget(path: ""))) {
-        self.network = network
+    init(url: String =  APIManager.makeURL(CustomerTarget(path: ""))) {
         self.url = url
     }
     

--- a/ILSANG/Sources/Network/EmojiNetwork.swift
+++ b/ILSANG/Sources/Network/EmojiNetwork.swift
@@ -8,11 +8,9 @@
 import Alamofire
 
 final class EmojiNetwork {
-    private let network: Network
     private let url: String
     
-    init(network: Network = Network(), url: String = APIManager.makeURL(CustomerTarget(path: "emoji"))) {
-        self.network = network
+    init(url: String = APIManager.makeURL(CustomerTarget(path: "emoji"))) {
         self.url = url
     }
         

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ApprovalView: View {
     @StateObject var vm = ApprovalViewModel(
-        imageNetwork: ImageNetwork(),
         emojiNetwork: EmojiNetwork(),
         challengeNetwork: ChallengeNetwork()
     )

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -37,12 +37,10 @@ final class ApprovalViewModel: ObservableObject {
         }
     )
     
-    private let imageNetwork: ImageNetwork
     private let emojiNetwork: EmojiNetwork
     private let challengeNetwork: ChallengeNetwork
     
-    init(imageNetwork: ImageNetwork, emojiNetwork: EmojiNetwork, challengeNetwork: ChallengeNetwork) {
-        self.imageNetwork = imageNetwork
+    init(emojiNetwork: EmojiNetwork, challengeNetwork: ChallengeNetwork) {
         self.emojiNetwork = emojiNetwork
         self.challengeNetwork = challengeNetwork
     }

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -13,14 +13,12 @@ struct MyPageActiveList: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            HStack {
-                Text("최근 활동 순")
-                    .font(.system(size: 14))
-                    .fontWeight(.medium)
-                    .foregroundColor(.gray400)
-                
-                Spacer()
-            }
+            Text("최근 활동 순")
+                .font(.system(size: 14))
+                .fontWeight(.medium)
+                .foregroundColor(.gray400)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            
             // Data List
             ScrollView {
                 VStack(spacing: 12) {

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -33,6 +33,11 @@ struct MyPageActiveList: View {
                 await vm.getxpLog(page: 0, size: 10)
             }
         }
+        .overlay {
+            if vm.xpLogList.isEmpty {
+                EmptyView(title: "활동 내역이 없어요!")
+            }
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -9,9 +9,7 @@ import SwiftUI
 
 struct MyPageActiveList: View {
     
-    @ObservedObject var vm = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
-    
-    @Binding var activeData: [XPContent]
+    @ObservedObject var vm: MypageViewModel
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -26,7 +24,7 @@ struct MyPageActiveList: View {
             // Data List
             ScrollView {
                 VStack(spacing: 12) {
-                    ForEach(activeData, id: \.recordId) { Data in
+                    ForEach(vm.xpLogList, id: \.recordId) { Data in
                         ListStruct(title: Data.title, detail: Data.createDate.timeAgoSinceCreation(), point: Data.xpPoint)
                     }
                 }

--- a/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
@@ -12,7 +12,6 @@ struct MyPageBadgeList: View {
     @ObservedObject var vm: MypageViewModel
 
     var body: some View {
-        
         VStack(alignment: .leading) {
             Text("최근 활동 순")
                 .font(.system(size: 14))

--- a/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct MyPageBadgeList: View {
     
-    @Binding var badgeData: [XPContent]
-    
+    @ObservedObject var vm: MypageViewModel
+
     var body: some View {
         
         VStack(alignment: .leading) {
@@ -22,7 +22,7 @@ struct MyPageBadgeList: View {
             // Data List
             ScrollView {
                 VStack(spacing: 12) {
-                    ForEach(badgeData, id: \.recordId) { Data in
+                    ForEach(vm.xpLogList, id: \.recordId) { Data in
                         ListStruct(title: Data.title, detail: Data.createDate.timeAgoCreatedAt(), point: Data.xpPoint)
                     }
                 }

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ChallengeDetailView: View {
     
     @Environment(\.dismiss) var dismiss
-    @StateObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
+    @ObservedObject var vm: MypageViewModel
     
     @State private var missionImage: UIImage?
     @State private var questImage: UIImage?

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -12,7 +12,6 @@ struct MyPageChallengeList: View {
     @ObservedObject var vm: MypageViewModel
     
     var body: some View {
-
         VStack(alignment: .leading) {
             HStack {
                 Text("수행한 챌린지")

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -37,6 +37,11 @@ struct MyPageChallengeList: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay {
+            if vm.challengeList.isEmpty {
+                EmptyView(title: "수행한 퀘스트가 없어요!")
+            }
+        }
     }
 }
 

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -9,9 +9,7 @@ import SwiftUI
 //MARK: 색상 폰트 변경 요청
 struct MyPageChallengeList: View {
     
-    @ObservedObject var vm = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
-    
-    @Binding var challengeList: [Challenge]
+    @ObservedObject var vm: MypageViewModel
     
     var body: some View {
 
@@ -27,15 +25,15 @@ struct MyPageChallengeList: View {
             // Data List
             ScrollView {
                 VStack(spacing: 12) {
-                    ForEach(challengeList, id: \.challengeId) { challenge in
-                        NavigationLink(destination: ChallengeDetailView(challengeData: challenge)) {
+                    ForEach(vm.challengeList, id: \.challengeId) { challenge in
+                        NavigationLink(destination: ChallengeDetailView(vm: vm, challengeData: challenge)) {
                             ListStruct(title: challenge.missionTitle ?? "챌린지명", detail: challenge.createdAt.timeAgoCreatedAt(), point: nil)
                         }
                     }
                 }
             }
             .refreshable {
-                await vm.getQuest(page: 0)
+                await vm.getChallenges(page: 0)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyPageProfile: View {
     
-    @StateObject var vm = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
+    @ObservedObject var vm: MypageViewModel
     
     var body: some View {
         NavigationLink(destination: ChangeNickNameView()) {
@@ -137,5 +137,5 @@ struct ProfileStatView: View {
 }
 
 #Preview {
-    MyPageProfile()
+    MyPageProfile(vm: MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork()))
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -13,7 +13,6 @@ struct MyPageProfile: View {
     
     var body: some View {
         NavigationLink(destination: ChangeNickNameView()) {
-            
             VStack {
                 //기본 프로필
                 HStack {
@@ -89,7 +88,6 @@ struct ProfileImageView: View {
             }
             
             VStack {
-                
                 Spacer()
                 
                 Text("Lv. \(Level)")

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -48,17 +48,9 @@ struct MyPageProfile: View {
                 }
                 .padding(18)
                 .background(Color.white)
-                .cornerRadius(12, corners: [.topLeft, .topRight])
-                .task {
-                    await vm.getUser()
-                    Log(vm.userData)
-                }
                 
                 StatView(dic: vm.xpStats)
                     .frame(height: 70)
-                    .task {
-                        await vm.getXpStat()
-                    }
             }
             .background(Color.primary100)
             .cornerRadius(12)

--- a/ILSANG/Sources/Views/MyPage/MyPageSegmenet.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageSegmenet.swift
@@ -8,50 +8,45 @@
 import SwiftUI
 
 struct MyPageSegment: View {
-    
     @Binding var selectedIndex: Int
     
-    let items = ["퀘스트", "활동", "뱃지"]
-    let icons = ["📜", "⛳️", "🎖️"]
+    private let items = ["퀘스트", "활동", "뱃지"]
+    private let icons = ["📜", "⛳️", "🎖️"]
     
     var body: some View {
-        HStack (spacing: 10) {
+        HStack(spacing: 10) {
             ForEach(0..<items.count, id: \.self) { index in
-                SegmenetStruct(sgmIcon: icons[index], sgmTitle: items[index], index: index, selectedIndex: $selectedIndex)
+                Button {
+                    selectedIndex = index
+                }  label: {
+                    SegmentStruct(sgmIcon: icons[index], sgmTitle: items[index], index: index, selectedIndex: selectedIndex)
+                }
             }
         }
         .padding(.vertical, 16)
     }
 }
 
-struct SegmenetStruct: View {
-    
+struct SegmentStruct: View {
     let sgmIcon: String
     let sgmTitle: String
     let index: Int
-    @Binding var selectedIndex: Int
+    let selectedIndex: Int
     
     var body: some View {
-        ZStack {
-            Rectangle()
-                .foregroundColor(.clear)
-                .frame(height: 38)
-                .frame(maxWidth: .infinity)
-                .background(selectedIndex == index ? Color.accentColor : Color.white)
-                .cornerRadius(12)
-            
-            HStack(alignment: .center, spacing: 4) {
-                Text(sgmIcon)
-                    .font(.system(size: 11))
-                
-                Text(sgmTitle)
-                    .font(.system(size: 14))
-                    .fontWeight(.semibold)
-                    .foregroundColor(selectedIndex == index ? Color.white : Color.gray500)
-            }
+        HStack(alignment: .center, spacing: 4) {
+            Text(sgmIcon)
+                .font(.system(size: 11))
+            Text(sgmTitle)
+                .font(.system(size: 14))
+                .fontWeight(.semibold)
+                .foregroundColor(selectedIndex == index ? Color.white : Color.gray500)
         }
-        .onTapGesture {
-            selectedIndex = index
-        }
+        .frame(height: 38)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .foregroundColor(selectedIndex == index ? Color.accentColor : Color.white)
+        )
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -11,10 +11,6 @@ struct MyPageView: View {
     
     @StateObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
     
-    @State var segmentSelect = 0
-    @State private var isSettingsViewActive = false
-    
-    
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
@@ -37,10 +33,10 @@ struct MyPageView: View {
                 MyPageProfile(vm: vm)
                 
                 // 퀘스트/활동/뱃지 세그먼트
-                MyPageSegment(selectedIndex: $segmentSelect)
+                MyPageSegment(selectedIndex: $vm.segmentSelect)
                 
                 // 퀘스트/활동/뱃지 리스트
-                switch segmentSelect {
+                switch vm.segmentSelect {
                 case 0:
                     MyPageChallengeList(vm: vm)
                 case 1:

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -58,7 +58,9 @@ struct MyPageView: View {
             .background(Color.background)
         }
         .task {
-            await vm.getQuest(page: 0)
+            await vm.getUser()
+            await vm.getXpStat()
+            await vm.getChallenges(page: 0)
             await vm.getxpLog(page: 0, size: 10)
         }
     }

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -46,12 +46,12 @@ struct MyPageView: View {
                 case 1:
                     MyPageActiveList(vm: vm)
                 case 2:
-                    emptyView()
-                    
                     // 뱃지 구현후 적용
-                    //MyPageBadgeList(badgeData: .constant([]))
+                    // MyPageBadgeList(vm: vm)
+                    EmptyView(title: "Coming Soon!")
+                    
                 default:
-                    emptyView()
+                    EmptyView()
                 }
             }
             .padding(.horizontal, 20)
@@ -64,18 +64,18 @@ struct MyPageView: View {
     }
 }
 
-struct emptyView: View {
+struct EmptyView: View {
+    var title: String = ""
+    
     var body: some View {
-        VStack {
-            Text("Coming Soon!")
-                .font(.system(size: 17))
-                .fontWeight(.medium)
-                .foregroundColor(.gray400)
-                .multilineTextAlignment(.center)
-                .refreshable {
-                    // 데이터 리프레시
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+        Text(title)
+            .font(.system(size: 17))
+            .fontWeight(.medium)
+            .foregroundColor(.gray400)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .refreshable {
+                // 데이터 리프레시
+            }
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -34,7 +34,7 @@ struct MyPageView: View {
                 .padding(.bottom, 5)
                 
                 // 개인 프로필
-                MyPageProfile()
+                MyPageProfile(vm: vm)
                 
                 // 퀘스트/활동/뱃지 세그먼트
                 MyPageSegment(selectedIndex: $segmentSelect)
@@ -42,17 +42,9 @@ struct MyPageView: View {
                 // 퀘스트/활동/뱃지 리스트
                 switch segmentSelect {
                 case 0:
-                    if let questData = vm.challengeList, !questData.isEmpty {
-                        MyPageChallengeList(challengeList: .constant(questData))
-                    } else {
-                        emptyView()
-                    }
+                    MyPageChallengeList(vm: vm)
                 case 1:
-                    if let activeData = vm.questXp, !activeData.isEmpty {
-                        MyPageActiveList(activeData: .constant(activeData))
-                    } else {
-                        emptyView()
-                    }
+                    MyPageActiveList(vm: vm)
                 case 2:
                     emptyView()
                     

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -9,12 +9,6 @@ import SwiftUI
 
 struct MyPageView: View {
     
-    @State var activeTestData: [XPContent] = [
-            XPContent(recordId: 1, title: "Mission Accomplished", xpPoint: 100, createDate: "2024-06-21"),
-            XPContent(recordId: 2, title: "Daily Login", xpPoint: 50, createDate: "2024-06-22"),
-            XPContent(recordId: 3, title: "Quest Completed", xpPoint: 150, createDate: "2024-06-23")
-        ]
-    
     @StateObject var vm: MypageViewModel = MypageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork())
     
     @State var segmentSelect = 0

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -20,9 +20,10 @@ struct MypageViewModelItem: Identifiable {
 
 class MypageViewModel: ObservableObject {
     @Published var userData: User?
-    @Published var challengeList: [Challenge]?
-    @Published var xpStats: [XpStat: Int]
-    @Published var questXp: [XPContent]?
+    @Published var xpStats: [XpStat: Int] = [:]
+    @Published var xpLogList: [XPContent] = []
+    @Published var challengeList: [Challenge] = []
+    
     @Published var challengeDelete = false
     
     private let userNetwork: UserNetwork
@@ -30,12 +31,8 @@ class MypageViewModel: ObservableObject {
     private let imageNetwork: ImageNetwork
     private let xpNetwork: XPNetwork
     
-    init(userData: User? = nil, challengeList: [Challenge]? = nil, xpStats: [XpStat: Int] = [:], questXp: [XPContent]? = nil, challengeDelete: Bool = false, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
+    init(userData: User? = nil, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
         self.userData = userData
-        self.challengeList = challengeList
-        self.xpStats = xpStats
-        self.questXp = questXp
-        self.challengeDelete = challengeDelete
         self.userNetwork = userNetwork
         self.challengeNetwork = challengeNetwork
         self.imageNetwork = imageNetwork
@@ -63,11 +60,10 @@ class MypageViewModel: ObservableObject {
         
         switch res {
         case .success(let model):
-            self.questXp = model.data
-            Log(questXp)
+            self.xpLogList = model.data
             
         case .failure:
-            self.questXp = nil
+            self.xpLogList = []
             Log(res)
         }
     }
@@ -94,7 +90,7 @@ class MypageViewModel: ObservableObject {
     }
     
     @MainActor
-    func getQuest(page: Int) async {
+    func getChallenges(page: Int) async {
         let Data = await challengeNetwork.getChallenges(page: page)
         
         switch Data {
@@ -103,7 +99,7 @@ class MypageViewModel: ObservableObject {
             Log(self.challengeList)
 
         case .failure:
-            self.challengeList = nil
+            self.challengeList = []
         }
     }
     

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -5,20 +5,12 @@
 //  Created by Kim Andrew on 6/25/24.
 //
 
-import Foundation
-import UIKit
 import SwiftUI
 
-struct MypageViewModelItem: Identifiable {
-    var id: UUID
-    var status: String
-    var nickname: String
-    var couponCount: Int
-    var completeChallengeCount: Int
-    var xpPoint: Int
-}
-
-class MypageViewModel: ObservableObject {
+final class MypageViewModel: ObservableObject {
+    
+    @Published var segmentSelect = 0
+    
     @Published var userData: User?
     @Published var xpStats: [XpStat: Int] = [:]
     @Published var xpLogList: [XPContent] = []


### PR DESCRIPTION
#### close #172 

### ✏️ 개요
네트워크 관련 작업 중 탭을 전환할수록 클래스 인스턴스가 많아지는 문제를 파악하여, 이를 개선했습니다.

### 💻 작업 사항
- 네트워크 관련 클래스 인스턴스 재생성 최소화
- 마이탭 뷰모델 생성 최소화

### 📄 리뷰 노트
- [MyPageViewModel 리팩토링 >> MyPageView 제외한 하위뷰에서는 ObservedObject 사용하도록 수정](https://github.com/TeamFair/ILSANG-iOS/commit/1428f8d00ec7703441374e70c72b4103e2d36b5c) 
- 마이탭의 가장 상위뷰인 MyPageView에서 모든 데이터 호출하도록 수정
- MyPageViewModel 내부 변수&메서드명 수정
  quest > challenge 수정, questXp > xpLogList 수정(challengeList와 통일..)
- 뷰모델에서 데이터 갖고 있도록 수정 (ChallengeDetailView는 추후 수정..,,)

### 📱결과 화면(optional)
"퀘스트탭 > 인증탭 > 랭킹탭 > 마이탭 > 퀘스트탭 > 인증탭 > 랭킹탭 > 마이탭 > 챌린지디테일뷰"로 화면 이동 수행한 결과

| 수정 전 | 수정 후 |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/c6a6131f-1c6d-4b68-85ab-3a7dd9aa2390"> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/550c4adf-8010-43bf-82dd-7d49e2d88a8d"> | 
| <img width="242" alt="image" src="https://github.com/user-attachments/assets/4dd78183-28c2-419d-8898-3e4c6a8858a7"> | <img width="222" alt="image" src="https://github.com/user-attachments/assets/b83c3ee3-c39b-49f0-b639-6c19eee29afe"> |