### PR TITLE
[Design/#234] 마이탭 도전 목록에서 이미지 표시 (추가 수정)

### DIFF
--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -67,6 +67,7 @@ struct MyPageChallengeList: View {
                             endPoint: .bottom
                         )
                     )
+                    .opacity(image == nil ? 0.3 : 1)
             }
             .clipShape(RoundedRectangle(cornerRadius: 12))
             

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -105,7 +105,9 @@ final class MyPageViewModel: ObservableObject {
     
     @MainActor
     private func updateChallengeImage(at index: Int, with image: UIImage?) {
-        self.challengeList[index].1 = image
+        if index < self.challengeList.count {
+            self.challengeList[index].1 = image
+        }
     }
     
     @MainActor


### PR DESCRIPTION
#### close #234 

### ✏️ 개요
마이탭 도전내역 목록과 관련한 수정사항을 반영합니다.

### 💻 작업 사항
- 마이탭 도전내역 이미지 적용 시 인덱스 에러 방지
- 이미지 못불러온 경우에 보여지는 로고에는 검정색 그라데이션을 옅게 적용하도록 수정

### 📱결과 화면(optional)
<img width="366" alt="image" src="https://github.com/user-attachments/assets/ea75584d-3f3f-44c8-aebc-4001507a82e3" />