### PR TITLE
[Feat/#193] 미완료 퀘스트 정렬 기능 추가

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		605DA0D62C07123400CC9450 /* View++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0D52C07123400CC9450 /* View++.swift */; };
 		6060B2EA2C08947B0083944D /* Image++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6060B2E92C08947B0083944D /* Image++.swift */; };
 		606132782CD68FE300830948 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606132772CD68FE300830948 /* TagView.swift */; };
+		6061327B2CDB33FD00830948 /* FilterPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6061327A2CDB33FD00830948 /* FilterPicker.swift */; };
 		606292D82C19E70A0098B6D2 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606292D72C19E70A0098B6D2 /* Network.swift */; };
 		606292DD2C19EAB00098B6D2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 606292DC2C19EAB00098B6D2 /* Alamofire */; };
 		606C21CC2CC6B4FC00803947 /* SubmitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C21CB2CC6B4FC00803947 /* SubmitStatusView.swift */; };
@@ -152,6 +153,7 @@
 		606132722CD325B600830948 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		606132732CD325CC00830948 /* Staging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Staging.xcconfig; sourceTree = "<group>"; };
 		606132772CD68FE300830948 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
+		6061327A2CDB33FD00830948 /* FilterPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterPicker.swift; sourceTree = "<group>"; };
 		606292D72C19E70A0098B6D2 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		606C21CB2CC6B4FC00803947 /* SubmitStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitStatusView.swift; sourceTree = "<group>"; };
 		606C87AE2C0B9B8C002D5C3E /* ApprovalImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalImageView.swift; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 			isa = PBXGroup;
 			children = (
 				607FCBE12BFA6A8300BB2D04 /* Buttons.swift */,
+				6061327A2CDB33FD00830948 /* FilterPicker.swift */,
 				607FCBEA2BFE44D900BB2D04 /* IconView.swift */,
 				A19628742C08648C0037C53A /* NavigationTitleView.swift */,
 				6044B7322C33F754002C13A0 /* ErrorView.swift */,
@@ -789,6 +792,7 @@
 				605DA0D62C07123400CC9450 /* View++.swift in Sources */,
 				60299E392CC13DEC0039663F /* ImageCacheService.swift in Sources */,
 				A1BB602E2C022A9900AAADD4 /* UserData.swift in Sources */,
+				6061327B2CDB33FD00830948 /* FilterPicker.swift in Sources */,
 				A19628752C08648C0037C53A /* NavigationTitleView.swift in Sources */,
 				A1AB3D5D2C113A70001EB9D8 /* LoginView.swift in Sources */,
 				606C21CC2CC6B4FC00803947 /* SubmitStatusView.swift in Sources */,

