### PR TITLE
[Bug/#263] sheet detents 고정되지 않는 현상 해결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		60ADF9C22D59D47100556958 /* FontWithLineHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9C12D59D47100556958 /* FontWithLineHeight.swift */; };
 		60ADF9C62D59D6C200556958 /* Roboto-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1EB63392C132AC100B63F9C /* Roboto-Medium.ttf */; };
 		60ADF9C72D59D6CB00556958 /* SFPRODISPLAYREGULAR.otf in Resources */ = {isa = PBXBuildFile; fileRef = A1EB633A2C132B0800B63F9C /* SFPRODISPLAYREGULAR.otf */; };
+		60ADF9C92D5A019B00556958 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9C82D5A019A00556958 /* UIApplication.swift */; };
+		60ADF9CB2D5A01BA00556958 /* UISheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9CA2D5A01BA00556958 /* UISheetPresentationController.swift */; };
 		60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */; };
 		60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */; };
 		60B8B9EB2BF9EEF3005F6DE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60B8B9EA2BF9EEF3005F6DE3 /* Assets.xcassets */; };
@@ -227,6 +229,8 @@
 		60ADF9BC2D59D3FD00556958 /* FontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStyle.swift; sourceTree = "<group>"; };
 		60ADF9BE2D59D41E00556958 /* Font++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font++.swift"; sourceTree = "<group>"; };
 		60ADF9C12D59D47100556958 /* FontWithLineHeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontWithLineHeight.swift; sourceTree = "<group>"; };
+		60ADF9C82D5A019A00556958 /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
+		60ADF9CA2D5A01BA00556958 /* UISheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISheetPresentationController.swift; sourceTree = "<group>"; };
 		60B8B9E32BF9EEF1005F6DE3 /* ILSANG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ILSANG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANGApp.swift; sourceTree = "<group>"; };
 		60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = "<group>"; };
@@ -415,6 +419,8 @@
 				A1AB3D6D2C117569001EB9D8 /* Color.swift */,
 				60C0F4232CCE9B2F00DB19AB /* UIDevice++.swift */,
 				604687A72D1FD9E70056E394 /* CGFloat++.swift */,
+				60ADF9C82D5A019A00556958 /* UIApplication.swift */,
+				60ADF9CA2D5A01BA00556958 /* UISheetPresentationController.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -913,6 +919,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60ADF9C92D5A019B00556958 /* UIApplication.swift in Sources */,
 				60924DC92C48C00E00221072 /* Quest.swift in Sources */,
 				604687A32D1FC32E0056E394 /* HomeViewModel.swift in Sources */,
 				A196286B2C0859730037C53A /* CustomerServiceView.swift in Sources */,
@@ -985,6 +992,7 @@
 				60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */,
 				608EBF9F2C39C17F00B862CC /* Dictionary++.swift in Sources */,
 				A1C6422A2C33F55A004954CA /* QuestNetwork.swift in Sources */,
+				60ADF9CB2D5A01BA00556958 /* UISheetPresentationController.swift in Sources */,
 				A1AB3D6C2C1142AA001EB9D8 /* LoginButton.swift in Sources */,
 				600D83A42C7B1FA4005C93E2 /* PaginationManager.swift in Sources */,
 				60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */,

--- a/ILSANG/Sources/Extension/UIApplication.swift
+++ b/ILSANG/Sources/Extension/UIApplication.swift
@@ -19,4 +19,10 @@ extension UIApplication {
         }
         return topVC
     }
+    
+    func updateSheetDetents(to detents: [UISheetPresentationController.Detent], whenCurrentDetentsAre currentDetents: [UISheetPresentationController.Detent]) {
+        guard let sheetPresentationController = topController?.sheetPresentationController,
+              sheetPresentationController.detents == currentDetents else { return }
+        sheetPresentationController.detents = detents
+    }
 }

--- a/ILSANG/Sources/Extension/UIApplication.swift
+++ b/ILSANG/Sources/Extension/UIApplication.swift
@@ -1,0 +1,22 @@
+//
+//  UIApplication.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 2/10/25.
+//
+
+import UIKit
+
+extension UIApplication {
+    var topController: UIViewController? {
+        guard let windowScene = connectedScenes.first as? UIWindowScene,
+              let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) else {
+            return nil
+        }
+        var topVC = keyWindow.rootViewController
+        while let presentedVC = topVC?.presentedViewController {
+            topVC = presentedVC
+        }
+        return topVC
+    }
+}

--- a/ILSANG/Sources/Extension/UISheetPresentationController.swift
+++ b/ILSANG/Sources/Extension/UISheetPresentationController.swift
@@ -12,7 +12,6 @@ extension UISheetPresentationController.Detent.Identifier {
 }
 
 extension UISheetPresentationController.Detent {
-    static let customDetent = UISheetPresentationController.Detent.custom(identifier: .custom) { _ in
-        return 464.0
-    }
+    static let questDetailDetentHeight: CGFloat = 464.0
+    static let questDetailDetent = UISheetPresentationController.Detent.custom { _ in questDetailDetentHeight }
 }

