### PR TITLE
[Feat/#237] 탑텐 유저 조회 API 연결, Rank 관련 리팩토링

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189262C3F00FB0070F2AD /* AuthChannel.swift */; };
 		601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189282C3F022D0070F2AD /* LoginViewModel.swift */; };
 		6028A94A2D39721F003FBC8C /* RankNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6028A9492D39721F003FBC8C /* RankNetwork.swift */; };
+		6028A94C2D397730003FBC8C /* TopRank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6028A94B2D39772F003FBC8C /* TopRank.swift */; };
 		6029881E2D041D3900903806 /* QuestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029881D2D041D3900903806 /* QuestStatus.swift */; };
 		602988202D041D4700903806 /* XpStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029881F2D041D4700903806 /* XpStat.swift */; };
 		602988222D041DDC00903806 /* RepeatType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602988212D041DDC00903806 /* RepeatType.swift */; };
@@ -85,7 +86,7 @@
 		60C6B4DF2C2D053600926C0E /* SubmitRouterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */; };
 		60C6B4E12C2D1C0100926C0E /* SubmitAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4E02C2D1C0100926C0E /* SubmitAlertViewModel.swift */; };
 		60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DADF542C6B4EC7001A0B3A /* Data++.swift */; };
-		60E258052D09CE1B0052C048 /* Rank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E258042D09CE1B0052C048 /* Rank.swift */; };
+		60E258052D09CE1B0052C048 /* StatRank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E258042D09CE1B0052C048 /* StatRank.swift */; };
 		60FB50CD2D15CEAE00C55E82 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FB50CC2D15CEAE00C55E82 /* HomeView.swift */; };
 		9FE63D6C2CB3A58800CA7940 /* RankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE63D6B2CB3A57B00CA7940 /* RankingView.swift */; };
 		9FE63D702CB3AAF100CA7940 /* RankingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE63D6F2CB3AAE900CA7940 /* RankingViewModel.swift */; };
@@ -156,6 +157,7 @@
 		601189262C3F00FB0070F2AD /* AuthChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthChannel.swift; sourceTree = "<group>"; };
 		601189282C3F022D0070F2AD /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		6028A9492D39721F003FBC8C /* RankNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankNetwork.swift; sourceTree = "<group>"; };
+		6028A94B2D39772F003FBC8C /* TopRank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopRank.swift; sourceTree = "<group>"; };
 		6029881D2D041D3900903806 /* QuestStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestStatus.swift; sourceTree = "<group>"; };
 		6029881F2D041D4700903806 /* XpStat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpStat.swift; sourceTree = "<group>"; };
 		602988212D041DDC00903806 /* RepeatType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatType.swift; sourceTree = "<group>"; };
@@ -228,7 +230,7 @@
 		60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterViewModel.swift; sourceTree = "<group>"; };
 		60C6B4E02C2D1C0100926C0E /* SubmitAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitAlertViewModel.swift; sourceTree = "<group>"; };
 		60DADF542C6B4EC7001A0B3A /* Data++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data++.swift"; sourceTree = "<group>"; };
-		60E258042D09CE1B0052C048 /* Rank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rank.swift; sourceTree = "<group>"; };
+		60E258042D09CE1B0052C048 /* StatRank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatRank.swift; sourceTree = "<group>"; };
 		60FB50CC2D15CEAE00C55E82 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		9FE63D6B2CB3A57B00CA7940 /* RankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingView.swift; sourceTree = "<group>"; };
 		9FE63D6F2CB3AAE900CA7940 /* RankingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingViewModel.swift; sourceTree = "<group>"; };
@@ -307,7 +309,8 @@
 				60C6B4D62C2C569800926C0E /* Challenge.swift */,
 				60924DC82C48C00E00221072 /* Quest.swift */,
 				6011891E2C3E94380070F2AD /* AuthUser.swift */,
