### PR TITLE
[Design/#262] 폰트 스타일 가이드 추가(styledFont), 프로젝트 타겟에 폰트 추가

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -74,6 +74,11 @@
 		60943FE62C0A38FB00C8A714 /* ApprovalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */; };
 		609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */; };
 		609A76DB2CFC5E90009F4567 /* StatGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76DA2CFC5E90009F4567 /* StatGridView.swift */; };
+		60ADF9BD2D59D3FD00556958 /* FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9BC2D59D3FD00556958 /* FontStyle.swift */; };
+		60ADF9BF2D59D41E00556958 /* Font++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9BE2D59D41E00556958 /* Font++.swift */; };
+		60ADF9C22D59D47100556958 /* FontWithLineHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9C12D59D47100556958 /* FontWithLineHeight.swift */; };
+		60ADF9C62D59D6C200556958 /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1EB63392C132AC100B63F9C /* Roboto-Medium.ttf */; };
+		60ADF9C72D59D6CB00556958 /* SFPRODISPLAYREGULAR.otf in Resources */ = {isa = PBXBuildFile; fileRef = A1EB633A2C132B0800B63F9C /* SFPRODISPLAYREGULAR.otf */; };
 		60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */; };
 		60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */; };
 		60B8B9EB2BF9EEF3005F6DE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60B8B9EA2BF9EEF3005F6DE3 /* Assets.xcassets */; };
@@ -217,6 +222,9 @@
 		60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalViewModel.swift; sourceTree = "<group>"; };
 		609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestImageWithTagView.swift; sourceTree = "<group>"; };
 		609A76DA2CFC5E90009F4567 /* StatGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatGridView.swift; sourceTree = "<group>"; };
+		60ADF9BC2D59D3FD00556958 /* FontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStyle.swift; sourceTree = "<group>"; };
+		60ADF9BE2D59D41E00556958 /* Font++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font++.swift"; sourceTree = "<group>"; };
+		60ADF9C12D59D47100556958 /* FontWithLineHeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontWithLineHeight.swift; sourceTree = "<group>"; };
 		60B8B9E32BF9EEF1005F6DE3 /* ILSANG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ILSANG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANGApp.swift; sourceTree = "<group>"; };
 		60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = "<group>"; };
@@ -397,6 +405,7 @@
 				60DADF542C6B4EC7001A0B3A /* Data++.swift */,
 				608EBF9E2C39C17F00B862CC /* Dictionary++.swift */,
 				605DA0D52C07123400CC9450 /* View++.swift */,
+				60ADF9BE2D59D41E00556958 /* Font++.swift */,
 				6060B2E92C08947B0083944D /* Image++.swift */,
 				6044B71C2C32B6A4002C13A0 /* UIImage++.swift */,
 				608EBFA02C39C5BB00B862CC /* String++.swift */,
@@ -518,6 +527,7 @@
 			isa = PBXGroup;
 			children = (
 				A19628732C08647F0037C53A /* View */,
+				60ADF9C52D59D5D600556958 /* ViewModifier */,
 				607FCBE52BFD129E00BB2D04 /* Model */,
 			);
 			path = Global;
@@ -532,6 +542,7 @@
 				601189262C3F00FB0070F2AD /* AuthChannel.swift */,
 				A11D88F62C916DE500846122 /* Icon.swift */,
 				60299E302CBFFF160039663F /* TransferableUIImage.swift */,
+				60ADF9BC2D59D3FD00556958 /* FontStyle.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -544,6 +555,14 @@
 				604687AB2D213B890056E394 /* StatHeaderView.swift */,
 			);
 			path = Component;
