### PR TITLE
[Feat/#204] 반복퀘스트 기능 & UI 구현

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189222C3E95D40070F2AD /* AuthNetwork.swift */; };
 		601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189262C3F00FB0070F2AD /* AuthChannel.swift */; };
 		601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189282C3F022D0070F2AD /* LoginViewModel.swift */; };
+		6029881E2D041D3900903806 /* QuestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029881D2D041D3900903806 /* QuestStatus.swift */; };
+		602988202D041D4700903806 /* XpStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029881F2D041D4700903806 /* XpStat.swift */; };
+		602988222D041DDC00903806 /* RepeatType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602988212D041DDC00903806 /* RepeatType.swift */; };
 		60299E312CBFFF160039663F /* TransferableUIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60299E302CBFFF160039663F /* TransferableUIImage.swift */; };
 		60299E392CC13DEC0039663F /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60299E382CC13DEC0039663F /* ImageCacheService.swift */; };
 		603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F040A2C2416D2008A2332 /* ImageNetwork.swift */; };
@@ -54,6 +57,8 @@
 		608EBFA12C39C5BB00B862CC /* String++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBFA02C39C5BB00B862CC /* String++.swift */; };
 		60924DC92C48C00E00221072 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60924DC82C48C00E00221072 /* Quest.swift */; };
 		60943FE62C0A38FB00C8A714 /* ApprovalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */; };
+		609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */; };
+		609A76DB2CFC5E90009F4567 /* StatGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76DA2CFC5E90009F4567 /* StatGridView.swift */; };
 		60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */; };
 		60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */; };
 		60B8B9EB2BF9EEF3005F6DE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60B8B9EA2BF9EEF3005F6DE3 /* Assets.xcassets */; };