-				60E258042D09CE1B0052C048 /* Rank.swift */,
+				60E258042D09CE1B0052C048 /* StatRank.swift */,
+				6028A94B2D39772F003FBC8C /* TopRank.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -899,8 +902,9 @@
 				6061327B2CDB33FD00830948 /* FilterPicker.swift in Sources */,
 				A19628752C08648C0037C53A /* NavigationTitleView.swift in Sources */,
 				A1AB3D5D2C113A70001EB9D8 /* LoginView.swift in Sources */,
+				6028A94C2D397730003FBC8C /* TopRank.swift in Sources */,
 				606C21CC2CC6B4FC00803947 /* SubmitStatusView.swift in Sources */,
-				60E258052D09CE1B0052C048 /* Rank.swift in Sources */,
+				60E258052D09CE1B0052C048 /* StatRank.swift in Sources */,
 				A196286F2C0859910037C53A /* DeleteAccountView.swift in Sources */,
 				6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */,
 				601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */,

--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189222C3E95D40070F2AD /* AuthNetwork.swift */; };
 		601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189262C3F00FB0070F2AD /* AuthChannel.swift */; };
 		601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189282C3F022D0070F2AD /* LoginViewModel.swift */; };
+		6028A94A2D39721F003FBC8C /* RankNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6028A9492D39721F003FBC8C /* RankNetwork.swift */; };
 		6029881E2D041D3900903806 /* QuestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029881D2D041D3900903806 /* QuestStatus.swift */; };
 		602988202D041D4700903806 /* XpStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029881F2D041D4700903806 /* XpStat.swift */; };
 		602988222D041DDC00903806 /* RepeatType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602988212D041DDC00903806 /* RepeatType.swift */; };
@@ -154,6 +155,7 @@
 		601189222C3E95D40070F2AD /* AuthNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNetwork.swift; sourceTree = "<group>"; };
 		601189262C3F00FB0070F2AD /* AuthChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthChannel.swift; sourceTree = "<group>"; };
 		601189282C3F022D0070F2AD /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		6028A9492D39721F003FBC8C /* RankNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankNetwork.swift; sourceTree = "<group>"; };
 		6029881D2D041D3900903806 /* QuestStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestStatus.swift; sourceTree = "<group>"; };
 		6029881F2D041D4700903806 /* XpStat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpStat.swift; sourceTree = "<group>"; };
 		602988212D041DDC00903806 /* RepeatType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatType.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 				600211EF2C1EF3F5000CC02E /* Base */,
 				601189222C3E95D40070F2AD /* AuthNetwork.swift */,
 				600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */,
+				6028A9492D39721F003FBC8C /* RankNetwork.swift */,
 				A1FF916D2C250C3B00F03E4B /* UserNetwork.swift */,
 				A1FF916F2C25119200F03E4B /* XPNetwork.swift */,
 				A18EB9B12C26B62E00405D56 /* LogoutNetwork.swift */,
@@ -968,6 +971,7 @@
 				607FCBD62BFA660C00BB2D04 /* MainTabView.swift in Sources */,
 				603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */,
 				6053345C2D31182500599159 /* XpLevelCalculator.swift in Sources */,
+				6028A94A2D39721F003FBC8C /* RankNetwork.swift in Sources */,
 				605DA0D12C0711CA00CC9450 /* CameraView.swift in Sources */,
 				A1FF91702C25119200F03E4B /* XPNetwork.swift in Sources */,
 				A1BB602C2BFF145100AAADD4 /* MyPageProfile.swift in Sources */,

--- a/ILSANG/Sources/Model/StatRank.swift
+++ b/ILSANG/Sources/Model/StatRank.swift
@@ -12,8 +12,10 @@ struct StatRank: Decodable {
     let nickname: String
 }
 
