### PR TITLE
[Chore/#209] 1.2.3 마케팅 버전 수정, 컴파일 에러 수정, 스탯라벨 중복 제거

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -988,7 +988,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V589568L2Q;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
@@ -1009,7 +1009,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1195,7 +1195,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V589568L2Q;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
@@ -1216,7 +1216,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1239,7 +1239,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ILSANG/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V589568L2Q;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ILSANG/Info.plist;
@@ -1260,7 +1260,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageBadgeList.swift
@@ -124,7 +124,6 @@ extension MyPageBadgeList {
                         .fill(mainColor)
                         .opacity(0.8)
                 }
-                StatLabels(width: width, subColor: subColor) // 능력치 레이블
             }
             .frame(width: width, height: width)
             

--- a/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
+++ b/ILSANG/Sources/Views/MyPage/MypageShareImage.swift
@@ -141,7 +141,8 @@ extension MypageShareImage {
     // 능력치 레이블 위치 지정
     private func StatLabels(width: CGFloat, subColor: Color) -> some View {
         ForEach(Array(XpStat.allCases.enumerated()), id: \.element) { index, stat in
-            let angle = (CGFloat(index) / CGFloat(XpStat.sortedStat.count)) * 2 * .pi - .pi / 2
+            let indexRatio = CGFloat(index) / CGFloat(XpStat.sortedStat.count)
+            let angle = (indexRatio * 2 * .pi) - .pi / 2
             let radius = width / 2 + 30
             let labelPoint = CGPoint(
                 x: width / 2 + radius * cos(angle),

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -122,7 +122,7 @@ extension QuestView {
                     }
                 }
             }
-            .padding(.top, 70)
+            .padding(.top, vm.selectedHeader == .uncompleted ? 70 : 0)
             .overlay(alignment: .top) {
                 if vm.selectedHeader == .uncompleted {
                     filterPickerView

--- a/ILSANG/Sources/Views/Setting/SettingView.swift
+++ b/ILSANG/Sources/Views/Setting/SettingView.swift
@@ -16,7 +16,7 @@ struct SettingView: View {
         Setting(title: "고객센터", type: .navigate),
         Setting(title: "약관 및 정책", type: .navigate),
         Setting(title: "오픈소스 정보", type: .navigate),
-        Setting(title: "현재 버전", type: .info("v.1.2.2")),
+        Setting(title: "현재 버전", type: .info("v.1.2.3")),
         Setting(title: "로그아웃", type: .alert),
         Setting(title: "회원 탈퇴", titleColor: .subRed, type: .navigate)
     ]


### PR DESCRIPTION
#### close #209 

### ✏️ 개요
1.2.3 배포를 위한 작업을 진행했습니다.

### 💻 작업 사항
- 마케팅 버전 수정
- 마이탭 및 퀘스트뷰 수정사항 반영

### 📄 리뷰 노트
스탯라벨이 뱃지에는 따로 있군여ㅠ
두번 나오길래 확인해서 지웠습니닥..