### PR TITLE
[Feat/#235] 마이탭 도전내역 목록 페이지네이션 및 리팩토링

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		60ADF9C72D59D6CB00556958 /* SFPRODISPLAYREGULAR.otf in Resources */ = {isa = PBXBuildFile; fileRef = A1EB633A2C132B0800B63F9C /* SFPRODISPLAYREGULAR.otf */; };
 		60ADF9C92D5A019B00556958 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9C82D5A019A00556958 /* UIApplication.swift */; };
 		60ADF9CB2D5A01BA00556958 /* UISheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9CA2D5A01BA00556958 /* UISheetPresentationController.swift */; };
+		60ADF9D82D60927900556958 /* ChallengeViewModelItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9D72D60927900556958 /* ChallengeViewModelItem.swift */; };
 		60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */; };
 		60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */; };
 		60B8B9EB2BF9EEF3005F6DE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60B8B9EA2BF9EEF3005F6DE3 /* Assets.xcassets */; };
@@ -231,6 +232,7 @@
 		60ADF9C12D59D47100556958 /* FontWithLineHeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontWithLineHeight.swift; sourceTree = "<group>"; };
 		60ADF9C82D5A019A00556958 /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
 		60ADF9CA2D5A01BA00556958 /* UISheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISheetPresentationController.swift; sourceTree = "<group>"; };
+		60ADF9D72D60927900556958 /* ChallengeViewModelItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeViewModelItem.swift; sourceTree = "<group>"; };
 		60B8B9E32BF9EEF1005F6DE3 /* ILSANG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ILSANG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANGApp.swift; sourceTree = "<group>"; };
 		60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 				A11D88F62C916DE500846122 /* Icon.swift */,
 				60299E302CBFFF160039663F /* TransferableUIImage.swift */,
 				60ADF9BC2D59D3FD00556958 /* FontStyle.swift */,
+				60ADF9D72D60927900556958 /* ChallengeViewModelItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -942,6 +945,7 @@
 				60299E392CC13DEC0039663F /* ImageCacheService.swift in Sources */,
 				6061327B2CDB33FD00830948 /* FilterPicker.swift in Sources */,
 				A19628752C08648C0037C53A /* NavigationTitleView.swift in Sources */,
+				60ADF9D82D60927900556958 /* ChallengeViewModelItem.swift in Sources */,
 				A1AB3D5D2C113A70001EB9D8 /* LoginView.swift in Sources */,
 				6028A94C2D397730003FBC8C /* TopRank.swift in Sources */,
 				606C21CC2CC6B4FC00803947 /* SubmitStatusView.swift in Sources */,

--- a/ILSANG/Sources/Global/Model/ChallengeViewModelItem.swift
+++ b/ILSANG/Sources/Global/Model/ChallengeViewModelItem.swift
@@ -1,0 +1,37 @@
+//
+//  ChallengeViewModelItem.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 2/15/25.
+//
+
+import UIKit
+
+struct ChallengeViewModelItem: Hashable {
+    let challengeId: String
+    let userNickName: String?
+    let missionTitle: String?
+    let challengeImageId: String
+    let writerImageId: String?
+    let status: String
+    let createdAt: String
+    let likeCnt, hateCnt: Int
+    var writerImage: UIImage?
+    var challengeImage: UIImage?
+    
+    init(challenge: Challenge) {
+        self.challengeId = challenge.challengeId
+        self.userNickName = challenge.userNickName
+        self.missionTitle = challenge.missionTitle
+        self.challengeImageId = challenge.receiptImageId
+        self.writerImageId = challenge.questImageId
+        self.status = challenge.status
+        self.createdAt = challenge.createdAt
+        self.likeCnt = challenge.likeCnt
+        self.hateCnt = challenge.hateCnt
+        self.writerImage = nil
+        self.challengeImage = nil
+    }
+    
+    static let mockData = ChallengeViewModelItem(challenge: .challengeMockData)
+}

--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -20,8 +20,8 @@ final class ChallengeNetwork {
         return await Network.requestData(url: url+"randomChallenge", method: .get, parameters: parameters, withToken: true)
     }
     
