### PR TITLE
[Design/#218] 반복 퀘스트 디테일 시트 디자인 구현

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestDetailView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetailView.swift
@@ -11,6 +11,9 @@ struct QuestDetailView: View {
     let quest: QuestViewModelItem
     let action: () -> Void
     
+    private var isRepeatQuest: Bool { quest.type == "REPEAT" }
+    private var repeatType: RepeatType? { RepeatType(rawValue: quest.target.lowercased()) ?? nil }
+    
     var body: some View {
         VStack(spacing: 0) {
             RoundedRectangle(cornerRadius: 2)
@@ -28,8 +31,21 @@ struct QuestDetailView: View {
             Divider()
                 .foregroundStyle(.gray100)
                 .padding(.top, 16)
-                .padding(.bottom, 32)
-
+                .padding(.bottom, isRepeatQuest ? 16 : 32)
+            
+            if isRepeatQuest {
+                Text("획득 가능 스탯")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.primaryPurple)
+                    )
+                    .padding(.bottom, 16)
+            }
+            
             statTagViewList
             
             Text("퀘스트를 수행하셨나요?\n인증 후 포인트를 적립받으세요")
@@ -49,25 +65,33 @@ struct QuestDetailView: View {
     }
     
     private var questInfoView: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 0) {
             Image(uiImage: quest.image ?? .logo)
                 .resizable()
                 .scaledToFill()
                 .frame(width: 80, height: 80)
                 .clipShape(Circle())
+                .padding(.trailing, 8)
             
-            VStack(alignment: .leading, spacing: 0 ) {
-                Text(quest.writer)
-                    .font(.system(size: 15, weight: .regular))
-                    .frame(height: 30)
+            VStack(alignment: .leading, spacing: 0) {
+                Group {
+                    if isRepeatQuest, let repeatType = repeatType {
+                        HStack(spacing: 4) {
+                            Text("반복 퀘스트")
+                            TagView(title: repeatType.description, tagStyle: .repeat(repeatType))
+                        }
+                    } else {
+                        Text(quest.writer)
+                    }
+                }
+                .font(.system(size: 15, weight: .regular))
+                .frame(height: quest.missionTitle.count >= 12 ? 22 : 30)
                 
                 Text(quest.missionTitle.forceCharWrapping)
-                    .font(.system(size: 18, weight: .bold))
-                    .lineLimit(2)
+                    .font(.system(size: 17, weight: .bold))
                     .kerning(-0.3)
-                    .frame(minHeight: 30)
+                    .lineLimit(2)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             
             Spacer(minLength: 0)
             
@@ -94,8 +118,9 @@ struct QuestDetailView: View {
         }
         .padding(.bottom, 7)
     }
+    
     private func statTagView(stat: XpStat, point: Int) -> some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 8) {
             Text(stat.headerText)
                 .font(.system(size: 15, weight: .bold))
                 .foregroundStyle(.gray500)
@@ -105,7 +130,6 @@ struct QuestDetailView: View {
                     RoundedRectangle(cornerRadius: 12)
                         .foregroundStyle(Color.background)
                 )
-                .padding(.bottom, 8)
             
             VStack(spacing: 0) {
                 Image(stat.image)
@@ -132,5 +156,6 @@ struct QuestDetailView: View {
 }
 
 #Preview {
-    QuestDetailView(quest: .mockData, action: { })
+    QuestDetailView(quest: .mockRepeatData, action: { })
+        .frame(height: 464)
 }

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -61,6 +61,17 @@ extension QuestViewModelItem {
         writer: "이디야커피",
         rewardDic: [.charm: 30, .intellect: 100, .fun: 5],
         type: "DEFAULT",
+        target: "NONE"
+    )
+    
+    static let mockRepeatData: QuestViewModelItem = QuestViewModelItem(
+        id: "11",
+        image: .img0,
+        imageId: mockImageId,
+        missionTitle: "아이스 아메리카노 가나잔 마시",
+        writer: "이디야커피",
+        rewardDic: [.charm: 30, .intellect: 100, .fun: 5],
+        type: "REPEAT",
         target: "DAILY"
     )
     
@@ -72,7 +83,7 @@ extension QuestViewModelItem {
             missionTitle: "아이스 카페라떼 15잔 마시기",
             writer: "이디야커피",
             rewardDic: [.charm: 3, .strength: 25],
-            type: "DEFAULT",
+            type: "REPEAT",
             target: "MONTHLY"
         ),
         QuestViewModelItem(
@@ -82,7 +93,7 @@ extension QuestViewModelItem {
             missionTitle: "하늘 사진 찍기",
             writer: "이디야커피",
             rewardDic: [.charm: 3, .fun: 25, .sociability: 20, .strength: 25],
-            type: "DEFAULT",
+            type: "REPEAT",
             target: "DAILY"
         ),
         QuestViewModelItem(
@@ -92,7 +103,7 @@ extension QuestViewModelItem {
             missionTitle: "아이스 아메리카노 15잔 마시기",
             writer: "이디야커피",
             rewardDic: [.charm: 30],
-            type: "DEFAULT",
+            type: "REPEAT",
             target: "WEEKLY"
         ),
         QuestViewModelItem(


### PR DESCRIPTION
#### close #218 

### ✏️ 개요
반복퀘스트일 경우 보여지는 퀘스트 디테일 시트를 구현했습니다.

### 💻 작업 사항
- [반복 퀘스트 디테일 시트 디자인 구현](https://github.com/TeamFair/ILSANG-iOS/commit/c9e52e6a80c7506face10e3fb76d9e7820f47708)

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/75dce0fb-163c-4aa1-815a-0ea82a0f85f1" width = "300">