+			sourceTree = "<group>";
+		};
+		60ADF9C52D59D5D600556958 /* ViewModifier */ = {
+			isa = PBXGroup;
+			children = (
+				60ADF9C12D59D47100556958 /* FontWithLineHeight.swift */,
+			);
+			path = ViewModifier;
 			sourceTree = "<group>";
 		};
 		60B8B9DA2BF9EEF1005F6DE3 = {
@@ -839,9 +858,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60ADF9C62D59D6C200556958 /* Roboto-Medium.ttf in Resources */,
 				60B8BA112BF9EF50005F6DE3 /* Launch Screen.storyboard in Resources */,
 				60B8B9EE2BF9EEF3005F6DE3 /* Preview Assets.xcassets in Resources */,
 				606C87B12C0CC89B002D5C3E /* 2406_TERMS_OF_USE.pdf in Resources */,
+				60ADF9C72D59D6CB00556958 /* SFPRODISPLAYREGULAR.otf in Resources */,
 				60B8B9EB2BF9EEF3005F6DE3 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -952,6 +973,7 @@
 				6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */,
 				607FCBD42BFA648000BB2D04 /* Tab.swift in Sources */,
 				6011891F2C3E94380070F2AD /* AuthUser.swift in Sources */,
+				60ADF9BD2D59D3FD00556958 /* FontStyle.swift in Sources */,
 				60299E312CBFFF160039663F /* TransferableUIImage.swift in Sources */,
 				A1FF91722C257E9A00F03E4B /* User.swift in Sources */,
 				60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */,
@@ -962,12 +984,14 @@
 				A1AB3D6C2C1142AA001EB9D8 /* LoginButton.swift in Sources */,
 				600D83A42C7B1FA4005C93E2 /* PaginationManager.swift in Sources */,
 				60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */,
+				60ADF9BF2D59D41E00556958 /* Font++.swift in Sources */,
 				60004AD92D42373300CD2254 /* Banner.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				A11D88F72C916DE500846122 /* Icon.swift in Sources */,
 				602988222D041DDC00903806 /* RepeatType.swift in Sources */,
 				A19628652C076D7B0037C53A /* SettingView.swift in Sources */,
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,
+				60ADF9C22D59D47100556958 /* FontWithLineHeight.swift in Sources */,
 				606292D82C19E70A0098B6D2 /* Network.swift in Sources */,
 				A1501B0A2C48C3E5001410E1 /* MyPageInfoView.swift in Sources */,
 				608EBFA12C39C5BB00B862CC /* String++.swift in Sources */,

--- a/ILSANG/Sources/Extension/Font++.swift
+++ b/ILSANG/Sources/Extension/Font++.swift
@@ -1,0 +1,14 @@
+//
+//  Font++.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 2/10/25.
+//
+
+import SwiftUI
+
+extension Font {
+    static func uiFont(_ weight: UIFont.Weight,_ size: CGFloat) -> UIFont {
+        return UIFont.systemFont(ofSize: size, weight: weight)
+    }
+}

--- a/ILSANG/Sources/Extension/View++.swift
+++ b/ILSANG/Sources/Extension/View++.swift
@@ -66,4 +66,26 @@ extension View {
         }
         return result
     }
+    
+    func fontWithLineHeight(_ fontWeight: UIFont.Weight, size: CGFloat, lineHeight: CGFloat, tracking: CGFloat = 0) -> some View {
+        return ModifiedContent(
+            content: self,
+            modifier: FontWithLineHeight(
+                font: Font.uiFont(fontWeight, size),
+                lineHeight: lineHeight,
+                tracking: tracking
+            )
+        )
+    }
+    
+    func fontWithLineHeight(_ fontStyle: FontStyle) -> some View {
+        return ModifiedContent(
+            content: self,
+            modifier: FontWithLineHeight(
+                font: Font.uiFont(fontStyle.weight, fontStyle.size),
+                lineHeight: fontStyle.lineHeight,
+                tracking: fontStyle.tracking
+            )
+        )
+    }
 }

--- a/ILSANG/Sources/Extension/View++.swift
+++ b/ILSANG/Sources/Extension/View++.swift
@@ -66,4 +66,26 @@ extension View {
         }
         return result
     }
