### PR TITLE
[Design/#234] 마이탭 도전 목록에서 이미지 표시

### DIFF
--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Challenge: Decodable {
+struct Challenge: Decodable, Hashable {
     let challengeId: String
     let userNickName: String?
     let missionTitle: String?

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -40,3 +40,35 @@ struct MyPageActiveList: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
+
+struct MyPageListItemView: View {
+    let title: String
+    let detail: String
+    let point: Int?
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundColor(.black)
+                Text(detail)
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundColor(.gray500)
+            }
+            
+            Spacer()
+            
+            if let point = point {
+                Text("\(point > 0 ? "+\(point)" : "\(point)")XP")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(Color.accentColor)
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .foregroundColor(.white)
+        )
+    }
+}

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
@@ -17,6 +17,12 @@ struct ChallengeDetailView: View {
     
     let challengeData : Challenge
     
+    init(vm: MyPageViewModel, missionImage: UIImage?, challengeData: Challenge) {
+        self.vm = vm
+        self._missionImage = State(initialValue: missionImage)
+        self.challengeData = challengeData
+    }
+    
     var body: some View {
         VStack(spacing: 0) {
             NavigationTitleView(title: "챌린지 정보", isSeparatorHidden: false) {
@@ -40,7 +46,6 @@ struct ChallengeDetailView: View {
         .background(Color.background)
         .navigationBarBackButtonHidden()
         .task {
-            missionImage = await vm.getImage(imageId: challengeData.receiptImageId)
             if let questImageId = challengeData.questImageId {
                 self.questImage = await vm.getImage(imageId: questImageId)
             }
@@ -174,7 +179,8 @@ struct ChallengeImageView: View {
                     imageNetwork: ImageNetwork(),
                     xpNetwork: XPNetwork()
                 ),
-                challengeData: Challenge.challengeMockData
+                missionImage: .logo,
+                challengeData: .challengeMockData
             )
         }
         .tabItem {

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -11,28 +11,25 @@ struct MyPageChallengeList: View {
     @ObservedObject var vm: MyPageViewModel
     
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                Text("수행한 챌린지")
-                    .font(.system(size: 14))
-                    .fontWeight(.medium)
-                    .foregroundColor(.gray400)
-                
-                Spacer()
-            }
-
+        VStack(alignment: .leading, spacing: 8) {
+            Text("수행한 챌린지")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.gray400)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            
             ScrollView {
-                VStack(spacing: 12) {
-                    ForEach(vm.challengeList, id: \.challengeId) { challenge in
-                        NavigationLink(destination: ChallengeDetailView(vm: vm, challengeData: challenge)) {
-                            MyPageListItemView(title: challenge.missionTitle ?? "챌린지명", detail: challenge.createdAt.timeAgoCreatedAt(), point: nil)
+                VStack(spacing: 9) {
+                    ForEach(vm.challengeList, id: \.challenge) { challenge in
+                        NavigationLink(destination: ChallengeDetailView(vm: vm, missionImage: challenge.image, challengeData: challenge.challenge)) {
+                            challengeListItemView(challenge: challenge.challenge, image: challenge.image)
                         }
                     }
                 }
-                .padding(.bottom, 60)
+                .padding(.top, 12)
+                .padding(.bottom, 72)
             }
             .refreshable {
-                await vm.getChallenges(page: 0)
+                await vm.fetchChallengesWithImages(page: 0)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -42,36 +39,53 @@ struct MyPageChallengeList: View {
             }
         }
     }
+    
+    private func challengeListItemView(challenge: Challenge, image: UIImage?) -> some View {
+        ZStack {
+            Group {
+                if let image = image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    Image(uiImage: .logoWithAlpha)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 100)
+                }
+            }
+            .scaledToFill()
+            .frame(height: 172)
+            .frame(maxWidth: .infinity)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .frame(height: 85)
+                    .foregroundStyle(
+                        .linearGradient(
+                            colors: [.clear, .black.opacity(0.8)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            
+            VStack(alignment: .leading, spacing: 6) {
+                Spacer()
+                Text(challenge.missionTitle ?? "")
+                    .font(.system(size: 23, weight: .bold))
+                    .foregroundColor(.white)
+                
+                Text(challenge.createdAt.timeAgoCreatedAt())
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundColor(.gray200)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+        }
+    }
 }
 
-struct MyPageListItemView: View {
-    let title: String
-    let detail: String
-    let point: Int?
-    
-    var body: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(title)
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundColor(.black)
-                Text(detail)
-                    .font(.system(size: 13, weight: .regular))
-                    .foregroundColor(.gray500)
-            }
-            
-            Spacer()
-            
-            if let point = point {
-                Text("\(point > 0 ? "+\(point)" : "\(point)")XP")
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(Color.accentColor)
-            }
-        }
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .foregroundColor(.white)
-        )
-    }
+#Preview {
+    MyPageChallengeList(vm: MyPageViewModel(userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork()))
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageTabView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageTabView.swift
@@ -21,7 +21,7 @@ struct MyPageTabView: View {
                 }
             }
         }
-        .padding(.vertical, 16)
+        .padding(.vertical, 20)
     }
 }
 

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -26,7 +26,7 @@ struct MyPageView: View {
             // 2) 도전내역 등록했을 때, 리프레시했을 때 재호출하도록 수정
             await vm.getUser()
             await vm.getXpStat()
-            await vm.getChallenges(page: 0)
+            await vm.fetchChallengesWithImages(page: 0)
             await vm.getXpLog(page: 0, size: 10)
         }
     }


### PR DESCRIPTION
#### close #234 

### ✏️ 개요
마이탭 목록에서 도전내역 이미지를 바로 볼 수 있도록 개선합니다.

### 💻 작업 사항
- 도전내역 이미지 호출부 구현
- 도전내역 목록 레이아웃 변경

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/eef73d2a-bb54-469d-a87e-b956a6bdfabb" width = "300">

https://github.com/user-attachments/assets/a51ff065-58df-4fb9-985e-2131871e966e

