### PR TITLE
[Design/#200] 퀘스트 상세정보 시트 디자인 수정사항 반영

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		605DA0D12C0711CA00CC9450 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0D02C0711CA00CC9450 /* CameraView.swift */; };
 		605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0D22C0711E900CC9450 /* CameraViewModel.swift */; };
 		605DA0D62C07123400CC9450 /* View++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605DA0D52C07123400CC9450 /* View++.swift */; };
+		605F28522CF1B2C5007EA739 /* QuestDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605F28512CF1B2C5007EA739 /* QuestDetailView.swift */; };
 		6060B2EA2C08947B0083944D /* Image++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6060B2E92C08947B0083944D /* Image++.swift */; };
 		606132782CD68FE300830948 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606132772CD68FE300830948 /* TagView.swift */; };
 		606292D82C19E70A0098B6D2 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606292D72C19E70A0098B6D2 /* Network.swift */; };
@@ -147,6 +148,7 @@
 		605DA0D02C0711CA00CC9450 /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		605DA0D22C0711E900CC9450 /* CameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewModel.swift; sourceTree = "<group>"; };
 		605DA0D52C07123400CC9450 /* View++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View++.swift"; sourceTree = "<group>"; };
+		605F28512CF1B2C5007EA739 /* QuestDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestDetailView.swift; sourceTree = "<group>"; };
 		6060B2E92C08947B0083944D /* Image++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image++.swift"; sourceTree = "<group>"; };
 		606132712CD3256C00830948 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		606132722CD325B600830948 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 			isa = PBXGroup;
 			children = (
 				60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */,
+				605F28512CF1B2C5007EA739 /* QuestDetailView.swift */,
 				607FCBE82BFE418600BB2D04 /* QuestViewModel.swift */,
 				607FCBE62BFD12B100BB2D04 /* QuestViewModelItem.swift */,
 				607FCBE32BFD124900BB2D04 /* QuestItemView.swift */,
@@ -795,6 +798,7 @@
 				A196286F2C0859910037C53A /* DeleteAccountView.swift in Sources */,
 				6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */,
 				601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */,
+				605F28522CF1B2C5007EA739 /* QuestDetailView.swift in Sources */,
 				A1AB3D6A2C1141B3001EB9D8 /* AppleLoginButtonView.swift in Sources */,
 				600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */,
 				A1FF916E2C250C3B00F03E4B /* UserNetwork.swift in Sources */,

--- a/ILSANG/Sources/Views/Quest/QuestDetailView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetailView.swift
@@ -13,14 +13,20 @@ struct QuestDetailView: View {
     
     var body: some View {
         VStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 2)
+                .frame(width: 30, height: 4)
+                .foregroundStyle(.gray100)
+                .padding(.top, 8)
+                .padding(.bottom, 14)
+
             Text("퀘스트 정보")
                 .font(.system(size: 17, weight: .bold))
-                .padding(.top, 4)
                 .padding(.bottom, 32)
             
             questInfoView
             
             Divider()
+                .foregroundStyle(.gray100)
                 .padding(.top, 16)
                 .padding(.bottom, 32)
 
@@ -39,7 +45,6 @@ struct QuestDetailView: View {
             }
         }
         .foregroundStyle(.gray500)
-        .padding(.top, 20)
         .padding(.horizontal, 20)
     }
     