--- a/ILSANG/Sources/Global/View/FilterPicker.swift
+++ b/ILSANG/Sources/Global/View/FilterPicker.swift
@@ -1,0 +1,88 @@
+//
+//  FilterPicker.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 11/6/24.
+//
+
+import SwiftUI
+
+struct PickerView<SelectionValue>: View where SelectionValue: Hashable & CustomStringConvertible & CaseIterable {
+    @State var status: PickerStatus = .close
+    @Binding var selection: SelectionValue
+    
+    var body: some View {
+        ZStack(alignment: .top) {
+            HStack(spacing: 0) {
+                Text("\(selection.description)")
+                    .font(.system(size: 15, weight: .regular))
+                Spacer(minLength: 0)
+                Image(systemName: status == .open ? "chevron.down" : "chevron.up")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 12)
+                    .frame(width: 19, height: 19)
+            }
+            .foregroundStyle(.gray500)
+            .padding(.horizontal, 12)
+            .frame(width: 150, height: 40)
+            .background(Color.white)
+            .clipShape(
+                RoundedRectangle(cornerRadius: 8)
+            )
+            .onTapGesture {
+                self.status.toggle()
+            }
+            .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
+            
+            if status == .open {
+                VStack(spacing: 0) {
+                    ForEach(Array(SelectionValue.allCases).filter { $0 != selection }, id: \.self) { value in
+                        Button(action: {
+                            self.selection = value
+                            self.status.toggle()
+                        }) {
+                            Text(value.description)
+                                .font(.system(size: 15, weight: .regular))
+                                .foregroundStyle(.gray500)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .frame(height: 40)
+                                .background(Color.white)
+                        }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .frame(width: 150)
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
+                .padding(.top, 44)
+                .zIndex(1)
+            }
+        }
+    }
+}
+
+enum QuestFilter: String, Hashable, CustomStringConvertible, CaseIterable {
+    case pointHighest = "포인트 높은 순"
+    case pointLowest = "포인트 낮은 순"
+    case popular = "인기순"
+    
+    var description: String {
+        return self.rawValue
+    }
+}
+
+enum PickerStatus {
+    case open
+    case close
+    
+    mutating func toggle() {
+        self = self == .open ? .close : .open
+    }
+}
+
+
+//#Preview {
+//    PickerView<ExampleSelection>(status: .close, selection: .constant(.option1))
+//}

--- a/ILSANG/Sources/Model/Quest.swift
+++ b/ILSANG/Sources/Model/Quest.swift
@@ -13,4 +13,5 @@ struct Quest: Codable {
     let creatorRole: String
     let imageId: String?
     let rewardList: [Reward]
+    // let score: Int
 }

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -98,7 +98,7 @@ extension QuestView {
             LazyVStack(spacing: 12) {
                 switch vm.selectedHeader {
                 case .uncompleted:
-                    ForEach(vm.uncompletedQuestListByXpStat[vm.selectedXpStat, default: []], id: \.id) { quest in
+                    ForEach(vm.filteredUncompletedQuestListByXpStat, id: \.id) { quest in
                         Button {
                             vm.tappedQuestBtn(quest: quest)
                         } label: {
@@ -120,18 +120,31 @@ extension QuestView {
                     }
                 }
             }
-            .padding(.top, 20)
+            .padding(.top, 70)
+            .overlay(alignment: .top) {
+                if vm.selectedHeader == .uncompleted {
+                    filterPickerView
+                }
+            }
             .padding(.bottom, 72)
         }
-        .frame(maxWidth: .infinity)
         .refreshable {
             await vm.refreshData()
         }
+        .frame(maxWidth: .infinity)
         .overlay {
             if vm.isCurrentListEmpty {
                 questListEmptyView
             }
         }
+    }
+    
+    private var filterPickerView: some View {
+        PickerView<QuestFilter>(selection: $vm.selectedFilter)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.trailing, 20)
+            .padding(.top, 13)
+            .padding(.bottom, 16)
     }
     
     private var questListEmptyView: some View {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -19,6 +19,8 @@ class QuestViewModel: ObservableObject {
     @Published var viewStatus: ViewStatus = .loading
     @Published var selectedHeader: QuestStatus = .uncompleted
     @Published var selectedXpStat: XpStat = .strength
+    @Published var selectedFilter: QuestFilter = .popular
+
     @Published var selectedQuest: QuestViewModelItem = .mockData
     @Published var showQuestSheet: Bool = false
     @Published var showSubmitRouterView: Bool = false {
@@ -35,7 +37,19 @@ class QuestViewModel: ObservableObject {
         .uncompleted: [],
         .completed: []
     ]
-    @Published var uncompletedQuestListByXpStat: [XpStat: [QuestViewModelItem]] = Dictionary(uniqueKeysWithValues: XpStat.allCases.map { ($0, []) })
+    
+    var uncompletedQuestListByXpStat: [XpStat: [QuestViewModelItem]] = Dictionary(uniqueKeysWithValues: XpStat.allCases.map { ($0, []) })
+
+    var filteredUncompletedQuestListByXpStat: [QuestViewModelItem] {
+        switch selectedFilter {
+        case .pointHighest:
+            return uncompletedQuestListByXpStat[selectedXpStat, default: []].sorted { $0.rewardDic[selectedXpStat, default: 0] > $1.rewardDic[selectedXpStat, default: 0] }
+        case .pointLowest:
+            return uncompletedQuestListByXpStat[selectedXpStat, default: []].sorted { $0.rewardDic[selectedXpStat, default: 0] < $1.rewardDic[selectedXpStat, default: 0] }
+        case .popular:
+            return uncompletedQuestListByXpStat[selectedXpStat, default: []]
+        }
+    }
     
     var isCurrentListEmpty: Bool {
         switch selectedHeader {

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -150,7 +150,7 @@ struct QuestViewModelItem {
             imageId: mockImageId,
             missionTitle: "아메리카노 15잔 마시기",
             writer: "이디야커피",
-            rewardDic: [:]
+            rewardDic: [.charm: 30, .intellect: 20, .fun: 25]
         ),
         QuestViewModelItem(
             id: "13",
@@ -158,7 +158,7 @@ struct QuestViewModelItem {
             imageId: mockImageId,
             missionTitle: "카페라떼 1잔 마시기",
             writer: "투썸플레이스",
-            rewardDic: [:]
+            rewardDic: [.charm: 30, .intellect: 100, .fun: 5]
         )
     ]
 }


### PR DESCRIPTION
#### close #193 

### ✏️ 개요
퀘스트 탭에 퀘스트 정렬 기능을 추가했습니다.

### 💻 작업 사항
- [x] 정렬 피커 생성
- [x] 퀘스트 정렬 기능 추가

### 📄 리뷰 노트
다음 작업(`반복 퀘스트 작업`)할 때 완료퀘스트 관련한 변수들을 제거하면 변수명을.. 더 간결하게 수정할 수 있을 것 같습니다 ㅎ,ㅎㅠ 

### 📱결과 화면(optional)

| 인기순(필터 닫힘) | 인기순(필터 열림) |
|--------|--------|
| <img src = "https://github.com/user-attachments/assets/4d8d698b-4bd3-4115-9cd2-fcf763c6294f" width = "230"> | <img src = "https://github.com/user-attachments/assets/11a3d694-d967-47f6-9b09-d687f29a1c54" width = "230"> |

| 포인트 높은순 | 포인트 낮은순 |
|--------|--------|
| <img src = "https://github.com/user-attachments/assets/4e8cba52-3274-44b8-8d09-bae82f07a9c2" width = "230"> | <img src = "https://github.com/user-attachments/assets/3ed1c523-b3ef-4415-a6df-70455b21ef37" width = "230"> | 