### PR TITLE
[Bug/#205] 오각형 그래프 버그 수정

### DIFF
--- a/ILSANG/Sources/Global/View/Polygon.swift
+++ b/ILSANG/Sources/Global/View/Polygon.swift
@@ -264,7 +264,7 @@ struct StatPolygon: Shape {
         
         // 값 정규화 (최소 비율과 최대 비율을 제한) 그래프가 역으로 꺾이는 문제 해결
         let minRatio: CGFloat = 0.2 // 최소 비율 (값이 작아도 최소 이 정도는 확보)
-        let maxValue: CGFloat = CGFloat(xpStats.values.max() ?? 50) // 최대값을 동적으로 설정
+        let maxValue: CGFloat = max(CGFloat(xpStats.values.max() ?? 0), 50) // 최대값을 동적으로 설정
         
         // 꼭짓점 좌표 계산
         let points = XpStat.allCases.enumerated().map { index, stat -> CGPoint in

--- a/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
@@ -58,7 +58,7 @@ struct MyPageBadgeList: View {
                         .font(.system(size: 12))
                         .foregroundColor(.gray400)
                     
-                    PentagonGraph(xpStats: vm.xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + vm.convertXPtoLv(XP: vm.userData?.xpPoint ?? 0)))
+                    PentagonGraph(xpPoint: vm.userData?.xpPoint ?? 10, xpStats: vm.xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + vm.convertXPtoLv(XP: vm.userData?.xpPoint ?? 0)))
                     
                     ShareLink(
                         item: ShareImage,
@@ -113,15 +113,17 @@ extension MyPageBadgeList {
         return Double(userXP) / Double(levelXP)
     }
     
-    private func PentagonGraph(xpStats: [XpStat: Int], width: CGFloat, mainColor: Color, subColor: Color, maxValue: Double) -> some View {
+    private func PentagonGraph(xpPoint:Int, xpStats: [XpStat: Int], width: CGFloat, mainColor: Color, subColor: Color, maxValue: Double) -> some View {
         HStack {
             Spacer()
             
             ZStack {
                 BackgroundPolygons(width: width, subColor: subColor) // 배경 오각형
-                StatPolygon(xpStats: xpStats, maxValue: maxValue, cornerRadius: 15) // 데이터 오각형
-                    .fill(mainColor)
-                    .opacity(0.8)
+                if xpPoint != 0 {
+                    StatPolygon(xpStats: xpStats, maxValue: maxValue, cornerRadius: 15) // 데이터 오각형
+                        .fill(mainColor)
+                        .opacity(0.8)
+                }
             }
             .frame(width: width, height: width)
             

--- a/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
@@ -123,6 +123,8 @@ extension MyPageBadgeList {
                     StatPolygon(xpStats: xpStats, maxValue: maxValue, cornerRadius: 15) // 데이터 오각형
                         .fill(mainColor)
                         .opacity(0.8)
+
+                    StatLabels(width: width, subColor: subColor) // 능력치 레이블
                 }
             }
             .frame(width: width, height: width)

--- a/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
@@ -123,9 +123,8 @@ extension MyPageBadgeList {
                     StatPolygon(xpStats: xpStats, maxValue: maxValue, cornerRadius: 15) // 데이터 오각형
                         .fill(mainColor)
                         .opacity(0.8)
-
-                    StatLabels(width: width, subColor: subColor) // 능력치 레이블
                 }
+                StatLabels(width: width, subColor: subColor) // 능력치 레이블
             }
             .frame(width: width, height: width)
             

--- a/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
@@ -60,7 +60,7 @@ struct MypageShareImage: View {
                     .font(.system(size: 12))
                     .foregroundColor(.gray400)
                 
-                PentagonGraph(xpStats: xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + userLV))
+                PentagonGraph(xpPoint: xpPoint, xpStats: xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + userLV))
                 
                 Spacer()
             }
@@ -102,17 +102,17 @@ extension MypageShareImage {
     }
     
     //MAX 값은 기본 60 + 레벨 * 10
-    private func PentagonGraph(xpStats: [XpStat: Int], width: CGFloat, mainColor: Color, subColor: Color, maxValue: Double) -> some View {
+    private func PentagonGraph(xpPoint:Int, xpStats: [XpStat: Int], width: CGFloat, mainColor: Color, subColor: Color, maxValue: Double) -> some View {
         HStack {
             Spacer()
             
             ZStack {
                 BackgroundPolygons(width: width, subColor: subColor) // 배경 오각형
-                StatPolygon(xpStats: xpStats, maxValue: maxValue, cornerRadius: 15) // 데이터 오각형
-                    .fill(mainColor)
-                    .opacity(0.8)
-                
-                StatLabels(width: width, subColor: subColor) // 능력치 레이블
+                if xpPoint != 0 {
+                    StatPolygon(xpStats: xpStats, maxValue: maxValue, cornerRadius: 15) // 데이터 오각형
+                        .fill(mainColor)
+                        .opacity(0.8)
+                }
             }
             .frame(width: width, height: width)
             

--- a/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
@@ -60,7 +60,7 @@ struct MypageShareImage: View {
                     .font(.system(size: 12))
                     .foregroundColor(.gray400)
                 
-                PentagonGraph(xpPoint: xpPoint, xpStats: xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + userLV))
+                PentagonGraph(xpPoint: Int(xpPoint), xpStats: xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + userLV))
                 
                 Spacer()
             }

--- a/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
@@ -113,6 +113,7 @@ extension MypageShareImage {
                         .fill(mainColor)
                         .opacity(0.8)
                 }
+                StatLabels(width: width, subColor: subColor) // 능력치 레이블
             }
             .frame(width: width, height: width)
             

--- a/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
@@ -60,7 +60,7 @@ struct MypageShareImage: View {
                     .font(.system(size: 12))
                     .foregroundColor(.gray400)
                 
-                PentagonGraph(xpPoint: Int(xpPoint), xpStats: xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + userLV))
+                PentagonGraph(xpPoint: Int(xpPoint) ?? 10, xpStats: xpStats, width: 185, mainColor: .primaryPurple, subColor: .gray300, maxValue: Double(60 + userLV))
                 
                 Spacer()
             }


### PR DESCRIPTION
#### close #205 

### ✏️ 개요
오각형 그래프 예외 상황 버그 수정

### 💻 작업 사항
총합 스텟이 0일 경우 그래프가 표시되지 않도록 수정

### 📄 리뷰 노트
여러 변수들 사용해서 이상 없는것 같은데 또 다른 변수가 있다면 제보 부탁드립니다. ㅠㅠ
경우의 수가 많아서 또 생길수도,,,,,