### PR TITLE
[Bug/#266] 홈뷰 리프레시할 경우 작업 취소되는 문제 해결

### DIFF
--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -35,7 +35,9 @@ struct HomeView: View {
                     }
                 }
                 .refreshable {
-                    await vm.loadInitialData()
+                    Task {
+                        await vm.loadInitialData()
+                    }
                 }
                 .disabled(vm.viewStatus == .loading)
             case .error:


### PR DESCRIPTION
#### close #266 

### ✏️ 개요
홈 화면을 리프레시할 경우 작업이 취소되어, 에러 화면이 보여지는 문제를 해결했습니다.
리프레시할 경우 태스크가 취소되는 것이 애플의 버그로 추정됩니다.

### 💻 작업 사항
- 홈뷰 리프레시 태스크 취소되는 문제 해결
https://stackoverflow.com/questions/74977787/why-is-async-task-cancelled-in-a-refreshable-modifier-on-a-scrollview-ios-16
https://developer.apple.com/forums/thread/722673
