### PR TITLE
[Bug/#176] 카메라 촬영 버튼 눌러도 제출화면으로 전환되지 않는 문제 해결

### DIFF
--- a/ILSANG/Sources/Views/Quest/Camera/CameraView.swift
+++ b/ILSANG/Sources/Views/Quest/Camera/CameraView.swift
@@ -63,11 +63,6 @@ struct CameraView: View {
             /// 사진찍기 버튼
             Button {
                 viewModel.capturePhoto()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if let myImage = viewModel.recentImage {
-                        self.submitViewModel.selectedImage = myImage
-                    }
-                }
             } label: {
                 Circle()
                     .stroke(lineWidth: 5)
@@ -82,6 +77,13 @@ struct CameraView: View {
         }
         .padding(.horizontal, 30)
         .padding(.bottom, 75)
+        .onChange(of: viewModel.recentImage) { _ in
+            // 카메라에서 촬영한 이미지로 카메라 뷰모델의 최근 이미지가 변경되면,
+            // submitViewModel의 이미지도 업데이트하여 SubmitRouterView에서 이미지를 보여줍니다.
+            if let myImage = viewModel.recentImage {
+                self.submitViewModel.selectedImage = myImage
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### close #176 

### ✏️ 개요
- 카메라 촬영 버튼 눌러도 랜덤하게 제출화면으로 전환되지 않는 문제 해결

### 💻 작업 사항
-  DispatchQueue 대신 onChange를 사용하여 촬영한 이미지 업데이트 로직 리팩토링

### 📄 리뷰 노트
이미지 제출 구현할 때, 맛큐때 있던 카메라 코드를 그대로 가져왔었는데,, 

기존 코드가 문제가 viewModel.capturePhoto() 로직 수행 후 0.5초 안에 viewModel.recentImage에 할당되지 않으면 뷰에서 바라보고 있는 이미지를 업데이트하지 않도록 되어있었습니다.. 

버튼 클릭시 업데이트하는 게 아닌 onChange로 로직을 이동하여, viewModel.recentImage의 변화를 감지하여 이미지를 화면에 그릴 수 있도록 수정하였습니다.  