--- a/ILSANG/Sources/Views/Quest/QuestDetailView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetailView.swift
@@ -1,0 +1,131 @@
+//
+//  QuestDetailView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 11/23/24.
+//
+
+import SwiftUI
+
+struct QuestDetailView: View {
+    let quest: QuestViewModelItem
+    let action: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("퀘스트 정보")
+                .font(.system(size: 17, weight: .bold))
+                .padding(.top, 4)
+                .padding(.bottom, 32)
+            
+            questInfoView
+            
+            Divider()
+                .padding(.top, 16)
+                .padding(.bottom, 32)
+
+            statTagViewList
+            
+            Text("퀘스트를 수행하셨나요?\n인증 후 포인트를 적립받으세요")
+                .font(.system(size: 14, weight: .regular))
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+                .padding(.vertical, 10)
+            
+            Spacer(minLength: 0)
+            
+            PrimaryButton(title: "퀘스트 인증하기") {
+                action()
+            }
+        }
+        .foregroundStyle(.gray500)
+        .padding(.top, 20)
+        .padding(.horizontal, 20)
+    }
+    
+    private var questInfoView: some View {
+        HStack(spacing: 8) {
+            Image(uiImage: quest.image ?? .logo)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 80, height: 80)
+                .clipShape(Circle())
+            
+            VStack(alignment: .leading, spacing: 0 ) {
+                Text(quest.writer)
+                    .font(.system(size: 15, weight: .regular))
+                    .frame(height: 30)
+                
+                Text(quest.missionTitle)
+                    .font(.system(size: 18, weight: .bold))
+                    .lineLimit(2)
+                    .kerning(-0.3)
+                    .frame(minHeight: 30)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            Spacer(minLength: 0)
+            
+            Text(String(quest.totalRewardXP()) + "XP")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(.primaryPurple)
+                .padding(.vertical, 12)
+                .padding(.horizontal, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundStyle(Color.primary100)
+                )
+        }
+    }
+    
+    private var statTagViewList: some View {
+        HStack(spacing: 12) {
+            ForEach(Array(XpStat.sortedStat), id: \.rawValue) { stat in
+                let point = quest.rewardDic[stat, default: 0]
+                if point > 0 {
+                    statTagView(stat: stat, point: point)
+                }
+            }
+        }
+        .padding(.bottom, 7)
+    }
+    private func statTagView(stat: XpStat, point: Int) -> some View {
+        VStack(spacing: 0) {
+            Text(stat.headerText)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(.gray500)
+                .padding(.vertical, 4)
+                .frame(width: 60)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundStyle(Color.background)
+                )
+                .padding(.bottom, 8)
+            
+            VStack(spacing: 0) {
+                Image(stat.image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 32, height: 32)
+                    .frame(width: 48, height: 48)
+                
+                HStack(spacing: 0) {
+                    Text("\(point)P")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.primaryPurple)
+                    Spacer(minLength: 0)
+                    Image(.arrowUp)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 12)
+                }
+                .frame(width: 56, height: 20)
+            }
+            .padding(.vertical, 6)
+        }
+    }
+}
+
+#Preview {
+    QuestDetailView(quest: .mockData, action: { })
+}

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -35,7 +35,7 @@ struct QuestView: View {
                 vm.tappedQuestApprovalBtn()
             }
             .presentationDetents([.height(464)])
-            .presentationDragIndicator(.visible)
+            .presentationDragIndicator(.hidden)
         }
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
             SubmitRouterView(selectedQuest: vm.selectedQuest)

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -31,9 +31,11 @@ struct QuestView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.background)
         .sheet(isPresented: $vm.showQuestSheet) {
-            questSheetView
-                .presentationDetents([.height(558)])
-                .presentationDragIndicator(.visible)
+            QuestDetailView(quest: vm.selectedQuest) {
+                vm.tappedQuestApprovalBtn()
+            }
+            .presentationDetents([.height(464)])
+            .presentationDragIndicator(.visible)
         }
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
             SubmitRouterView(selectedQuest: vm.selectedQuest)
@@ -152,51 +154,6 @@ extension QuestView {
         ) {
             Task { await vm.loadInitialData() }
         }
-    }
-    
-    private var questSheetView: some View {
-        VStack(spacing: 0) {
-            Text("퀘스트 정보")
-                .font(.system(size: 17, weight: .bold))
-                .padding(.bottom, 22)
-                .padding(.top, 4)
-            
-            Image(uiImage: vm.selectedQuest.image ?? .logo)
-                .resizable()
-                .scaledToFill()
-                .frame(width: 122, height: 122)
-                .clipShape(Circle())
-                .padding(.bottom, 20)
-            
-            Text(vm.selectedQuest.writer)
-                .font(.system(size: 15, weight: .regular))
-                .padding(.bottom, 5)
-            
-            Text(vm.selectedQuest.missionTitle)
-                .font(.system(size: 18, weight: .bold))
-                .padding(.bottom, 18)
-            
-            Text("+" + String(vm.selectedQuest.totalRewardXP()) + "XP")
-                .font(.system(size: 30, weight: .semibold))
-                .foregroundStyle(.primaryPurple)
-                .padding(.bottom, 19)
-            
-            StatView(dic: vm.selectedQuest.rewardDic)
-                .padding(.bottom, 17)
-            
-            Text("퀘스트를 수행하셨나요?\n인증 후 포인트를 적립받으세요")
-                .font(.system(size: 14, weight: .regular))
-                .multilineTextAlignment(.center)
-                .lineSpacing(4)
-            
-            Spacer(minLength: 0)
-            
-            PrimaryButton(title: "퀘스트 인증하기") {
-                vm.tappedQuestApprovalBtn()
-            }
-        }
-        .foregroundStyle(.gray500)
-        .padding(20)
     }
 }
 


### PR DESCRIPTION
#### close #200 

### ✏️ 개요
퀘스트 상세정보 UI 수정사항을 반영합니다.

### 💻 작업 사항
- 퀘스트 상세정보 UI 수정

### 📄 리뷰 노트
- 없습니다앗 !!

### 📱결과 화면(optional)
| AS-IS | TO-BE | TO-BE |
|--------|--------|--------|
| <img src = "https://github.com/user-attachments/assets/e9f86f2c-d930-4212-86fc-63d2bf184935" width = "240">  |<img src = "https://github.com/user-attachments/assets/711e1704-64a5-4184-a750-23dfbc5ed6fa" width = "240"> | <img src = "https://github.com/user-attachments/assets/e973dab6-ab3e-41c7-80d7-0d8912f16e5d" width = "240"> | 
