### PR TITLE
[Feat/#184] 닉네임 글자 수 제한

### DIFF
--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -187,12 +187,16 @@ final class MypageViewModel: ObservableObject {
 
 extension ChangeNickNameView {
     func isValidNickname(_ name: String) -> Bool {
-        let regex = "^[가-힣a-zA-Z0-9]*$"
+        let Korean = ".*[가-힣].*"
+        let English = ".*[a-zA-Z].*"
+        let Number = ".*[0-9].*"
         
-        let isValidCharacters = NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: name)
+        let koreanMatch = NSPredicate(format: "SELF MATCHES %@", Korean).evaluate(with: name)
+        let englishMatch = NSPredicate(format: "SELF MATCHES %@", English).evaluate(with: name)
+        let numberMatch = NSPredicate(format: "SELF MATCHES %@", Number).evaluate(with: name)
         
         let isValidLength = (2...12).contains(name.count)
         
-        return isValidCharacters && isValidLength
+        return koreanMatch && englishMatch && numberMatch && isValidLength
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageViewModel.swift
@@ -184,3 +184,15 @@ final class MypageViewModel: ObservableObject {
         return Double(userXP) / Double(levelXP)
     }
 }
+
+extension ChangeNickNameView {
+    func isValidNickname(_ name: String) -> Bool {
+        let regex = "^[가-힣a-zA-Z0-9]*$"
+        
+        let isValidCharacters = NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: name)
+        
+        let isValidLength = (2...12).contains(name.count)
+        
+        return isValidCharacters && isValidLength
+    }
+}

--- a/ILSANG/Sources/Views/NickName/ChangeNickNameView.swift
+++ b/ILSANG/Sources/Views/NickName/ChangeNickNameView.swift
@@ -73,7 +73,7 @@ struct ChangeNickNameView: View {
                     
                     Spacer()
                     
-                    PrimaryButton(title: "변경 완료", buttonAble: !isSame || !name.isEmpty) {
+                    PrimaryButton(title: "변경 완료", buttonAble: !isSame && isqualified) {
                         Task {
                             if await UserNetwork().putUser(nickname: name) {
                                 withAnimation {

--- a/ILSANG/Sources/Views/NickName/ChangeNickNameView.swift
+++ b/ILSANG/Sources/Views/NickName/ChangeNickNameView.swift
@@ -13,7 +13,11 @@ struct ChangeNickNameView: View {
     
     @State private var name: String = ""
     @State private var isSame : Bool = false
+    @State private var isqualified : Bool = true
     @State private var showAlert : Bool = false
+    
+    //닉네임 최대치
+    private let characterLimit = 12
     
     var body: some View {
         ZStack {
@@ -48,11 +52,24 @@ struct ChangeNickNameView: View {
                                 .cornerRadius(12)
                         )
                         .padding(.bottom, 12)
+                        .onChange(of: name) { maxName in
+                            if maxName.count > characterLimit {
+                                name = String(maxName.prefix(characterLimit))
+                            }
+                            isqualified = isValidNickname(maxName)
+                        }
                     
-                    Text("입력하신 닉네임은 이미 사용중이에요.\n다른 닉네임을 입력해주세요.")
-                        .opacity(isSame ? 1 : 0)
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.subRed)
+                    ZStack(alignment: .leading) {
+                        Text("한글+영어+숫자 포함 2 ~ 12자 이하로 닉네임을 입력해주세요.")
+                            .opacity(isqualified ? 0 : 1)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.subRed)
+                        
+                        Text("입력하신 닉네임은 이미 사용중이에요.\n다른 닉네임을 입력해주세요.")
+                            .opacity(isSame ? 1 : 0)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.subRed)
+                    }
                     
                     Spacer()
                     


### PR DESCRIPTION
#### close #184 

### ✏️ 개요
닉네임 유효성 검사 > 글자수 제한
한글+영어+숫자 포함 2~12자 이하 제한

### 💻 작업 사항
2~12 글자 수 제한
한글, 영어, 숫자 최소 1글자 포함 시 변경 가능

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/f6385fa1-8f12-4891-a992-fda6bae9c520" width = "300"> 
<img src = "https://github.com/user-attachments/assets/91b2ddde-2a12-487f-b53c-ff32431d9407" width = "300"> 
<img src = "https://github.com/user-attachments/assets/8435f3b5-a8c3-46a5-b503-ac039ede6c6b" width = "300"> 