### PR TITLE
[Feat/#242] 메인 배너 API 연동 및 UI 구현, URL 파싱을 통한 탭 이동 기능 추가

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		60004AD52D3B799700CD2254 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60004AD42D3B799700CD2254 /* Constants.swift */; };
+		60004AD72D4221F500CD2254 /* BannerNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60004AD62D4221F500CD2254 /* BannerNetwork.swift */; };
+		60004AD92D42373300CD2254 /* Banner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60004AD82D42373300CD2254 /* Banner.swift */; };
 		600211E82C1EED40000CC02E /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211E72C1EED40000CC02E /* Emoji.swift */; };
 		600211EA2C1EEE6D000CC02E /* APITarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211E92C1EEE6D000CC02E /* APITarget.swift */; };
 		600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600211EB2C1EEED7000CC02E /* APIManager.swift */; };
@@ -146,6 +148,8 @@
 
 /* Begin PBXFileReference section */
 		60004AD42D3B799700CD2254 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		60004AD62D4221F500CD2254 /* BannerNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerNetwork.swift; sourceTree = "<group>"; };
+		60004AD82D42373300CD2254 /* Banner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banner.swift; sourceTree = "<group>"; };
 		600211E72C1EED40000CC02E /* Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emoji.swift; sourceTree = "<group>"; };
 		600211E92C1EEE6D000CC02E /* APITarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITarget.swift; sourceTree = "<group>"; };
 		600211EB2C1EEED7000CC02E /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
@@ -313,6 +317,7 @@
 				6011891E2C3E94380070F2AD /* AuthUser.swift */,
 				60E258042D09CE1B0052C048 /* StatRank.swift */,
 				6028A94B2D39772F003FBC8C /* TopRank.swift */,
+				60004AD82D42373300CD2254 /* Banner.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -428,6 +433,7 @@
 			children = (
 				600211EF2C1EF3F5000CC02E /* Base */,
 				601189222C3E95D40070F2AD /* AuthNetwork.swift */,
+				60004AD62D4221F500CD2254 /* BannerNetwork.swift */,
 				600211ED2C1EEF91000CC02E /* EmojiNetwork.swift */,
 				6028A9492D39721F003FBC8C /* RankNetwork.swift */,
 				A1FF916D2C250C3B00F03E4B /* UserNetwork.swift */,
@@ -955,6 +961,7 @@
 				A1AB3D6C2C1142AA001EB9D8 /* LoginButton.swift in Sources */,
 				600D83A42C7B1FA4005C93E2 /* PaginationManager.swift in Sources */,
 				60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */,
+				60004AD92D42373300CD2254 /* Banner.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				A11D88F72C916DE500846122 /* Icon.swift in Sources */,
 				602988222D041DDC00903806 /* RepeatType.swift in Sources */,
@@ -992,6 +999,7 @@
 				A10EF9392C87292C003D78A2 /* OpenSourceInfoView.swift in Sources */,
 				604687AC2D213B890056E394 /* StatHeaderView.swift in Sources */,
 				607FCBDD2BFA686700BB2D04 /* MyPageView.swift in Sources */,