-struct TopRank: Decodable {
-    let lank: Int
-    let xpSum: Int
-    let nickname: String
+extension StatRank {
+    static let mockDataList: [StatRank] = [
+        StatRank(xpType: "CHARM", xpPoint: 200, customerId: "1234-5678-91011", nickname: "TestUser1"),
+        StatRank(xpType: "STRENGTH", xpPoint: 150, customerId: "2234-5678-91011", nickname: "TestUser2"),
+        StatRank(xpType: "CHARM", xpPoint: 300, customerId: "3234-5678-91011", nickname: "TestUser3")
+    ]
 }

--- a/ILSANG/Sources/Model/StatRank.swift
+++ b/ILSANG/Sources/Model/StatRank.swift
@@ -5,9 +5,15 @@
 //  Created by Lee Jinhee on 12/11/24.
 //
 
-struct Rank: Decodable {
+struct StatRank: Decodable {
     let xpType: String
     let xpPoint: Int
     let customerId: String
+    let nickname: String
+}
+
+struct TopRank: Decodable {
+    let lank: Int
+    let xpSum: Int
     let nickname: String
 }

--- a/ILSANG/Sources/Model/TopRank.swift
+++ b/ILSANG/Sources/Model/TopRank.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct TopRank: Decodable {
+    let lank: Int
+    let xpSum: Int
+    let nickname: String
+}

--- a/ILSANG/Sources/Model/TopRank.swift
+++ b/ILSANG/Sources/Model/TopRank.swift
@@ -1,0 +1,8 @@
+//
+//  TopRank.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 1/17/25.
+//
+
+import Foundation

--- a/ILSANG/Sources/Network/RankNetwork.swift
+++ b/ILSANG/Sources/Network/RankNetwork.swift
@@ -1,0 +1,23 @@
+//
+//  RankNetwork.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 1/17/25.
+//
+
+import Alamofire
+
+final class RankNetwork {
+    private let openRankUrl = APIManager.makeURL(OpenTarget(path: "v1/rank/top-users"))
+    private let statRankUrl = APIManager.makeURL(CustomerTarget(path: "rank"))
+    
+    func getTopUserRank() async -> Result<Response<[TopUserRank]>, Error> {
+        let parameters: Parameters = ["limit": 10]
+        return await Network.requestData(url: openRankUrl, method: .get, parameters: parameters, withToken: false)
+    }
+    
+    func getRankByStat(xpstat: String) async -> Result<Response<[Rank]>, Error> {
+        let parameters: Parameters = ["xpType":xpstat, "size": 20]
+        return await Network.requestData(url: statRankUrl, method: .get, parameters: parameters, withToken: true)
+    }
+}

--- a/ILSANG/Sources/Network/RankNetwork.swift
+++ b/ILSANG/Sources/Network/RankNetwork.swift
@@ -11,12 +11,12 @@ final class RankNetwork {
     private let openRankUrl = APIManager.makeURL(OpenTarget(path: "v1/rank/top-users"))
     private let statRankUrl = APIManager.makeURL(CustomerTarget(path: "rank"))
     
-    func getTopUserRank() async -> Result<Response<[TopUserRank]>, Error> {
+    func getTopUserRank() async -> Result<Response<[TopRank]>, Error> {
         let parameters: Parameters = ["limit": 10]
         return await Network.requestData(url: openRankUrl, method: .get, parameters: parameters, withToken: false)
     }
     
-    func getRankByStat(xpstat: String) async -> Result<Response<[Rank]>, Error> {
+    func getRankByStat(xpstat: String) async -> Result<Response<[StatRank]>, Error> {
         let parameters: Parameters = ["xpType":xpstat, "size": 20]
         return await Network.requestData(url: statRankUrl, method: .get, parameters: parameters, withToken: true)
     }

--- a/ILSANG/Sources/Network/UserNetwork.swift
+++ b/ILSANG/Sources/Network/UserNetwork.swift
@@ -29,7 +29,7 @@ final class UserNetwork {
         }
     }
     
-    func getUserRank(xpstat: String) async -> Result<Response<[Rank]>, Error> {
+    func getUserRank(xpstat: String) async -> Result<Response<[StatRank]>, Error> {
         let parameters: Parameters = ["xpType":xpstat, "size": 20]
         
         return await Network.requestData(url: rankUrl, method: .get, parameters: parameters, withToken: true)

--- a/ILSANG/Sources/Network/UserNetwork.swift
+++ b/ILSANG/Sources/Network/UserNetwork.swift
@@ -10,7 +10,6 @@ import Alamofire
 
 final class UserNetwork {
     private let url = APIManager.makeURL(CustomerTarget(path: "user"))
-    private let rankUrl = APIManager.makeURL(CustomerTarget(path: "rank"))
     
     func getUser() async -> Result<Response<User>, Error> {
         return await Network.requestData(url: url, method: .get, parameters: nil, withToken: true)
@@ -27,11 +26,5 @@ final class UserNetwork {
         case.failure:
             return false
         }
-    }
-    
-    func getUserRank(xpstat: String) async -> Result<Response<[StatRank]>, Error> {
-        let parameters: Parameters = ["xpType":xpstat, "size": 20]
-        
-        return await Network.requestData(url: rankUrl, method: .get, parameters: parameters, withToken: true)
     }
 }

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -228,8 +228,7 @@ struct HomeView: View {
                 ScrollView(.horizontal) {
                     HStack(spacing: 8) {
                         ForEach(Array(vm.userRankList.enumerated()), id: \.offset) { idx, rank in
-                            let rank = Rank(xpType: "", xpPoint: rank.xpSum, customerId: "", nickname: rank.nickname)
-                            RankingItemView(idx: idx + 1, rank: rank, style: .vertical)
+                            RankingItemView(topRank: rank, style: .vertical)
                         }
                     }
                     .padding(.horizontal, LayoutConstants.horizontalPadding)

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct HomeView: View {
-    @StateObject var vm: HomeViewModel = HomeViewModel(questNetwork: QuestNetwork())
+    @StateObject var vm: HomeViewModel = HomeViewModel(questNetwork: QuestNetwork(), rankNetwork: RankNetwork())
     @EnvironmentObject var sharedState: SharedState
     @Environment(\.redactionReasons) var redactionReasons
     
@@ -228,6 +228,7 @@ struct HomeView: View {
                 ScrollView(.horizontal) {
                     HStack(spacing: 8) {
                         ForEach(Array(vm.userRankList.enumerated()), id: \.offset) { idx, rank in
+                            let rank = Rank(xpType: "", xpPoint: rank.xpSum, customerId: "", nickname: rank.nickname)
                             RankingItemView(idx: idx + 1, rank: rank, style: .vertical)
                         }
                     }

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -22,13 +22,7 @@ final class HomeViewModel: ObservableObject {
             return "추천 퀘스트"
         }
     }
-    @Published var userRankList: [Rank] = [
-        .init(xpType: "", xpPoint: 1220, customerId: "", nickname: "유저ABC"),
-        .init(xpType: "", xpPoint: 20, customerId: "", nickname: "유저123456"),
-        .init(xpType: "",xpPoint: 700, customerId: "", nickname: "일상999"),
-        .init(xpType: "", xpPoint: 50, customerId: "", nickname: "유저939393"),
-        .init(xpType: "", xpPoint: 20, customerId: "", nickname: "일상0213493")
-    ] // 10개
+    @Published var userRankList: [TopUserRank] = [] // 10개
     @Published var largestRewardQuestList: [XpStat: [QuestViewModelItem]] = [:] // 3*5개
     @Published var recommendQuestList: [QuestViewModelItem] = [] //QuestViewModelItem.mockQuestList // 10개
     @Published var popularQuestList: [QuestViewModelItem] = QuestViewModelItem.mockQuestList // 4n개
@@ -56,12 +50,14 @@ final class HomeViewModel: ObservableObject {
     @Published var showLargestRewardQuest: Bool = true
     @Published var showRecommendRewardQuest: Bool = true
     @Published var showPopularRewardQuest: Bool = true
-    @Published var showRankList = false
+    @Published var showRankList = true
     
     private let questNetwork: QuestNetwork
+    private let rankNetwork: RankNetwork
     
-    init(questNetwork: QuestNetwork) {
+    init(questNetwork: QuestNetwork, rankNetwork: RankNetwork) {
         self.questNetwork = questNetwork
+        self.rankNetwork = rankNetwork
         Task {
             await loadInitialData()
         }
@@ -71,10 +67,16 @@ final class HomeViewModel: ObservableObject {
     func loadInitialData() async {
         self.errorCnt = 0
         changeViewStatus(.loading)
+        self.showPopularRewardQuest = true
+        self.showRecommendRewardQuest = true
+        self.showLargestRewardQuest = true
+        self.showRankList = true
+
         await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 do {
                     try await self.loadPopularQuestList()
+                    self.showPopularRewardQuest = true
                 } catch {
                     Log("Failed to load popular quests: \(error.localizedDescription)")
                     self.errorCnt += 1
@@ -100,8 +102,18 @@ final class HomeViewModel: ObservableObject {
                 }
             }
             
-            // TODO: 랭킹 API 호출
+            group.addTask {
+                do {
+                    try await self.loadRankList()
+                } catch {
+                    Log("Failed to load large reward quests: \(error.localizedDescription)")
+                    self.errorCnt += 1
+                    self.showRankList = false
+
+                }
+            }
         }
+        
         if errorCnt >= 3 {
             // changeViewStatus(.error) // v1.3.0 이후 적용
             // return
@@ -149,6 +161,18 @@ final class HomeViewModel: ObservableObject {
                 self.largestRewardQuestList[stat] = quests.map { QuestViewModelItem(quest: $0) }
                 await cacheImages(for: &largestRewardQuestList[stat, default: []], getWriterImage: true)
             }
+        case .failure(let error):
+            throw error
+        }
+    }  
+    
+    @MainActor
+    func loadRankList() async throws {
+        let res = await rankNetwork.getTopUserRank()
+        
+        switch res {
+        case .success(let rank):
+            self.userRankList = rank.data
         case .failure(let error):
             throw error
         }

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -22,7 +22,7 @@ final class HomeViewModel: ObservableObject {
             return "추천 퀘스트"
         }
     }
-    @Published var userRankList: [TopUserRank] = [] // 10개
+    @Published var userRankList: [TopRank] = [] // 10개
     @Published var largestRewardQuestList: [XpStat: [QuestViewModelItem]] = [:] // 3*5개
     @Published var recommendQuestList: [QuestViewModelItem] = [] //QuestViewModelItem.mockQuestList // 10개
     @Published var popularQuestList: [QuestViewModelItem] = QuestViewModelItem.mockQuestList // 4n개
@@ -76,7 +76,6 @@ final class HomeViewModel: ObservableObject {
             group.addTask {
                 do {
                     try await self.loadPopularQuestList()
-                    self.showPopularRewardQuest = true
                 } catch {
                     Log("Failed to load popular quests: \(error.localizedDescription)")
                     self.errorCnt += 1
@@ -199,6 +198,7 @@ final class HomeViewModel: ObservableObject {
     }
     
     /// getWriterImage, getMainImage 중 가져올 이미지 타입을 true로 설정
+    @MainActor
     func cacheImages(for quests: inout [QuestViewModelItem], getWriterImage: Bool = false, getMainImage: Bool = false) async {
         await withTaskGroup(of: (Int, UIImage?).self) { group in
             for (index, quest) in quests.enumerated() {

--- a/ILSANG/Sources/Views/Ranking/RankingItemView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingItemView.swift
@@ -7,8 +7,14 @@
 
 import SwiftUI
 
-struct RankingItemView: View {
+struct Rank {
     let idx: Int
+    let nickname: String
+    var xpType: String? = nil
+    let score: Int
+}
+
+struct RankingItemView: View {
     let rank: Rank
     let style: RankingItemStyle
     
@@ -17,23 +23,33 @@ struct RankingItemView: View {
         case vertical
     }
     
+    init(topRank: TopRank, style: RankingItemStyle) {
+        self.rank = Rank(idx: topRank.lank, nickname: topRank.nickname, score: topRank.xpSum)
+        self.style = style
+    }
+    
+    init(idx: Int, statRank: StatRank, style: RankingItemStyle) {
+        self.rank = Rank(idx: idx, nickname: statRank.nickname, xpType: statRank.xpType, score: statRank.xpPoint)
+        self.style = style
+    }
+    
     var body: some View {
         switch style {
         case .horizontal:
-            RankingHorizontalItemView(idx: idx, rank: rank)
+            RankingHorizontalItemView(rank: rank)
         case .vertical:
-            RankingVerticalItemView(idx: idx, rank: rank)
+            RankingVerticalItemView(rank: rank)
         }
     }
 }
 
 fileprivate struct RankingHorizontalItemView: View {
-    let idx: Int
     let rank: Rank
     
     var body: some View {
         HStack(spacing: 0) {
             // 랭킹 아이콘 & 순위
+            let idx = rank.idx
             if idx <= 3 {
                 Image("rank\(idx)")
                     .resizable()
@@ -56,9 +72,16 @@ fileprivate struct RankingHorizontalItemView: View {
             VStack (alignment: .leading, spacing: 4) {
                 Text(rank.nickname)
                     .font(.system(size: 15, weight: .bold))
-                Text("\(convertStat(rank.xpType)): \(rank.xpPoint)p")
-                    .font(.system(size: 13))
-                    .foregroundColor(.gray400)
+                
+                if let xpType = rank.xpType {
+                    Text("\(convertStat(xpType)) : \(rank.score)p")
+                        .font(.system(size: 13))
+                        .foregroundColor(.gray400)
+                } else {
+                    Text("\(rank.score)p")
+                        .font(.system(size: 13))
+                        .foregroundColor(.gray400)
+                }
             }
             
             Spacer(minLength: 0)
@@ -91,7 +114,6 @@ extension RankingHorizontalItemView {
 
 
 fileprivate struct RankingVerticalItemView: View {
-    let idx: Int
     let rank: Rank
     
     var body: some View {
@@ -105,6 +127,7 @@ fileprivate struct RankingVerticalItemView: View {
                 .padding(6)
             
             // 랭킹 아이콘 & 순위
+            let idx = rank.idx
             if idx <= 3 {
                 Image("rank\(idx)")
                     .resizable()
@@ -120,7 +143,7 @@ fileprivate struct RankingVerticalItemView: View {
                 .font(.system(size: 13, weight: .bold))
                 .foregroundColor(.black)
             
-            Text("\(rank.xpPoint)xp")
+            Text("\(rank.score)xp")
                 .font(.system(size: 13))
                 .foregroundColor(.gray500)
         }

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -72,7 +72,7 @@ extension RankingView {
             LazyVStack(spacing: 12) {
                 if let ranks = vm.userRank[vm.selectedXpStat] {
                     ForEach(Array(ranks.enumerated()), id: \.element.customerId) { idx, rank in
-                        RankingItemView(idx: idx + 1, rank: rank, style: .horizontal)
+                        RankingItemView(idx: idx + 1, statRank: rank, style: .horizontal)
                     }
                 }
             }

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -9,23 +9,11 @@ import SwiftUI
 
 struct RankingView: View {
     
-    @StateObject var vm = RankingViewModel(userNetwork: UserNetwork())
-    @Namespace private var namespace
+    @StateObject var vm = RankingViewModel(rankNetwork: RankNetwork())
     
     var body: some View {
         VStack (spacing: 0){
-            //HeaderView
-            HStack {
-                Text("랭킹")
-                    .font(.system(size: 21))
-                    .fontWeight(.bold)
-                    .foregroundColor(.gray500)
-                
-                Spacer()
-            }
-            .frame(height: 50)
-            .padding(.horizontal, 20)
-            
+            headerView
             subHeaderView
             
             switch vm.viewStatus {
@@ -40,13 +28,25 @@ struct RankingView: View {
             }
         }
         .background(Color.background)
-        .task {
-            await vm.loadAllUserRank()
+        .onChange(of: vm.selectedXpStat) { _, newValue in
+            Task {
+                await vm.loadRankIfNeeded(xpStat: newValue)
+            }
         }
     }
 }
 
 extension RankingView {
+    private var headerView: some View {
+        Text("랭킹")
+            .font(.system(size: 21, weight: .bold))
+            .fontWeight(.bold)
+            .foregroundColor(.gray500)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 50)
+            .padding(.horizontal, 20)
+    }
+    
     private var subHeaderView: some View {
         StatHeaderView(
             selectedXpStat: $vm.selectedXpStat,
@@ -54,17 +54,6 @@ extension RankingView {
             height: 44,
             hasBottomLine: true
         )
-    }
-    
-    private var networkErrorView: some View {
-        ErrorView(
-            systemImageName: "wifi.exclamationmark",
-            title: "네트워크 연결 상태를 확인해주세요",
-            subTitle: "네트워크 연결 상태가 좋지 않아\n랭킹을 불러올 수 없어요",
-            emoticon: "🥲"
-        ) {
-            Task { await vm.loadUserRank(xpStat: vm.selectedXpStat) }
-        }
     }
     
     private var rankingListView: some View {
@@ -82,8 +71,19 @@ extension RankingView {
         .animation(nil, value: vm.selectedXpStat)
         .refreshable {
             Task {
-                await vm.loadUserRank(xpStat: vm.selectedXpStat)
+                await vm.fetchAndStoreUserRank(xpStat: vm.selectedXpStat)
             }
+        }
+    }
+    
+    private var networkErrorView: some View {
+        ErrorView(
+            systemImageName: "wifi.exclamationmark",
+            title: "네트워크 연결 상태를 확인해주세요",
+            subTitle: "네트워크 연결 상태가 좋지 않아\n랭킹을 불러올 수 없어요",
+            emoticon: "🥲"
+        ) {
+            Task { await vm.loadRankIfNeeded(xpStat: vm.selectedXpStat) }
         }
     }
 }

--- a/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
@@ -18,13 +18,8 @@ class RankingViewModel: ObservableObject {
     
     @Published var viewStatus: ViewStatus = .loading
     @Published var selectedXpStat: XpStat = .strength
-    @Published var userRank: [XpStat: [Rank]] = Dictionary(uniqueKeysWithValues: XpStat.allCases.map { ($0, []) })
-    @Published var mokData: [Rank] = [
-        Rank(xpType: "CHARM", xpPoint: 200, customerId: "1234-5678-91011", nickname: "TestUser1"),
-        Rank(xpType: "STRENGTH", xpPoint: 150, customerId: "2234-5678-91011", nickname: "TestUser2"),
-        Rank(xpType: "CHARM", xpPoint: 300, customerId: "3234-5678-91011", nickname: "TestUser3")
-    ]
-    
+    @Published var userRank: [XpStat: [StatRank]] = Dictionary(uniqueKeysWithValues: XpStat.allCases.map { ($0, []) })
+   
     private let userNetwork: UserNetwork
     
     init(userNetwork: UserNetwork) {


### PR DESCRIPTION
#### close #237 

### ✏️ 개요
홈화면에 보여줄 탑텐 유저 조회 API를 연결했습니다.
랭킹과 관련한 부분을 리팩토링했습니다.

### 💻 작업 사항
- 탑텐 사용자 조회 API 연결, HomeView 표시
- 기존 랭킹 모델 리팩토링
- RankingView, RankingViewModel 리팩토링

### 📄 리뷰 노트

#### 1. 랭킹 모델 리팩토링 
- 서버에서 랭킹과 관련해서 받아오는 엔티티를 StatRank, TopRank 두가지 모델로 구분.
- 앱 내에서 UI를 보여주기 위한 공통 데이터모델인 Rank 모델 수정.
- StatRank, TopRank 두 모델 전부 Rank모델로 매핑하는 부분 추가.

#### 2. RankingViewModel API 호출 횟수 개선

- **[데이터 로드 방식 AS-IS]**
  - 뷰 onAppear >> 5가지 스탯에 대한 API 호출
  - 리로드 >> 선택된 스탯에 대한 API 호출

- **[데이터 로드 방식 TO-BE]**
  - 뷰모델 초기화 >>, 초기 스탯에 대한 랭킹 불러옴
  - 선택된 스탯 변경 >> 불러왔던 데이터가 있는지 확인한 후 선택된 스탯에 대한 API 호출
  - 리로드 >> 선택된 스탯에 대한 API 호출

### 📱결과 화면(optional)
<img width="424" alt="스크린샷 2025-01-18 오전 2 33 18" src="https://github.com/user-attachments/assets/53bdc89b-b384-44c9-8da1-7f90372b215a" />