+    
+    func styledFont(_ fontWeight: UIFont.Weight, size: CGFloat, lineHeight: CGFloat, tracking: CGFloat = 0) -> some View {
+        return ModifiedContent(
+            content: self,
+            modifier: FontWithLineHeight(
+                font: Font.uiFont(fontWeight, size),
+                lineHeight: lineHeight,
+                tracking: tracking
+            )
+        )
+    }
+    
+    func styledFont(_ fontStyle: FontStyle) -> some View {
+        return ModifiedContent(
+            content: self,
+            modifier: FontWithLineHeight(
+                font: Font.uiFont(fontStyle.weight, fontStyle.size),
+                lineHeight: fontStyle.lineHeight,
+                tracking: fontStyle.tracking
+            )
+        )
+    }
 }

--- a/ILSANG/Sources/Global/Model/FontStyle.swift
+++ b/ILSANG/Sources/Global/Model/FontStyle.swift
@@ -1,0 +1,42 @@
+//
+//  FontStyle.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 2/10/25.
+//
+
+import UIKit
+
+struct FontStyle {
+    let size: CGFloat
+    let weight: UIFont.Weight
+    let lineHeight: CGFloat
+    let tracking: CGFloat
+    
+    static let title1 = FontStyle(size: 23, weight: .bold, lineHeight: 24, tracking: 0)
+    static let title2 = FontStyle(size: 17, weight: .bold, lineHeight: 22, tracking: 0)
+    
+    static let heading1 = FontStyle(size: 17, weight: .bold, lineHeight: 20, tracking: -0.4)
+    static let heading2 = FontStyle(size: 15, weight: .bold, lineHeight: 18, tracking: -0.4)
+    static let heading3 = FontStyle(size: 19, weight: .bold, lineHeight: 23, tracking: -0.4)
+    
+    static let subTitle1 = FontStyle(size: 16, weight: .regular, lineHeight: 24, tracking: -0.4)
+    static let subTitle2 = FontStyle(size: 16, weight: .regular, lineHeight: 24, tracking: -0.4)
+    
+    static let caption1 = FontStyle(size: 13, weight: .regular, lineHeight: 20, tracking: -0.3)
+    static let caption2 = FontStyle(size: 12, weight: .regular, lineHeight: 16, tracking: -0.3)
+    
+    static let body = FontStyle(size: 15, weight: .regular, lineHeight: 22, tracking: -0.3)
+    
+    static let button = FontStyle(size: 16, weight: .semibold, lineHeight: 18, tracking: 0)
+    
+    static let tabBold = FontStyle(size: 14, weight: .semibold, lineHeight: 24, tracking: 0)
+    static let tabRegular = FontStyle(size: 14, weight: .regular, lineHeight: 24, tracking: 0)
+    
+    static let badge1 = FontStyle(size: 11, weight: .semibold, lineHeight: 12, tracking: 0)
+    static let badge2 = FontStyle(size: 10, weight: .semibold, lineHeight: 12, tracking: -0.3)
+    
+    func uiFont() -> UIFont {
+        return UIFont.systemFont(ofSize: size, weight: weight)
+    }
+}

--- a/ILSANG/Sources/Global/ViewModifier/FontWithLineHeight.swift
+++ b/ILSANG/Sources/Global/ViewModifier/FontWithLineHeight.swift
@@ -1,0 +1,22 @@
+//
+//  FontWithLineHeight.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 2/10/25.
+//
+
+import SwiftUI
+
+struct FontWithLineHeight: ViewModifier {
+    let font: UIFont
+    let lineHeight: CGFloat // Text의 전체 높이 (Full Height)
+    let tracking: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .font(Font(font))
+            .tracking(tracking)
+            .lineSpacing(lineHeight - font.lineHeight)
+            .padding(.vertical, (lineHeight - font.lineHeight) / 2)
+    }
+}


### PR DESCRIPTION
#### close #262 

### ✏️ 개요
폰트 스타일 가이드를 적용합니다.

### 💻 작업 사항
- 각 텍스트 스타일별로 지정된 수치를 타이틀로 접근할 수 있도록 구현
- 커스텀된 텍스트 스타일도 지원하도록 설정

<img width="340" alt="image" src="https://github.com/user-attachments/assets/887e1689-14ad-4173-882d-0908acd5074c" />
<img width="317" alt="image" src="https://github.com/user-attachments/assets/91765b3e-7f23-4223-8dbd-9e768482f6ca" />
