### PR TITLE
[Ref/#282] 초기 데이터 로드 방식 개선 – .task에서 호출하며 데이터가 없을 때만 로드

### DIFF
--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -27,7 +27,7 @@ struct ApprovalView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.background)
         .task {
-            await vm.loadInitialData()
+            await vm.loadDataIfNeeded()
         }
         .overlay { reportAlertView }
     }

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -51,6 +51,13 @@ final class ApprovalViewModel {
     }
     
     @MainActor
+    func loadDataIfNeeded() async {
+        if itemList.isEmpty {
+            await loadInitialData()
+        }
+    }
+    
+    @MainActor
     func loadInitialData() async {
         changeViewStatus(.loading)
         await self.paginationManager?.loadData(isRefreshing: true)

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -26,6 +26,9 @@ struct MyPageView: View {
             // 2) 도전내역 등록했을 때, 리프레시했을 때 재호출하도록 수정
             await vm.fetchUser()
             await vm.fetchXpStats()
+            
+            // 도전내역, 활동로그 불러오기
+            await vm.loadDataIfNeeded()
         }
     }
     

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -48,8 +48,11 @@ final class MyPageViewModel: ObservableObject {
         self.xpNetwork = xpNetwork
         
         self.userData = UserService.shared.currentUser
-        
-        Task {
+    }
+    
+    @MainActor
+    func loadDataIfNeeded() async {
+        if challengeList.isEmpty || xpLogList.isEmpty {
             await loadInitialData()
         }
     }

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -34,6 +34,9 @@ struct QuestView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.background)
+        .task {
+            await vm.loadDataIfNeeded()
+        }
         .onReceive(
             vm.$selectedHeader.combineLatest(vm.$selectedXpStat, vm.questFilterState.$selectedValue, vm.repeatFilterState.$selectedValue)
         ) { _ in

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -126,8 +126,10 @@ class QuestViewModel: ObservableObject {
             guard let self = self else { return }
             Task { await self.repeatPaginationManager.loadData(isRefreshing: true) }
         }
-        
-        Task {
+    }
+    
+    func loadDataIfNeeded() async {
+        if isCurrentListEmpty {
             await loadInitialData()
         }
     }

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -28,6 +28,9 @@ struct RankingView: View {
             }
         }
         .background(Color.background)
+        .task {
+            await vm.loadRankIfNeeded(xpStat: vm.selectedXpStat)
+        }
         .onChange(of: vm.selectedXpStat) { _, newValue in
             Task {
                 await vm.loadRankIfNeeded(xpStat: newValue)

--- a/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
@@ -25,9 +25,6 @@ class RankingViewModel: ObservableObject {
     
     init(rankNetwork: RankNetwork)  {
         self.rankNetwork = rankNetwork
-        Task {
-            await loadRankIfNeeded(xpStat: selectedXpStat)
-        }
     }
     
     func loadRankIfNeeded(xpStat: XpStat) async {


### PR DESCRIPTION
#### close #282

### ✏️ 개요
기존에는 .task 내에서 데이터 로드 로직을 실행하여 탭이 변경될 때마다 데이터를 불러오는 방식이었습니다. 이를 방지하기 위해 일부 ViewModel의 init에서 데이터를 로드하도록 구현했으나, 앱 실행 시 한꺼번에 많은 데이터를 불러와 로딩 시간이 길어지는 문제가 발생했습니다.

이에 따라 .task 내 데이터 로드 로직을 유지하면서, 데이터가 비어있는 경우에만 실행되도록 개선하여 불필요한 로드 요청을 최소화하고 초기 구동 속도를 최적화했습니다.

### 💻 작업 사항
- 데이터 로드 방식 변경

### 📱결과 화면(optional)
홈 뷰 동작 기준

<img width="292" alt="image" src="https://github.com/user-attachments/assets/324b2359-f74d-465e-bd27-02e258ea5fa0" />