@@ -138,6 +143,9 @@
 		601189222C3E95D40070F2AD /* AuthNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNetwork.swift; sourceTree = "<group>"; };
 		601189262C3F00FB0070F2AD /* AuthChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthChannel.swift; sourceTree = "<group>"; };
 		601189282C3F022D0070F2AD /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		6029881D2D041D3900903806 /* QuestStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestStatus.swift; sourceTree = "<group>"; };
+		6029881F2D041D4700903806 /* XpStat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpStat.swift; sourceTree = "<group>"; };
+		602988212D041DDC00903806 /* RepeatType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatType.swift; sourceTree = "<group>"; };
 		60299E302CBFFF160039663F /* TransferableUIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferableUIImage.swift; sourceTree = "<group>"; };
 		60299E382CC13DEC0039663F /* ImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheService.swift; sourceTree = "<group>"; };
 		603F040A2C2416D2008A2332 /* ImageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetwork.swift; sourceTree = "<group>"; };
@@ -176,6 +184,8 @@
 		608EBFA02C39C5BB00B862CC /* String++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String++.swift"; sourceTree = "<group>"; };
 		60924DC82C48C00E00221072 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalViewModel.swift; sourceTree = "<group>"; };
+		609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestImageWithTagView.swift; sourceTree = "<group>"; };
+		609A76DA2CFC5E90009F4567 /* StatGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatGridView.swift; sourceTree = "<group>"; };
 		60B8B9E32BF9EEF1005F6DE3 /* ILSANG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ILSANG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANGApp.swift; sourceTree = "<group>"; };
 		60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = "<group>"; };
@@ -307,6 +317,16 @@
 			path = Service;
 			sourceTree = "<group>";
 		};
+		6029881C2D041D2500903806 /* Enum */ = {
+			isa = PBXGroup;
+			children = (
+				6029881D2D041D3900903806 /* QuestStatus.swift */,
+				6029881F2D041D4700903806 /* XpStat.swift */,
+				602988212D041DDC00903806 /* RepeatType.swift */,
+			);
+			path = Enum;
+			sourceTree = "<group>";
+		};
 		60299E2F2CBFF8D20039663F /* MyPageChallenge */ = {
 			isa = PBXGroup;
 			children = (
@@ -381,6 +401,7 @@
 		607FCBD92BFA681800BB2D04 /* Quest */ = {
 			isa = PBXGroup;
 			children = (
+				609A76D72CFC507A009F4567 /* Component */,
 				60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */,
 				605F28512CF1B2C5007EA739 /* QuestDetailView.swift */,
 				607FCBE82BFE418600BB2D04 /* QuestViewModel.swift */,
@@ -455,6 +476,15 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		609A76D72CFC507A009F4567 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */,
+				609A76DA2CFC5E90009F4567 /* StatGridView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
 		60B8B9DA2BF9EEF1005F6DE3 = {
 			isa = PBXGroup;
 			children = (
@@ -527,6 +557,7 @@
 		60B8BA132BF9F07D005F6DE3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				6029881C2D041D2500903806 /* Enum */,
 				600D83A22C7B1F7E005C93E2 /* Manager */,
 				6011891B2C3E8B2B0070F2AD /* Service */,
 				600211E62C1EED2B000CC02E /* Model */,
@@ -796,6 +827,7 @@
 				601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */,
 				A1BB60262BFE05B000AAADD4 /* MyPageSegmenet.swift in Sources */,
 				9FE63D6C2CB3A58800CA7940 /* RankingView.swift in Sources */,
+				602988202D041D4700903806 /* XpStat.swift in Sources */,
 				9FE63D722CB3AB4F00CA7940 /* RankingItemView.swift in Sources */,
 				9FE63D702CB3AAF100CA7940 /* RankingViewModel.swift in Sources */,
 				605DA0D62C07123400CC9450 /* View++.swift in Sources */,
@@ -809,6 +841,7 @@
 				A196286F2C0859910037C53A /* DeleteAccountView.swift in Sources */,
 				6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */,
 				601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */,
+				609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */,
 				605F28522CF1B2C5007EA739 /* QuestDetailView.swift in Sources */,
 				A1AB3D6A2C1141B3001EB9D8 /* AppleLoginButtonView.swift in Sources */,
 				600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */,
@@ -849,6 +882,7 @@
 				60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				A11D88F72C916DE500846122 /* Icon.swift in Sources */,
+				602988222D041DDC00903806 /* RepeatType.swift in Sources */,
 				A19628652C076D7B0037C53A /* SettingView.swift in Sources */,
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,
 				606292D82C19E70A0098B6D2 /* Network.swift in Sources */,
@@ -862,6 +896,8 @@
 				60C0F4242CCE9B2F00DB19AB /* UIDevice++.swift in Sources */,
 				A1F770642C2AABCE00DB24A0 /* MypageViewModel.swift in Sources */,
 				606132782CD68FE300830948 /* TagView.swift in Sources */,
+				6029881E2D041D3900903806 /* QuestStatus.swift in Sources */,
+				609A76DB2CFC5E90009F4567 /* StatGridView.swift in Sources */,
 				605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */,
 				600211EE2C1EEF91000CC02E /* EmojiNetwork.swift in Sources */,
 				601189212C3E94A60070F2AD /* AuthService.swift in Sources */,
@@ -988,11 +1024,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V589568L2Q;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "일상";
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSCameraUsageDescription = "일상은 퀘스트 인증 사진을 촬영하기 위해 카메라 접근 권한이 필요합니다.\n계속하려면 카메라 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "일상은 촬영한 퀘스트 인증 사진을 저장하기 위해 앨범 접근 권한이 필요합니다.\n계속하려면 앨범 접근 권한을 허용해주세요.";
@@ -1011,7 +1047,6 @@
 				);
 				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -1195,11 +1230,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V589568L2Q;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "일상";
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSCameraUsageDescription = "일상은 퀘스트 인증 사진을 촬영하기 위해 카메라 접근 권한이 필요합니다.\n계속하려면 카메라 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "일상은 촬영한 퀘스트 인증 사진을 저장하기 위해 앨범 접근 권한이 필요합니다.\n계속하려면 앨범 접근 권한을 허용해주세요.";
@@ -1239,11 +1274,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V589568L2Q;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "일상";
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSCameraUsageDescription = "일상은 퀘스트 인증 사진을 촬영하기 위해 카메라 접근 권한이 필요합니다.\n계속하려면 카메라 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "일상은 촬영한 퀘스트 인증 사진을 저장하기 위해 앨범 접근 권한이 필요합니다.\n계속하려면 앨범 접근 권한을 허용해주세요.";
@@ -1262,7 +1297,7 @@
 				);
 				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Fg_Badge_green_.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Fg_Badge_green_.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.082",
+          "green" : "0.369",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Daily_Left.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Daily_Left.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x17",
+          "red" : "0x7D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Daily_Right.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Daily_Right.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x5D",
+          "red" : "0xA4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Monthly_Left.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Monthly_Left.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x30",
+          "green" : "0xDA",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Monthly_Right.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Monthly_Right.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x05",
+          "green" : "0xFF",
+          "red" : "0xD1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Weekly_Left.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Weekly_Left.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9E",
+          "green" : "0x00",
+          "red" : "0x45"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Weekly_Right.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/Weekly_Right.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x00",
+          "red" : "0x70"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/XCConfig/Staging.xcconfig
+++ b/ILSANG/Resources/XCConfig/Staging.xcconfig
@@ -13,5 +13,5 @@ PORT = 8880
 
 
 // App Settings
-APP_NAME = 일상
-APP_BUNDLE_ID = com.ilsang240615
+APP_NAME = 일상 DEV
+APP_BUNDLE_ID = com.ilsang240615.dev

--- a/ILSANG/Sources/Enum/QuestStatus.swift
+++ b/ILSANG/Sources/Enum/QuestStatus.swift
@@ -1,0 +1,43 @@
+//
+//  QuestStatus.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 12/7/24.
+//
+
+import Foundation
+
+enum QuestStatus: String, CaseIterable {
+    case `default`
+    case `repeat`
+    case completed
+    
+    var headerText: String {
+        switch self {
+        case .default:
+            "기본"
+        case .repeat:
+            "반복"
+        case .completed:
+            "완료"
+        }
+    }
+    
+    var emptyTitle: String {
+        switch self {
+        case .default, .repeat:
+            "퀘스트를 모두 완료하셨어요!"
+        case .completed:
+            "완료된 퀘스트가 없어요"
+        }
+    }
+    
+    var emptySubTitle: String {
+        switch self {
+        case .default, .repeat:
+            "상상할 수 없는 퀘스트를 준비 중이니\n다음 업데이트를 기대해 주세요!"
+        case .completed:
+            "퀘스트를 수행하러 가볼까요?"
+        }
+    }
+}

--- a/ILSANG/Sources/Enum/RepeatType.swift
+++ b/ILSANG/Sources/Enum/RepeatType.swift
@@ -1,0 +1,49 @@
+//
+//  RepeatType.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 12/7/24.
+//
+
+import SwiftUI
+
+enum RepeatType: String, Hashable, CustomStringConvertible, CaseIterable {
+    case daily
+    case weekly
+    case monthly
+    
+    var description: String {
+        switch self {
+        case .daily:
+            "일간"
+        case .weekly:
+            "주간"
+        case .monthly:
+            "월간"
+        }
+    }
+    
+    var fgColor: Color {
+        switch self {
+        case .daily, .weekly:
+            Color.white
+        case .monthly:
+            Color.fgBadgeGreen
+        }
+    }
+    
+    var bgGradient: Gradient {
+        switch self {
+        case .daily:
+            Gradient(colors: [.dailyLeft, .dailyRight])
+        case .weekly:
+            Gradient(colors: [.weeklyLeft, .weeklyRight])
+        case .monthly:
+            Gradient(colors: [.monthlyLeft, .monthlyRight])
+        }
+    }
+    
+    func toParam() -> String {
+        return self.rawValue.uppercased()
+    }
+}

--- a/ILSANG/Sources/Enum/XpStat.swift
+++ b/ILSANG/Sources/Enum/XpStat.swift
@@ -1,0 +1,65 @@
+//
+//  XpStat.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 12/7/24.
+//
+
+import Foundation
+
+enum XpStat: String, CaseIterable {
+    case strength
+    case intellect
+    case fun
+    case charm
+    case sociability
+    
+    var headerText: String {
+        switch self {
+        case .strength:
+            "체력"
+        case .intellect:
+            "지능"
+        case .fun:
+            "재미"
+        case .charm:
+            "매력"
+        case .sociability:
+            "사회성"
+        }
+    }
+    
+    var parameterText: String {
+        switch self {
+        case .strength:
+            "STRENGTH"
+        case .intellect:
+            "INTELLECT"
+        case .fun:
+            "FUN"
+        case .charm:
+            "CHARM"
+        case .sociability:
+            "SOCIABILITY"
+        }
+    }
+    
+    var image: ImageResource {
+        switch self {
+        case .strength:
+            return .strength
+        case .intellect:
+            return .intellect
+        case .fun:
+            return .fun
+        case .charm:
+            return .charm
+        case .sociability:
+            return .sociability
+        }
+    }
+    
+    static var sortedStat: [XpStat] {
+        return [.strength, .intellect, .fun, .charm, .sociability]
+    }
+}

--- a/ILSANG/Sources/Global/View/FilterPicker.swift
+++ b/ILSANG/Sources/Global/View/FilterPicker.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct PickerView<SelectionValue>: View where SelectionValue: Hashable & CustomStringConvertible & CaseIterable {
     @State var status: PickerStatus = .close
     @Binding var selection: SelectionValue
+    let width: CGFloat
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -25,7 +26,7 @@ struct PickerView<SelectionValue>: View where SelectionValue: Hashable & CustomS
             }
             .foregroundStyle(.gray500)
             .padding(.horizontal, 12)
-            .frame(width: 150, height: 40)
+            .frame(width: width, height: 40)
             .background(Color.white)
             .clipShape(
                 RoundedRectangle(cornerRadius: 8)
@@ -37,7 +38,8 @@ struct PickerView<SelectionValue>: View where SelectionValue: Hashable & CustomS
             
             if status == .open {
                 VStack(spacing: 0) {
-                    ForEach(Array(SelectionValue.allCases).filter { $0 != selection }, id: \.self) { value in
+                    let selectableList = SelectionValue.allCases.filter { $0 != selection }
+                    ForEach(Array(selectableList.enumerated()), id: \.offset) { idx, value in
                         Button(action: {
                             self.selection = value
                             self.status.toggle()
@@ -48,11 +50,19 @@ struct PickerView<SelectionValue>: View where SelectionValue: Hashable & CustomS
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .frame(height: 40)
                                 .background(Color.white)
+                                .padding(.horizontal, 12)
+                        }
+                        .overlay(alignment: .bottom) {
+                            if idx != selectableList.count - 1 {
+                                Rectangle()
+                                    .frame(height: 1)
+                                    .frame(maxWidth: .infinity)
+                                    .foregroundStyle(.gray100)
+                            }
                         }
                     }
                 }
-                .padding(.horizontal, 12)
-                .frame(width: 150)
+                .frame(width: width)
                 .background(Color.white)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)

--- a/ILSANG/Sources/Global/View/TagView.swift
+++ b/ILSANG/Sources/Global/View/TagView.swift
@@ -30,7 +30,7 @@ struct TagView: View {
 
 extension TagView {
     enum TagStyle {
-        case level, levelStroke, xp, xpWithIcon
+        case level, levelStroke, xp, xpWithIcon, `repeat`(RepeatType)
         
         var font: Font {
             switch self {
@@ -38,6 +38,7 @@ extension TagView {
             case .levelStroke: return .system(size: 13, weight: .bold)
             case .xp: return .system(size: 10, weight: .semibold)
             case .xpWithIcon: return .system(size: 12, weight: .regular)
+            case .repeat: return .system(size: 10, weight: .semibold)
             }
         }
         
@@ -47,6 +48,7 @@ extension TagView {
             case .levelStroke: return .primaryPurple
             case .xp: return .white
             case .xpWithIcon: return .primaryPurple
+            case .repeat(let type): return type.fgColor
             }
         }
         
@@ -56,13 +58,23 @@ extension TagView {
             case .levelStroke: return .white
             case .xp: return .primaryPurple
             case .xpWithIcon: return .clear
+            case .repeat: return .white
+            }
+        }
+        
+        var gradient: Gradient? {
+            switch self {
+            case .repeat(let type):
+                return type.bgGradient
+            case .level, .levelStroke, .xp, .xpWithIcon:
+                return nil
             }
         }
         
         var strokeColor: Color? {
             switch self {
             case .xpWithIcon, .levelStroke: return .primaryPurple
-            case .level, .xp: return nil
+            case .level, .xp, .repeat: return nil
             }
         }
         
@@ -70,8 +82,18 @@ extension TagView {
             switch self {
             case .level: return EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12)
             case .levelStroke: return EdgeInsets(top: 4, leading: 14.5, bottom: 4, trailing: 14.5)
-            case .xp: return EdgeInsets(top: 4, leading: 5, bottom: 4, trailing: 5)
+            case .xp: return EdgeInsets(top: 0, leading: 7, bottom: 0, trailing: 7)
             case .xpWithIcon: return EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4)
+            case .repeat: return EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 11)
+            }
+        }
+        
+        var height: CGFloat {
+            switch self {
+            case .level, .levelStroke, .xp, .repeat:
+                20
+            case .xpWithIcon:
+                25
             }
         }
         
@@ -89,7 +111,20 @@ struct TagViewModifier: ViewModifier {
             .font(style.font)
             .foregroundColor(style.fgColor)
             .padding(style.padding)
-            .background(style.bgColor)
+            .frame(height: style.height)
+            .background(
+                ZStack {
+                    if let gradient = style.gradient {
+                        LinearGradient(
+                            gradient: gradient,
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    } else {
+                        style.bgColor
+                    }
+                }
+            )
             .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius))
             .overlay(
                 RoundedRectangle(cornerRadius: style.cornerRadius)

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -61,6 +61,7 @@ final class Network {
         } else {
             request = AF.request(fullPath, method: method, encoding: parameters != nil ? URLEncoding.queryString : JSONEncoding.default, headers: headers)
         }
+        Log(fullPath)
         
         let response = await request.validate(statusCode: 200..<300)
             .serializingDecodable(T.self, emptyResponseCodes: [200])

--- a/ILSANG/Sources/Network/QuestNetwork.swift
+++ b/ILSANG/Sources/Network/QuestNetwork.swift
@@ -16,9 +16,14 @@ final class QuestNetwork {
         self.questUrl = questUrl
     }
     
-    func getUncompletedQuest(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
+    func getDefaultQuest(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
         let parameters: Parameters = ["page": page, "size": size]
         return await Network.requestData(url: questUrl+"uncompletedQuest", method: .get, parameters: parameters, withToken: true)
+    } 
+    
+    func getRepeatQuest(status: RepeatType, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
+        let parameters: Parameters = ["status": status.toParam(), "page": page, "size": size]
+        return await Network.requestData(url: questUrl+"uncompletedRepeatQuest", method: .get, parameters: parameters, withToken: true)
     }
     
     func getCompletedQuest(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {

--- a/ILSANG/Sources/Views/Quest/Component/QuestImageWithTagView.swift
+++ b/ILSANG/Sources/Views/Quest/Component/QuestImageWithTagView.swift
@@ -1,0 +1,29 @@
+//
+//  QuestImageWithTagView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 12/1/24.
+//
+
+import SwiftUI
+
+struct QuestImageWithTagView: View {
+    let image: UIImage?
+    let tagTitle: String
+    let tagStyle: TagView.TagStyle
+    let tagOffset: (x: CGFloat, y: CGFloat)
+    private let imageSize: CGSize = CGSize(width: 60, height: 60)
+    
+    var body: some View {
+        Image(uiImage: image ?? .logo)
+            .resizable()
+            .scaledToFit()
+            .frame(width: imageSize.width, height: imageSize.height)
+            .background(Color.badgeBlue)
+            .clipShape(Circle())
+            .overlay(alignment: .topTrailing) {
+                TagView(title: tagTitle, tagStyle: tagStyle)
+                    .position(x: tagOffset.x, y: tagOffset.y)
+            }
+    }
+}

--- a/ILSANG/Sources/Views/Quest/Component/StatGridView.swift
+++ b/ILSANG/Sources/Views/Quest/Component/StatGridView.swift
@@ -1,0 +1,40 @@
+//
+//  StatGridView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 12/1/24.
+//
+
+import SwiftUI
+
+struct StatGridView: View {
+    let rewardDic: [XpStat: Int]
+    
+    var body: some View {
+        if rewardDic.filter({ $0.value > 0 }).count <= 3 {
+            tagView(range: 0..<5)
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                tagView(range: 0..<3) // 0 1 2
+                tagView(range: 3..<5) // 3 4
+            }
+        }
+    }
+    
+    private func tagView(range: Range<Int>) -> some View {
+        HStack(spacing: 4) {
+            ForEach(Array(XpStat.sortedStat[range]), id: \.rawValue) { stat in
+                let reward = rewardDic[stat, default: 0]
+                if reward > 0 {
+                    TagView(title: "\(reward)P", image: stat.image, tagStyle: .xpWithIcon)
+                }
+            }
+        }
+    }
+}
+
+
+#Preview {
+    StatGridView(rewardDic: [.charm: 225, .fun: 0, .intellect: 392, .strength: 20, .sociability: 20])
+        .padding(.horizontal, 20)
+}

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -7,93 +7,122 @@
 
 import SwiftUI
 
+// 공통 데이터 구조
+struct QuestCommonComponent {
+    let title: String
+    let writer: String
+    let rewardDic: [XpStat: Int]
+    let image: UIImage?
+    let tagTitle: String
+    let action: (() -> Void)?
+}
+
 struct QuestItemView: View {
-    let quest: QuestViewModelItem
-    let status: QuestStatus
-    private let separatorOffset = 72.0
+    let component: QuestCommonComponent
+    let style: QuestStyle
+    
+    init(style: QuestStyle, quest: QuestViewModelItem, tagTitle: String, action: @escaping () -> Void) {
+        self.component = QuestCommonComponent(
+            title: quest.missionTitle,
+            writer: quest.writer,
+            rewardDic: quest.rewardDic,
+            image: quest.image,
+            tagTitle: tagTitle,
+            action: action
+        )
+        self.style = style
+    }
     
     var body: some View {
-        HStack(spacing: 0) {
-            Image(uiImage: quest.image ?? .logo)
-                .resizable()
-                .scaledToFill()
-                .frame(width: 60, height: 60)
-                .background(Color.badgeBlue)
-                .clipShape(Circle())
-                .padding(.leading, 20)
-                .padding(.trailing, 16)
-                .overlay(alignment: .top) {
-                    TagView(title: String(quest.totalRewardXP()) + "XP", tagStyle: .xp)
-                        .offset(x: 20, y: 2)
-                }
-            
-            VStack(alignment: .leading, spacing: 4) {
-                Text(quest.missionTitle.forceCharWrapping)
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundColor(.black)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .multilineTextAlignment(.leading)
-                    .lineLimit(2)
+        Button(action: { component.action?() }) {
+            HStack(spacing: 0) {
+                QuestImageWithTagView(
+                    image: component.image,
+                    tagTitle: component.tagTitle,
+                    tagStyle: style.tagStyle,
+                    tagOffset: style.tagOffset
+                )
+                .padding(.trailing, 20)
                 
-                Text(quest.writer)
-                    .font(.system(size: 13, weight: .regular))
-                    .foregroundColor(.gray400)
-                    .padding(.bottom, 4)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(component.title)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundColor(.black)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                    
+                    Text(component.writer)
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundColor(.gray400)
+                        .padding(.bottom, 4)
+                    
+                    StatGridView(rewardDic: component.rewardDic)
+                }
                 
-                if status == .uncompleted {
-                    HStack(spacing: 4) {
-                        ForEach(Array(XpStat.sortedStat), id: \.rawValue) { stat in
-                            let reward = quest.rewardDic[stat, default: 0]
-                            if reward > 0 {
-                                TagView(title: "\(reward)P", image: stat.image, tagStyle: .xpWithIcon)
-                            }
-                        }
-                    }
-                }
+                Spacer()
+                
+                style.trailingView()
             }
-            
-            Spacer(minLength: 4)
-            
-            Group {
-                switch status {
-                case .uncompleted:
-                    IconView(iconWidth: 6, size: .small, icon: .arrowRight, color: .gray)
-                        .padding(.trailing, 24)
-                case .completed:
-                    VStack(spacing: 7) {
-                        IconView(iconWidth: 13, size: .small, icon: .check, color: .green)
-                        Text("적립완료")
-                            .font(.system(size: 12, weight: .semibold))
-                            .multilineTextAlignment(.center)
-                            .foregroundColor(.green)
-                    }
-                    .frame(width: separatorOffset)
-                }
-            }
+            .padding(20)
+            .background(style.backgroundColor)
+            .cornerRadius(12)
+            .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
+            .padding(.horizontal, 20)
         }
-        .padding(.vertical, 24)
-        .background(.white)
-        .overlay(alignment: .trailing) {
-            if status == .completed {
-                VLine()
-                    .stroke(style: StrokeStyle(lineWidth: 0.5, dash: [3.3]))
-                    .frame(width: 0.5)
-                    .foregroundStyle(.gray200)
-                    .offset(x: -separatorOffset)
-                    .padding(.vertical, 12)
-            }
-        }
-        .disabled(status == .uncompleted)
-        .cornerRadius(status == .uncompleted ? 12 : 16)
-        .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
-        .padding(.horizontal, 20)
+        .disabled(style.isDisabled)
     }
 }
 
-
-#Preview {
-    VStack {
-        QuestItemView(quest: QuestViewModelItem.mockData, status: .completed)
-        QuestItemView(quest: QuestViewModelItem.mockData, status: .uncompleted)
+// 스타일 관리
+enum QuestStyle {
+    case uncompleted
+    case completed
+    case repeatable(RepeatType)
+    
+    var tagStyle: TagView.TagStyle {
+        switch self {
+        case .uncompleted: return .xp
+        case .completed: return .xp
+        case .repeatable(let repeatType): return .repeat(repeatType)
+        }
+    }
+    
+    var tagOffset: (x: CGFloat, y: CGFloat) {
+        switch self {
+        case .uncompleted, .completed:
+            return (x: 48, y: 5)
+        case .repeatable:
+            return (x: 54, y: 3)
+        }
+    }
+    
+    @ViewBuilder
+    func trailingView() -> some View {
+        switch self {
+        case .uncompleted, .repeatable:
+            IconView(iconWidth: 6, size: .small, icon: .arrowRight, color: .gray)
+        case .completed:
+            VStack(spacing: 7) {
+                IconView(iconWidth: 13, size: .small, icon: .check, color: .green)
+                Text("적립완료")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.green)
+            }
+            .frame(width: 72)
+        }
+    }
+    
+    var backgroundColor: Color {
+        switch self {
+        case .completed: return Color.white
+        default: return Color.white
+        }
+    }
+    
+    var isDisabled: Bool {
+        switch self {
+        case .completed: return true
+        default: return false
+        }
     }
 }

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -21,6 +21,10 @@ struct QuestItemView: View {
     let component: QuestCommonComponent
     let style: QuestStyle
     
+    fileprivate struct Constants {
+        static let separatorOffset = 72.0
+    }
+
     init(style: QuestStyle, quest: QuestViewModelItem, tagTitle: String, action: @escaping () -> Void) {
         self.component = QuestCommonComponent(
             title: quest.missionTitle,
@@ -59,13 +63,18 @@ struct QuestItemView: View {
                     StatGridView(rewardDic: component.rewardDic)
                 }
                 
-                Spacer()
+                Spacer(minLength: 0)
                 
                 style.trailingView()
             }
-            .padding(20)
+            .padding(.vertical, 20)
+            .padding(.leading, 20)
+            .padding(.trailing, style.trailingPadding)
             .background(style.backgroundColor)
             .cornerRadius(12)
+            .overlay(alignment: .trailing) {
+                style.overlayView()
+            }
             .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
             .padding(.horizontal, 20)
         }
@@ -106,9 +115,18 @@ enum QuestStyle {
                 IconView(iconWidth: 13, size: .small, icon: .check, color: .green)
                 Text("적립완료")
                     .font(.system(size: 12, weight: .semibold))
+                    .multilineTextAlignment(.center)
                     .foregroundColor(.green)
             }
-            .frame(width: 72)
+            .frame(width: QuestItemView.Constants.separatorOffset)
+        }
+    }
+    var trailingPadding: CGFloat {
+        switch self {
+        case .uncompleted, .repeatable:
+            20
+        case .completed:
+            0
         }
     }
     
@@ -123,6 +141,21 @@ enum QuestStyle {
         switch self {
         case .completed: return true
         default: return false
+        }
+    }
+    
+    @ViewBuilder
+    func overlayView() -> some View {
+        switch self {
+        case .completed:
+            VLine()
+                .stroke(style: StrokeStyle(lineWidth: 0.5, dash: [3.3]))
+                .frame(width: 0.5)
+                .foregroundStyle(.gray200)
+                .offset(x: -QuestItemView.Constants.separatorOffset)
+                .padding(.vertical, 12)
+        case .repeatable, .uncompleted:
+            EmptyView()
         }
     }
 }

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -15,7 +15,7 @@ struct QuestView: View {
         VStack(spacing: 0) {
             headerView
                 
-            if vm.selectedHeader == .uncompleted {
+            if vm.selectedHeader == .default || vm.selectedHeader == .repeat {
                 subHeaderView
             }
             
@@ -46,7 +46,7 @@ struct QuestView: View {
 
 extension QuestView {
     private var headerView: some View {
-        HStack(spacing: 15) {
+        HStack(spacing: 16) {
             ForEach(QuestStatus.allCases, id: \.headerText) { status in
                 Button {
                     vm.selectedHeader = status
@@ -99,18 +99,36 @@ extension QuestView {
         ScrollView {
             LazyVStack(spacing: 12) {
                 switch vm.selectedHeader {
-                case .uncompleted:
-                    ForEach(vm.filteredUncompletedQuestListByXpStat, id: \.id) { quest in
-                        Button {
-                            vm.tappedQuestBtn(quest: quest)
-                        } label: {
-                            QuestItemView(quest: quest, status: .uncompleted)
-                        }
+                case .default:
+                    ForEach(vm.filteredDefaultQuestListByXpStat, id: \.id) { quest in
+                        QuestItemView(
+                            style: .uncompleted,
+                            quest: quest,
+                            tagTitle: String(quest.totalRewardXP())+"XP",
+                            action: {
+                                vm.tappedQuestBtn(quest: quest)
+                            }
+                        )
                     }
-                    
+                case .repeat:
+                    ForEach(vm.filteredRepeatQuestListByXpStat, id: \.id) { quest in
+                        QuestItemView(
+                            style: .repeatable(vm.selectedRepeatType),
+                            quest: quest,
+                            tagTitle: vm.selectedRepeatType.description,
+                            action: {
+                                vm.tappedQuestBtn(quest: quest)
+                            }
+                        )
+                    }
                 case .completed:
                     ForEach(vm.itemListByStatus[.completed, default: []], id: \.id) { quest in
-                        QuestItemView(quest: quest, status: .completed)
+                        QuestItemView(
+                            style: .completed,
+                            quest: quest,
+                            tagTitle: String(quest.totalRewardXP())+"XP",
+                            action: { }
+                        )
                     }
                     if vm.hasMorePage(status: .completed) {
                         ProgressView()
@@ -122,11 +140,22 @@ extension QuestView {
                     }
                 }
             }
-            .padding(.top, 70)
+            .padding(.top, vm.selectedHeader == .default || vm.selectedHeader == .repeat ? 70 : 0)
             .overlay(alignment: .top) {
-                if vm.selectedHeader == .uncompleted {
-                    filterPickerView
+                Group {
+                    if (vm.selectedHeader == .default) {
+                        filterPickerDefaultView
+                    } else if (vm.selectedHeader == .repeat) {
+                        HStack(alignment: .top, spacing: 8) {
+                            filterPickerRepeatView
+                            filterPickerDefaultView
+                        }
+                    }
                 }
+                .padding(.top, 13)
+                .padding(.bottom, 16)
+                .padding(.trailing, 20)
+                .frame(maxWidth: .infinity, alignment: .trailing)
             }
             .padding(.bottom, 72)
         }
@@ -141,21 +170,20 @@ extension QuestView {
         }
     }
     
-    private var filterPickerView: some View {
-        PickerView<QuestFilter>(selection: $vm.selectedFilter)
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .padding(.trailing, 20)
-            .padding(.top, 13)
-            .padding(.bottom, 16)
+    private var filterPickerDefaultView: some View {
+        PickerView<QuestFilter>(selection: $vm.selectedFilter, width: 150)
+    }
+    
+    private var filterPickerRepeatView: some View {
+        PickerView<RepeatType>(selection: $vm.selectedRepeatType, width: 85)
     }
     
     private var questListEmptyView: some View {
         ErrorView(
             title: vm.selectedHeader.emptyTitle,
-            subTitle: vm.selectedHeader.emptySubTitle
-        ) {
-            Task { await vm.loadInitialData() }
-        }
+            subTitle: vm.selectedHeader.emptySubTitle,
+            showButton: false
+        )
     }
     
     private var networkErrorView: some View {
@@ -172,37 +200,4 @@ extension QuestView {
 
 #Preview {
     QuestView(vm: QuestViewModel(questNetwork: QuestNetwork()))
-}
-
-struct StatView: View {
-    let columns = [GridItem(.flexible(minimum: 60)), GridItem(.flexible(minimum: 60)), GridItem(.flexible(minimum: 60))]
-    let stats: [XpStat] = [.strength, .intellect, .sociability, .charm, .fun]
-    let dic: [XpStat: Int]
-    
-    var body: some View {
-        LazyVGrid(columns: columns, spacing: 8) {
-            ForEach(stats, id: \.self) { stat in
-                HStack {
-                    Text("\(stat.headerText) : \(dic[stat] ?? 0)P")
-                        .frame(height: 22, alignment: .leading)
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(.primaryPurple)
-                    Spacer(minLength: 0)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.leading, 8)
-            }
-        }
-        .padding(.horizontal, 12)
-        .frame(height: 84)
-        .background(
-            RoundedRectangle(cornerRadius: 14)
-                .foregroundStyle(.primary100.opacity(0.5))
-        )
-    }
-}
-
-#Preview {
-    StatView(dic: [.charm: 225, .fun: 392, .sociability: 0])
-        .padding(.horizontal, 20)
 }

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -7,95 +7,6 @@
 
 import UIKit
 
-enum QuestStatus: String, CaseIterable {
-    case uncompleted
-    case completed
-    
-    var headerText: String {
-        switch self {
-        case .uncompleted:
-            "퀘스트"
-        case .completed:
-            "완료"
-        }
-    }
-    
-    var emptyTitle: String {
-        switch self {
-        case .uncompleted:
-            "퀘스트를 모두 완료하셨어요!"
-        case .completed:
-            "완료된 퀘스트가 없어요"
-        }
-    }
-    
-    var emptySubTitle: String {
-        switch self {
-        case .uncompleted:
-            "상상할 수 없는 퀘스트를 준비 중이니\n다음 업데이트를 기대해 주세요!"
-        case .completed:
-            "퀘스트를 수행하러 가볼까요?"
-        }
-    }
-}
-
-enum XpStat: String, CaseIterable {
-    case strength
-    case intellect
-    case fun
-    case charm
-    case sociability
-    
-    var headerText: String {
-        switch self {
-        case .strength:
-            "체력"
-        case .intellect:
-            "지능"
-        case .fun:
-            "재미"
-        case .charm:
-            "매력"
-        case .sociability:
-            "사회성"
-        }
-    }
-    
-    var parameterText: String {
-        switch self {
-        case .strength:
-            "STRENGTH"
-        case .intellect:
-            "INTELLECT"
-        case .fun:
-            "FUN"
-        case .charm:
-            "CHARM"
-        case .sociability:
-            "SOCIABILITY"
-        }
-    }
-    
-    var image: ImageResource {
-        switch self {
-        case .strength:
-            return .strength
-        case .intellect:
-            return .intellect
-        case .fun:
-            return .fun
-        case .charm:
-            return .charm
-        case .sociability:
-            return .sociability
-        }
-    }
-    
-    static var sortedStat: [XpStat] {
-        return [.strength, .intellect, .fun, .charm, .sociability]
-    }
-}
-
 struct QuestViewModelItem {
     let id: String
     var image: UIImage?
@@ -131,7 +42,9 @@ struct QuestViewModelItem {
     func totalRewardXP() -> Int {
         self.rewardDic.values.reduce(0, +)
     }
-    
+}
+
+extension QuestViewModelItem {
     static let mockImageId = "IMQU2024071520500801"
     
     static let mockData: QuestViewModelItem = QuestViewModelItem(
@@ -150,7 +63,23 @@ struct QuestViewModelItem {
             imageId: mockImageId,
             missionTitle: "아메리카노 15잔 마시기",
             writer: "이디야커피",
-            rewardDic: [.charm: 30, .intellect: 20, .fun: 25]
+            rewardDic: [.charm: 3, .sociability: 20, .strength: 25]
+        ),
+        QuestViewModelItem(
+            id: "9f8aacc9-98c1-f9d7d35a67fb",
+            image: .checkmark,
+            imageId: mockImageId,
+            missionTitle: "아메리카노 15잔 마시기",
+            writer: "이디야커피",
+            rewardDic: [.charm: 3, .fun: 25, .sociability: 20, .strength: 25]
+        ),
+        QuestViewModelItem(
+            id: "9f8aacc9-a221-4-f9d7d35a67fb",
+            image: .checkmark,
+            imageId: mockImageId,
+            missionTitle: "아메리카노 15잔 마시기",
+            writer: "이디야커피",
+            rewardDic: [.charm: 30, .intellect: 20, .fun: 25, .sociability: 20, .strength: 25]
         ),
         QuestViewModelItem(
             id: "13",
@@ -158,7 +87,7 @@ struct QuestViewModelItem {
             imageId: mockImageId,
             missionTitle: "카페라떼 1잔 마시기",
             writer: "투썸플레이스",
-            rewardDic: [.charm: 30, .intellect: 100, .fun: 5]
+            rewardDic: [.charm: 200, .intellect: 50, .fun: 25, .sociability: 100, .strength: 25]
         )
     ]
 }


### PR DESCRIPTION
#### close #204

### ✏️ 개요
반복퀘스트 기능 추가에 따라 UI를 구현하고, API 조회기능을 추가하였습니다.

### 💻 작업 사항
- QuestView 재사용을 위한 컴포넌트 분리 (StatGridView, QuestImageWithTagView)
- QuestItemView 컴포넌트 리팩토링(기본,반복,완료 타입에 따른 스타일 지정)
- TagView 수정 사항 적용
- FilterPicker 구분선 및 width 추가
- Network fullPath 로그 추가
- 퀘스트 목록 중복 제거 로직 수정


### 📄 리뷰 노트
- 1ab91ae01328dd90c1de9735fd2e476aeb7a8e1e 컬러 추가사항이 있어서, 이 커밋만 확인하시는게 보기 편할 것 같습니다.
<details><summary>퀘스트 목록 중복 제거로직 수정</summary>
<p>

---
<h4>🏁 기존</h4>

**API 응답 결과**
각 페이지의 목록 간의 중복이 존재 (page0에서 조회한 퀘스트가 page1에서 다시 조회됨)

**기존 로직**
1) 새 목록을 순회하며 퀘스트가 기존 목록에 존재하면 새 목록에서 해당 퀘스트 제거 
2) 최종 중복 제거된 새 목록을 기존 목록에 추가

<h4>🏁 현재</h4>

**API 응답 결과**
기존 중복 문제 + **한 페이지 내에서 중복 문제** (기존 중복은 파악하지 않았으나.. 예방차원에서 유지..)

**수정한 로직**
1) 새 목록 내부 중복 제거 + 새 목록과 기존 목록을 비교해서 새 목록에서 중복 제거 
2) 최종 중복 제거된 새 목록을 기존 목록에 추가
---

</p>
</details> 

### 📱결과 화면(optional)
| 기본 탭  | 반복 탭 | 완료 탭 |
|--------|--------|--------|
| <img src = "https://github.com/user-attachments/assets/e47b1b89-eb76-4afa-98bb-bfaba3631d95" width = "300"> | <img src = "https://github.com/user-attachments/assets/93a3023d-6d4a-4a51-ab8c-8e6cd08e260a" width = "300">  | <img src = "https://github.com/user-attachments/assets/388cc88d-880e-4f2e-8c3b-9bdf50b14dca" width = "300"> | 


![Simulator Screen Recording - iPhone 15 - 2024-12-08 at 16 28 49](https://github.com/user-attachments/assets/1185e60d-cb77-4c6e-870d-05a6ec3df351)