### PR TITLE
[Design/#254] 도전내역 제출 성공 팝업 디자인 수정사항 반영(여백 및 사이즈)

### DIFF
--- a/ILSANG/Sources/Views/Quest/Submit/SubmitStatusView.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitStatusView.swift
@@ -7,10 +7,12 @@
 
 import SwiftUI
 
+// 제출 완료 상태 화면
 struct SubmitCompleteView: View {
     let totalXP: Int
     let xpStats: [XpStat: Int]
     var action: () -> ()
+    private let defaultSpacing: CGFloat = 16
     
     init(quest: QuestViewModelItem, action: @escaping ()->()) {
         self.totalXP = quest.totalRewardXP()
@@ -19,77 +21,77 @@ struct SubmitCompleteView: View {
     }
     
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: defaultSpacing) {
             Image(.arrowUpEffect)
                 .resizable()
                 .frame(width:58, height: 45)
-                .padding(.bottom, 8)
+                .padding(.bottom, -8)
             
             Text("\(totalXP)XP가 상승했어요")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(.gray500)
-                .padding(.bottom, 12)
             
-            xpStatStatusView(stats: xpStats)
-                .padding(.bottom, 12)
+            xpStatSummaryView(statValues: xpStats)
             
             PrimaryButton(title: "확인") {
                 action()
             }
-            .padding(.horizontal ,16)
         }
-        .padding(.vertical, 16)
+        .padding(defaultSpacing)
         .frame(width: 260)
         .background(
-            RoundedRectangle(cornerRadius: 20)
+            RoundedRectangle(cornerRadius: 16)
                 .foregroundStyle(.white)
         )
     }
     
-    private func xpStatStatusView(stats: [XpStat: Int]) -> some View {
+    private func xpStatSummaryView(statValues: [XpStat: Int]) -> some View {
         let stats: [[XpStat]] = [[.strength, .intellect, .charm],
                                  [.fun, .sociability]]
         
-        return VStack(spacing: 6) {
+        return VStack(spacing: 0) {
             ForEach(stats, id: \.self) { row in
-                HStack(spacing: 8) {
+                HStack(spacing: 4) {
                     ForEach(row, id: \.self) { stat in
-                        xpStatItemView(image: stat.image, value: xpStats[stat])
+                        xpStatItemView(icon: stat.image, point: statValues[stat])
                     }
                 }
             }
         }
-        .padding(4)
-        .frame(width: 200, height: 40)
+        .padding(8)
+        .frame(width: 228, height: 76)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .foregroundStyle(Color.background)
         )
     }
     
-    private func xpStatItemView(image: ImageResource, value: Int?) -> some View {
+    private func xpStatItemView(icon: ImageResource, point: Int?) -> some View {
         HStack(spacing: 0) {
-            Image(image)
+            Image(icon)
                 .resizable()
-                .frame(width: 12, height: 12)
                 .scaledToFit()
+                .frame(width: 19, height: 19)
+                .frame(width: 30, height: 30)
             
-            Text("\(value ?? 0)P")
-                .font(.system(size: 11, weight: .semibold))
+            Text("\(point ?? 0)P")
+                .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(.primaryPurple)
-                .frame(width: 30, height: 14)
-            
-            Spacer(minLength: 0)
-            
-            if let value = value, value > 0 {
+                        
+            if let point = point, point > 0 {
                 Image(.arrowUp)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 10)
+                    .padding(.leading, 2)
             }
         }
         .padding(.horizontal, 2)
-        .frame(width: 52, height: 14)
+        .frame(height: 30)
     }
 }
 
+// 제출 진행 중 & 제출 실패 상태 화면
 struct SubmitStatusView: View {
     let status: SubmitStatus
     var onConfirm: () -> ()


### PR DESCRIPTION
#### close #254

### ✏️ 개요
도전내역 제출 성공 팝업 디자인 수정 요청사항을 반영합니다.

### 💻 작업 사항
- 도전내역 제출 성공 팝업 디자인 수정

### 📱결과 화면(optional)
AS-IS
<img src = "https://github.com/user-attachments/assets/7630bdda-e6b8-4b85-9c11-5bd2c32bb676" width = "280"> 

TO-BE
<img width="300" alt="image" src="https://github.com/user-attachments/assets/040659a0-0bda-4707-b068-fc25b2c5740b" />