--- a/ILSANG/Sources/Extension/UISheetPresentationController.swift
+++ b/ILSANG/Sources/Extension/UISheetPresentationController.swift
@@ -1,0 +1,18 @@
+//
+//  UISheetPresentationController.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 2/10/25.
+//
+
+import UIKit
+
+extension UISheetPresentationController.Detent.Identifier {
+    static let custom = UISheetPresentationController.Detent.Identifier("custom")
+}
+
+extension UISheetPresentationController.Detent {
+    static let customDetent = UISheetPresentationController.Detent.custom(identifier: .custom) { _ in
+        return 464.0
+    }
+}

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -47,13 +47,10 @@ struct HomeView: View {
             QuestDetailView(quest: vm.selectedQuest) {
                 vm.onQuestApprovalTapped()
             }
-            .presentationDetents([.height(464)])
+            .presentationDetents([.height(UISheetPresentationController.Detent.questDetailDetentHeight)])
             .presentationDragIndicator(.hidden)
             .onAppear {
-                // 풀시트(.large)로 화면이 표시되면 customDetent 사이즈로 재설정
-                guard let sheetPresentationController = UIApplication.shared.topController?.sheetPresentationController,
-                      sheetPresentationController.detents == [.large()] else { return }
-                sheetPresentationController.detents = [UISheetPresentationController.Detent.customDetent]
+                UIApplication.shared.updateSheetDetents(to: [.questDetailDetent], whenCurrentDetentsAre: [.large()])
             }
         }
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -49,6 +49,12 @@ struct HomeView: View {
             }
             .presentationDetents([.height(464)])
             .presentationDragIndicator(.hidden)
+            .onAppear {
+                // 풀시트(.large)로 화면이 표시되면 customDetent 사이즈로 재설정
+                guard let sheetPresentationController = UIApplication.shared.topController?.sheetPresentationController,
+                      sheetPresentationController.detents == [.large()] else { return }
+                sheetPresentationController.detents = [UISheetPresentationController.Detent.customDetent]
+            }
         }
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
             SubmitRouterView(selectedQuest: vm.selectedQuest)

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -47,6 +47,12 @@ struct QuestView: View {
             }
             .presentationDetents([.height(464)])
             .presentationDragIndicator(.hidden)
+            .onAppear {
+                // 풀시트(.large)로 화면이 표시되면 customDetent 사이즈로 재설정
+                guard let sheetPresentationController = UIApplication.shared.topController?.sheetPresentationController,
+                      sheetPresentationController.detents == [.large()] else { return }
+                sheetPresentationController.detents = [UISheetPresentationController.Detent.customDetent]
+            }
         }
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
             SubmitRouterView(selectedQuest: vm.selectedQuest)

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -45,13 +45,10 @@ struct QuestView: View {
             QuestDetailView(quest: vm.selectedQuest) {
                 vm.tappedQuestApprovalBtn()
             }
-            .presentationDetents([.height(464)])
+            .presentationDetents([.height(UISheetPresentationController.Detent.questDetailDetentHeight)])
             .presentationDragIndicator(.hidden)
             .onAppear {
-                // 풀시트(.large)로 화면이 표시되면 customDetent 사이즈로 재설정
-                guard let sheetPresentationController = UIApplication.shared.topController?.sheetPresentationController,
-                      sheetPresentationController.detents == [.large()] else { return }
-                sheetPresentationController.detents = [UISheetPresentationController.Detent.customDetent]
+                UIApplication.shared.updateSheetDetents(to: [.questDetailDetent], whenCurrentDetentsAre: [.large()])
             }
         }
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {


### PR DESCRIPTION
#### close #263 

### ✏️ 개요
간헐적으로 Sheet 높이가 고정되지 않는 문제를 해결합니다.
https://chad0909.atlassian.net/browse/ISPR-260

### 💻 작업 사항
- sheet 높이 고정
  - 화면이 .large로 표시되면, custom detents(464)으로 재설정하도록 구현
```swift
guard let sheetPresentationController = UIApplication.shared.topController?.sheetPresentationController,
    sheetPresentationController.detents == [.large()] else { return }
sheetPresentationController.detents = [UISheetPresentationController.Detent.customDetent]
``` 
 
### 📱결과 화면(optional)
#### 수정 전 (영상의 2초처럼 시트가 길게 표시됨)
https://github.com/user-attachments/assets/11719e33-6425-4944-a84e-9b32d91a19ab

#### 수정 전 (시트가 길게 표시됨)
https://github.com/user-attachments/assets/44b710fd-f448-46ee-b975-c3d199877105

#### 수정 후
https://github.com/user-attachments/assets/fc08bd98-e5ab-4f1b-9137-8e36b23632ae