+				60004AD72D4221F500CD2254 /* BannerNetwork.swift in Sources */,
 				607FCBEB2BFE44D900BB2D04 /* IconView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1127,7 +1135,7 @@
 				);
 				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/ILSANG/Sources/Model/Banner.swift
+++ b/ILSANG/Sources/Model/Banner.swift
@@ -1,0 +1,45 @@
+//
+//  Banner.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 1/23/25.
+//
+
+import UIKit
+
+struct Banner {
+    let id: Int
+    let title: String
+    let description: String
+    let imageId: String
+    var image: UIImage?
+    
+    init(id: Int, title: String, description: String, imageId: String, image: UIImage) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.imageId = imageId
+        self.image = image
+    }
+    
+    init(from banner: BannerEntity) {
+        self.id = banner.id
+        self.title = banner.title
+        self.description = banner.description
+        self.imageId = banner.image.imageId
+        self.image = nil
+    }
+}
+
+struct BannerEntity: Decodable {
+    let id: Int
+    let title: String
+    let description: String
+    let image: BannerImage
+    let activeYn: String
+    
+    struct BannerImage: Decodable {
+        let imageId: String
+        let location: String
+    }
+}

--- a/ILSANG/Sources/Network/BannerNetwork.swift
+++ b/ILSANG/Sources/Network/BannerNetwork.swift
@@ -1,0 +1,18 @@
+//
+//  BannerNetwork.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 1/23/25.
+//
+
+import Alamofire
+import Foundation
+
+final class BannerNetwork {
+    private let url = APIManager.makeURL(OpenTarget(path: "v1/banners"))
+    
+    func getMainBanners() async -> Result<ResponseWithPage<[BannerEntity]>, Error> {
+        let parameters: Parameters = ["page": 0, "size" : 10, "titleLike": "", "descriptionLike": "", "activeYn": "Y"]
+        return await Network.requestData(url: url, method: .get, parameters: parameters, withToken: false)
+    }
+}

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct HomeView: View {
-    @StateObject var vm: HomeViewModel = HomeViewModel(questNetwork: QuestNetwork(), rankNetwork: RankNetwork())
+    @StateObject var vm: HomeViewModel = HomeViewModel(questNetwork: QuestNetwork(), rankNetwork: RankNetwork(), bannerNetwork: BannerNetwork())
     @EnvironmentObject var sharedState: SharedState
     @Environment(\.redactionReasons) var redactionReasons
     
@@ -73,7 +73,9 @@ struct HomeView: View {
     
     private var content: some View {
         LazyVStack(spacing: LayoutConstants.sectionSpacing) {
-            // TODO: 메인 배너 섹션
+            if vm.showMainBanners {
+                mainBannerSection
+            }
             if vm.showPopularRewardQuest {
                 popularQuestSection
             }
@@ -90,6 +92,29 @@ struct HomeView: View {
         .padding(.bottom, 72)
         .redacted(reason: vm.viewStatus == .loading ? .placeholder : [])
         .foregroundStyle(redactionReasons.contains(.placeholder) ? .clear: Color.gray500)
+    }
+    
+    private var mainBannerSection: some View {
+        let height: CGFloat = .screenWidth / 11 * 10
+        return TabView {
+            ForEach(Array(vm.mainBanners.enumerated()), id: \.offset) { idx, item in
+                if let bannerImage = item.image {
+                    Image(uiImage: bannerImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: height)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .onTapGesture {
+                            if let tab = vm.getTabFromURL(from: item.description) { /// 해당하는 탭으로 이동
+                                sharedState.selectedTab = tab
+                            }
+                        }
+                }
+            }
+        }
+        .frame(height: height)
+        .tabViewStyle(.page(indexDisplayMode: .never))
     }
     
     private var popularQuestSection: some View {

--- a/ILSANG/Sources/Views/Router/Tab.swift
+++ b/ILSANG/Sources/Views/Router/Tab.swift
@@ -5,7 +5,7 @@
 //  Created by Lee Jinhee on 5/20/24.
 //
 
-enum Tab: CaseIterable {
+enum Tab: String, CaseIterable {
     case home
     case quest
     case approval


### PR DESCRIPTION
#### close #242 

### ✏️ 개요
홈탭에서 사용할 메인 배너 API를 연결하고, UI 구현, 탭 이동 기능을 구현했습니다.

### 💻 작업 사항
- 배너 API 연결
- TabView 활용하여 UI 구현
- description의 URL 파싱하여 탭 이동하도록 구현 `(URL예시 - ILSANG://tab/quest)`

### 📱결과 화면(optional)
![Simulator Screen Recording - iPhone 15 Pro Max - 2025-01-23 at 18 08 05](https://github.com/user-attachments/assets/95c8b559-1eb0-4eb1-8145-cbf39353606a)