-    func getChallenges(page: Int) async -> Result<ResponseWithPage<[Challenge]>, Error> {
-        let parameters: Parameters = ["userDataOnly": true, "page": page, "size": "20"]
+    func getChallenges(page: Int, size: Int) async -> Result<ResponseWithPage<[Challenge]>, Error> {
+        let parameters: Parameters = ["userDataOnly": true, "page": page, "size": size]
         return await Network.requestData(url: url+"challenge", method: .get, parameters: parameters, withToken: true)
     }
     

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MyPageActiveList: View {
-    
     @ObservedObject var vm: MyPageViewModel
     
     var body: some View {

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -29,7 +29,7 @@ struct MyPageActiveList: View {
                 .padding(.bottom, 60)
             }
             .refreshable {
-                await vm.getXpLog(page: 0, size: 10)
+                await vm.fetchXpLog(page: 0, size: 10)
             }
         }
         .overlay {

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
@@ -12,15 +12,11 @@ struct ChallengeDetailView: View {
     @Environment(\.dismiss) var dismiss
     @ObservedObject var vm: MyPageViewModel
     
-    @State private var missionImage: UIImage?
-    @State private var questImage: UIImage?
+    let idx: Int
     
-    let challengeData : Challenge
-    
-    init(vm: MyPageViewModel, missionImage: UIImage?, challengeData: Challenge) {
+    init(vm: MyPageViewModel, idx: Int) {
         self.vm = vm
-        self._missionImage = State(initialValue: missionImage)
-        self.challengeData = challengeData
+        self.idx = idx
     }
     
     var body: some View {
@@ -33,12 +29,12 @@ struct ChallengeDetailView: View {
             }
             .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
             
-            if let missionImage = missionImage {
-                ChallengeImageView(missionImage: missionImage, questImage: questImage, challengeData: challengeData)
+            if let missionImage = vm.challengeList[idx].challengeImage {
+                ChallengeImageView(missionImage: missionImage, challengeData: vm.challengeList[idx])
             } else {
                 ErrorView(title: "챌린지 정보를 불러오지 못했어요", subTitle: "챌린지 정보를 불러오는 데 실패했어요.\n인터넷 연결 상태 확인 후 다시 시도해주세요.") {
                     Task {
-                        missionImage = await vm.getImage(imageId: challengeData.receiptImageId)
+                        vm.challengeList[idx].challengeImage = await vm.getImage(imageId: vm.challengeList[idx].challengeImageId)
                     }
                 }
             }
@@ -46,8 +42,8 @@ struct ChallengeDetailView: View {
         .background(Color.background)
         .navigationBarBackButtonHidden()
         .task {
-            if let questImageId = challengeData.questImageId {
-                self.questImage = await vm.getImage(imageId: questImageId)
+            if let questImageId = vm.challengeList[idx].writerImageId {
+                self.vm.challengeList[idx].writerImage = await vm.getImage(imageId: questImageId)
             }
         }
         .overlay {
@@ -57,7 +53,7 @@ struct ChallengeDetailView: View {
                     onCancel: { vm.challengeDelete = false },
                     onConfirm: {
                         Task {
-                            if await vm.updateChallengeStatus(challengeId: challengeData.challengeId,ImageId: challengeData.receiptImageId) {
+                            if await vm.updateChallengeStatus(challengeId: vm.challengeList[idx].challengeId, imageId: vm.challengeList[idx].challengeImageId) {
                                 vm.challengeDelete = false
                                 dismiss()
                             } else {
@@ -97,7 +93,7 @@ struct ChallengeDetailView: View {
     
     private var dailyShareUIImage: UIImage {
         let renderer = ImageRenderer(
-            content: ChallengeImageView(missionImage: missionImage ?? .logo, questImage: questImage ?? .logo, challengeData: challengeData).frame(width: 440)
+            content: ChallengeImageView(missionImage: vm.challengeList[idx].challengeImage ?? .logo, challengeData: vm.challengeList[idx]).frame(width: 440)
         )
         renderer.scale = 3.0
         return renderer.uiImage ?? .init()
@@ -106,8 +102,7 @@ struct ChallengeDetailView: View {
 
 struct ChallengeImageView: View {
     let missionImage: UIImage
-    let questImage: UIImage?
-    let challengeData : Challenge
+    let challengeData : ChallengeViewModelItem
 
     var body: some View {
         Image(uiImage: missionImage)
@@ -121,8 +116,8 @@ struct ChallengeImageView: View {
     
     private var challengeInfoView: some View {
         HStack(spacing: 0) {
-            if let questImage = questImage {
-                Image(uiImage: questImage)
+            if let writerImage = challengeData.writerImage {
+                Image(uiImage: writerImage)
                     .resizable()
                     .frame(width: 48, height: 48)
                     .background(.primary100)
@@ -179,8 +174,7 @@ struct ChallengeImageView: View {
                     imageNetwork: ImageNetwork(),
                     xpNetwork: XPNetwork()
                 ),
-                missionImage: .logo,
-                challengeData: .challengeMockData
+                idx: 0
             )
         }
         .tabItem {

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeDetailView.swift
@@ -92,6 +92,10 @@ struct ChallengeDetailView: View {
     }
     
     private var dailyShareUIImage: UIImage {
+        guard vm.challengeList.indices.contains(idx) else {
+            return UIImage()
+        }
+        
         let renderer = ImageRenderer(
             content: ChallengeImageView(missionImage: vm.challengeList[idx].challengeImage ?? .logo, challengeData: vm.challengeList[idx]).frame(width: 440)
         )

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -18,18 +18,26 @@ struct MyPageChallengeList: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             
             ScrollView {
-                VStack(spacing: 9) {
-                    ForEach(vm.challengeList, id: \.challenge) { challenge in
-                        NavigationLink(destination: ChallengeDetailView(vm: vm, missionImage: challenge.image, challengeData: challenge.challenge)) {
-                            challengeListItemView(challenge: challenge.challenge, image: challenge.image)
+                LazyVStack(spacing: 9) {
+                    ForEach(Array(vm.challengeList.enumerated()), id: \.offset) { idx, challenge in
+                        NavigationLink(destination: ChallengeDetailView(vm: vm, idx: idx)) {
+                            challengeListItemView(challenge: challenge)
                         }
+                    }
+                    
+                    if vm.hasMorePage() {
+                        ProgressView()
+                            .padding(.top, 12)
+                            .task {
+                                await vm.challengePaginationManager.loadData(isRefreshing: false)
+                            }
                     }
                 }
                 .padding(.top, 12)
                 .padding(.bottom, 72)
             }
             .refreshable {
-                await vm.fetchChallengesWithImages(page: 0)
+                await vm.challengePaginationManager.loadData(isRefreshing: true)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -40,10 +48,10 @@ struct MyPageChallengeList: View {
         }
     }
     
-    private func challengeListItemView(challenge: Challenge, image: UIImage?) -> some View {
+    private func challengeListItemView(challenge: ChallengeViewModelItem) -> some View {
         ZStack {
             Group {
-                if let image = image {
+                if let image = challenge.challengeImage {
                     Image(uiImage: image)
                         .resizable()
                         .scaledToFill()
@@ -67,7 +75,7 @@ struct MyPageChallengeList: View {
                             endPoint: .bottom
                         )
                     )
-                    .opacity(image == nil ? 0.3 : 1)
+                    .opacity(challenge.challengeImage == nil ? 0.3 : 1)
             }
             .clipShape(RoundedRectangle(cornerRadius: 12))
             

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -26,8 +26,6 @@ struct MyPageView: View {
             // 2) 도전내역 등록했을 때, 리프레시했을 때 재호출하도록 수정
             await vm.fetchUser()
             await vm.fetchXpStats()
-            await vm.challengePaginationManager.loadData(isRefreshing: true)
-            await vm.fetchXpLog(page: 0, size: 10)
         }
     }
     

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -24,10 +24,10 @@ struct MyPageView: View {
             // TODO:
             // 1) 초기화시 데이터 로딩하도록 수정
             // 2) 도전내역 등록했을 때, 리프레시했을 때 재호출하도록 수정
-            await vm.getUser()
-            await vm.getXpStat()
-            await vm.fetchChallengesWithImages(page: 0)
-            await vm.getXpLog(page: 0, size: 10)
+            await vm.fetchUser()
+            await vm.fetchXpStats()
+            await vm.challengePaginationManager.loadData(isRefreshing: true)
+            await vm.fetchXpLog(page: 0, size: 10)
         }
     }
     

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -39,6 +39,16 @@ final class MyPageViewModel: ObservableObject {
         self.xpNetwork = xpNetwork
         
         self.userData = UserService.shared.currentUser
+        
+        Task {
+            await loadInitialData()
+        }
+    }
+    
+    func loadInitialData() async {
+        // TODO: 도전내역 등록했을 때 재호출하도록 수정
+        await challengePaginationManager.loadData(isRefreshing: true)
+        await fetchXpLog(page: 0, size: 10)
     }
     
     @discardableResult @MainActor

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -13,10 +13,19 @@ final class MyPageViewModel: ObservableObject {
     @Published var selectedTab: MyPageTab = .quest
     
     @Published var xpStats: [XpStat: Int] = [:]
+    @Published var challengeList: [ChallengeViewModelItem] = []
     @Published var xpLogList: [XpLog] = []
-    @Published var challengeList: [(challenge: Challenge, image: UIImage?)] = [] // [(Challenge.challengeMockData, nil)]
     
     @Published var challengeDelete = false
+    
+    lazy var challengePaginationManager = PaginationManager<ChallengeViewModelItem>(
+        size: 10,
+        threshold: 7,
+        loadPage: { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await loadChallengeListWithImage(page: page, size: 10)
+        }
+    )
     
     private let userNetwork: UserNetwork
     private let challengeNetwork: ChallengeNetwork
@@ -32,8 +41,45 @@ final class MyPageViewModel: ObservableObject {
         self.userData = UserService.shared.currentUser
     }
     
+    @discardableResult @MainActor
+    func loadChallengeListWithImage(page: Int, size: Int) async -> ([ChallengeViewModelItem], Int) {
+        let getQuestList = await fetchChallenges(page: page, size: size)
+        
+        let newQuestList = getQuestList.data
+        var currentQuestList = challengeList
+        
+        if page == 0 {
+            currentQuestList = newQuestList
+        } else {
+            currentQuestList += newQuestList
+        }
+        
+        await withTaskGroup(of: (Int, UIImage?).self) { group in
+            for (index, quest) in newQuestList.enumerated() {
+                group.addTask {
+                    let imageId = quest.challengeImageId
+                    let image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+                    return (index, image)
+                }
+            }
+            
+            for await (index, image) in group {
+                if let image = image {
+                    if page == 0 {
+                        currentQuestList[index].challengeImage = image
+                    } else {
+                        currentQuestList[currentQuestList.count - newQuestList.count + index].challengeImage = image
+                    }
+                }
+            }
+        }
+        challengeList = currentQuestList
+        
+        return (challengeList, getQuestList.total)
+    }
+    
     @MainActor
-    func getUser() async {
+    func fetchUser() async {
         let res = await userNetwork.getUser()
         
         switch res {
@@ -46,21 +92,19 @@ final class MyPageViewModel: ObservableObject {
     }
     
     @MainActor
-    func getXpLog(page: Int, size: Int) async {
+    func fetchXpLog(page: Int, size: Int) async {
         let res = await xpNetwork.getXpHistory(page: page, size: 10)
         
         switch res {
         case .success(let model):
             self.xpLogList = model.data
-            
         case .failure(let err):
-            self.xpLogList = []
             Log(err)
         }
     }
     
     @MainActor
-    func getXpStat() async {
+    func fetchXpStats() async {
         let res = await xpNetwork.getXpStats()
         
         switch res {
@@ -75,50 +119,34 @@ final class MyPageViewModel: ObservableObject {
             ]
         case .failure(let error):
             Log("XP 스탯 조회 실패: \(error)")
-            self.xpStats = [:]
         }
     }
     
-    @MainActor
-    func fetchChallengesWithImages(page: Int) async {
-        let response = await challengeNetwork.getChallenges(page: page)
+    func fetchChallenges(page: Int, size: Int) async ->  (data: [ChallengeViewModelItem], total: Int) {
+        let response = await challengeNetwork.getChallenges(page: page, size: size)
         
         switch response {
-        case .success(let model):
+        case .success(let res):
             // 데이터 초기화: 이미지가 없는 상태로 미리 표시
-            self.challengeList = model.data.map { ($0, nil as UIImage?) }
-            
-            await withTaskGroup(of: Void.self) { group in
-                for (index, challenge) in model.data.enumerated() {
-                    group.addTask {
-                        let image = await self.getImage(imageId: challenge.receiptImageId)
-                        await self.updateChallengeImage(at: index, with: image)
-                    }
-                }
-            }
-            
+            return (res.data.map {ChallengeViewModelItem.init(challenge: $0)}, res.total)
         case .failure(let error):
             Log("챌린지 조회 실패: \(error)")
-            self.challengeList = []
+            return ([], 0)
         }
     }
     
-    @MainActor
-    private func updateChallengeImage(at index: Int, with image: UIImage?) {
-        if index < self.challengeList.count {
-            self.challengeList[index].1 = image
-        }
-    }
-    
-    @MainActor
-    func updateChallengeStatus(challengeId: String, ImageId: String) async -> Bool {
+    func updateChallengeStatus(challengeId: String, imageId: String) async -> Bool {
         let deleteChallengeRes = await challengeNetwork.deleteChallenge(challengeId: challengeId)
-        let deleteImageRes = await imageNetwork.deleteImage(imageId: ImageId)
+        let deleteImageRes = await imageNetwork.deleteImage(imageId: imageId)
         
         return deleteChallengeRes && deleteImageRes
     }
     
     func getImage(imageId: String) async -> UIImage? {
         await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+    }
+    
+    func hasMorePage() -> Bool {
+        return challengePaginationManager.canLoadMoreData()        
     }
 }


### PR DESCRIPTION
#### close #235 

### ✏️ 개요
마이탭의 도전내역 목록 데이터를 페이지네이션 처리하여 가져옵니다.

### 💻 작업 사항
- 마이탭 도전내역 목록 페이지네이션

### 📱결과 화면(optional)
https://github.com/user-attachments/assets/d0424960-8937-4c73-8258-025faca7f654


