### PR TITLE
[Feat/#221] 퀘스트 탭 데이터 로딩 사용성 개선(작업 병렬 실행), 런치스크린 1.5초 유지

### DIFF
--- a/ILSANG/Sources/Service/UserService.swift
+++ b/ILSANG/Sources/Service/UserService.swift
@@ -64,7 +64,7 @@ final class UserService: ObservableObject {
     }
     
     /// 갖고 있는 토큰으로 로그인 시도
-    func login() async throws -> Bool {
+    func login() async -> Bool {
         let authUser = AuthUser(email: userEmail, accessToken: accessToken, refreshToken: refreshToken)
         if authToken.isEmpty {
             await updateLoginStatus(false)

--- a/ILSANG/Sources/Views/ILSANGApp.swift
+++ b/ILSANG/Sources/Views/ILSANGApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @main
 struct ILSANGApp: App {
     @AppStorage("isLogin") var isLogin = Bool()
+    @State private var isSplashScreenVisible = true
     
     init() {
         setTabBarAppearance()
@@ -17,26 +18,33 @@ struct ILSANGApp: App {
     
     var body: some Scene {
         WindowGroup {
-            if !isLogin {
-                LoginView(vm: LoginViewModel())
-            } else {
-                MainTabView()
-                    .task {
-                        if isLogin {
-                            await handleLogin()
-                        }
-                    }
+            ZStack {
+                if isSplashScreenVisible {
+                    SplashScreenView()
+                } else if !isLogin {
+                    LoginView(vm: LoginViewModel())
+                } else {
+                    MainTabView()
+                }
+            }
+            .task {
+                await runAppStartup()
             }
         }
     }
     
     @MainActor
-    private func handleLogin() async {
-        do {
-            isLogin = try await UserService.shared.login()
-        } catch {
-            isLogin = false
+    private func runAppStartup() async {
+        // 1. 스플래시 화면 표시
+        try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5초 대기
+        
+        // 2. 로그인 상태 확인
+        if isLogin {
+            let _ = await UserService.shared.login()
         }
+        
+        // 3. 스플래시 화면 종료
+        isSplashScreenVisible = false
     }
     
     func setTabBarAppearance() {
@@ -46,6 +54,23 @@ struct ILSANGApp: App {
         appearance.stackedItemPositioning = .centered
         UITabBar.appearance().standardAppearance = appearance
         UITabBar.appearance().scrollEdgeAppearance = appearance
+    }
+}
+
+struct SplashScreenView: View {
+    var body: some View {
+        ZStack {
+            Color.white
+                .ignoresSafeArea()
+            VStack {
+                Image(.logo) /// 런치스크린에서 사용한 이미지
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 172, height: 172)
+                    .offset(y: -8)
+                    .ignoresSafeArea()
+            }
+        }
     }
 }
 

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -127,9 +127,10 @@ class QuestViewModel: ObservableObject {
     
     func loadInitialData() async {
         await changeViewStatus(.loading)
-        await defaultPaginationManager.loadData(isRefreshing: true)
-        await repeatPaginationManager.loadData(isRefreshing: true)
-        await completedPaginationManager.loadData(isRefreshing: true)
+        async let defaultLoad: () = defaultPaginationManager.loadData(isRefreshing: true)
+        async let repeatLoad: () = repeatPaginationManager.loadData(isRefreshing: true)
+        async let completedLoad: () = completedPaginationManager.loadData(isRefreshing: true)
+        _ = await (defaultLoad, repeatLoad, completedLoad)
         await changeViewStatus(.loaded)
     }
     


### PR DESCRIPTION
#### close #221 

### ✏️ 개요
앱 초기화 시` 로그인 > 유저정보 조회 > 퀘스트 데이터 조회` 순서로 api 실행이 보장되도록 개선했습니다.
현재 퀘스트탭의 일반,반복,미완료 퀘스트를 순차적으로 불러오고 있어, 퀘스트 탭의 로딩이 오래 걸리는 문제를 각 태스크가`병렬로 처리`되도록 수정했습니다.
또한, 데이터 로딩에 비해 런치 스크린이 매우 짧아 더 오래 걸리는 경험을 준다고 생각하여, `런치스크린을 1.5초 유지`하도록 임시로 수정합니다.

### 💻 작업 사항
- 앱 초기화 api 실행 순서 개선( **로그인 > 유저정보 조회 > 퀘스트 데이터 조회**)
- 퀘스트 탭 초기 api 병렬 실행
- 런치스크린 1.5초 유지된 후 로그인 상태에 따른 화면 표시되도록 수정

<img width="300" alt="image" src="https://github.com/user-attachments/assets/be0bd70f-bd1d-464e-9e2f-1d75fc7f3e02" />
