### PR TITLE
[Feat/#288] 다른 사용자 정보 조회 기능 추가 (스탯, 도전 내역 목록)

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -21,6 +21,13 @@
 		601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189222C3E95D40070F2AD /* AuthNetwork.swift */; };
 		601189272C3F00FB0070F2AD /* AuthChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189262C3F00FB0070F2AD /* AuthChannel.swift */; };
 		601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601189282C3F022D0070F2AD /* LoginViewModel.swift */; };
+		601BCF102D7B43F000138387 /* OtherUserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601BCF0F2D7B43F000138387 /* OtherUserProfileView.swift */; };
+		601BCF122D7B449C00138387 /* OtherUserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601BCF112D7B449C00138387 /* OtherUserProfileViewModel.swift */; };
+		601BCF142D7B502400138387 /* OtherUserXpStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601BCF132D7B502400138387 /* OtherUserXpStatView.swift */; };
+		601BCF162D7B502B00138387 /* OtherUserChallengeList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601BCF152D7B502B00138387 /* OtherUserChallengeList.swift */; };
+		601BCF182D7C0C1400138387 /* ChallengeListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601BCF172D7C0C1400138387 /* ChallengeListItemView.swift */; };
+		601BCF1A2D7C134500138387 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601BCF192D7C134500138387 /* ProgressBar.swift */; };
+		601BCF1C2D7C150700138387 /* OtherUserChallengeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601BCF1B2D7C150700138387 /* OtherUserChallengeDetailView.swift */; };
 		6028A94A2D39721F003FBC8C /* RankNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6028A9492D39721F003FBC8C /* RankNetwork.swift */; };
 		6028A94C2D397730003FBC8C /* TopRank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6028A94B2D39772F003FBC8C /* TopRank.swift */; };
 		6029881E2D041D3900903806 /* QuestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029881D2D041D3900903806 /* QuestStatus.swift */; };
@@ -177,6 +184,13 @@
 		601189222C3E95D40070F2AD /* AuthNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNetwork.swift; sourceTree = "<group>"; };
 		601189262C3F00FB0070F2AD /* AuthChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthChannel.swift; sourceTree = "<group>"; };
 		601189282C3F022D0070F2AD /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		601BCF0F2D7B43F000138387 /* OtherUserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserProfileView.swift; sourceTree = "<group>"; };
+		601BCF112D7B449C00138387 /* OtherUserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserProfileViewModel.swift; sourceTree = "<group>"; };
+		601BCF132D7B502400138387 /* OtherUserXpStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserXpStatView.swift; sourceTree = "<group>"; };
+		601BCF152D7B502B00138387 /* OtherUserChallengeList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserChallengeList.swift; sourceTree = "<group>"; };
+		601BCF172D7C0C1400138387 /* ChallengeListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeListItemView.swift; sourceTree = "<group>"; };
+		601BCF192D7C134500138387 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
+		601BCF1B2D7C150700138387 /* OtherUserChallengeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserChallengeDetailView.swift; sourceTree = "<group>"; };
 		6028A9492D39721F003FBC8C /* RankNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankNetwork.swift; sourceTree = "<group>"; };
 		6028A94B2D39772F003FBC8C /* TopRank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopRank.swift; sourceTree = "<group>"; };
 		6029881D2D041D3900903806 /* QuestStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestStatus.swift; sourceTree = "<group>"; };
@@ -383,6 +397,18 @@
 			path = Service;
 			sourceTree = "<group>";
 		};
+		601BCF0E2D7B438100138387 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				601BCF0F2D7B43F000138387 /* OtherUserProfileView.swift */,
+				601BCF132D7B502400138387 /* OtherUserXpStatView.swift */,
+				601BCF152D7B502B00138387 /* OtherUserChallengeList.swift */,
+				601BCF1B2D7C150700138387 /* OtherUserChallengeDetailView.swift */,
+				601BCF112D7B449C00138387 /* OtherUserProfileViewModel.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
 		6029881C2D041D2500903806 /* Enum */ = {
 			isa = PBXGroup;
 			children = (
@@ -397,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				A1BB60272BFE129000AAADD4 /* MyPageChallengeList.swift */,
+				601BCF172D7C0C1400138387 /* ChallengeListItemView.swift */,
 				A1868C432C09B6C50020BF16 /* ChallengeDetailView.swift */,
 			);
 			path = MyPageChallenge;
@@ -555,6 +582,7 @@
 				607FCBDA2BFA681F00BB2D04 /* Approval */,
 				9FE63D6A2CB3A53900CA7940 /* Ranking */,
 				607FCBDB2BFA682800BB2D04 /* MyPage */,
+				601BCF0E2D7B438100138387 /* Profile */,
 				A19628632C076D5A0037C53A /* Setting */,
 				A19628602C0763CB0037C53A /* NickName */,
 			);
@@ -752,6 +780,7 @@
 			isa = PBXGroup;
 			children = (
 				A1F0ADBF2CD738A20068E0A6 /* Polygon.swift */,
+				601BCF192D7C134500138387 /* ProgressBar.swift */,
 				607FCBE12BFA6A8300BB2D04 /* Buttons.swift */,
 				6061327A2CDB33FD00830948 /* FilterPicker.swift */,
 				607FCBEA2BFE44D900BB2D04 /* IconView.swift */,
@@ -955,6 +984,7 @@
 				607FCBE22BFA6A8300BB2D04 /* Buttons.swift in Sources */,
 				605DA0CF2C07118900CC9450 /* SubmitRouterView.swift in Sources */,
 				A1FF91742C257F6400F03E4B /* XpLog.swift in Sources */,
+				601BCF182D7C0C1400138387 /* ChallengeListItemView.swift in Sources */,
 				607FCBD82BFA681500BB2D04 /* ApprovalView.swift in Sources */,
 				A1AB3D692C1141B3001EB9D8 /* KakaoLoginButtonView.swift in Sources */,
 				A142E0312C2D9F37004395F8 /* SettingAlertView.swift in Sources */,
@@ -968,6 +998,7 @@
 				9FE63D722CB3AB4F00CA7940 /* RankingItemView.swift in Sources */,
 				9FE63D702CB3AAF100CA7940 /* RankingViewModel.swift in Sources */,
 				6053345F2D31272B00599159 /* MyPagePointSectionView.swift in Sources */,
+				601BCF142D7B502400138387 /* OtherUserXpStatView.swift in Sources */,
 				605DA0D62C07123400CC9450 /* View++.swift in Sources */,
 				A1678CCE2CF4C59C00843854 /* MyPageShareImage.swift in Sources */,
 				60299E392CC13DEC0039663F /* ImageCacheService.swift in Sources */,
@@ -979,7 +1010,9 @@
 				606C21CC2CC6B4FC00803947 /* SubmitStatusView.swift in Sources */,
 				60E258052D09CE1B0052C048 /* StatRank.swift in Sources */,
 				A196286F2C0859910037C53A /* DeleteAccountView.swift in Sources */,
+				601BCF162D7B502B00138387 /* OtherUserChallengeList.swift in Sources */,
 				6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */,
+				601BCF1A2D7C134500138387 /* ProgressBar.swift in Sources */,
 				601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */,
 				609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */,
 				605F28522CF1B2C5007EA739 /* QuestDetailView.swift in Sources */,
@@ -995,6 +1028,7 @@
 				601189292C3F022D0070F2AD /* LoginViewModel.swift in Sources */,
 				604687A52D1FC36A0056E394 /* TitleWithContentView.swift in Sources */,
 				A19628622C0763F90037C53A /* ChangeNickNameView.swift in Sources */,
+				601BCF1C2D7C150700138387 /* OtherUserChallengeDetailView.swift in Sources */,
 				60C6B4DF2C2D053600926C0E /* SubmitRouterViewModel.swift in Sources */,
 				604687AA2D1FDA090056E394 /* CarouselAutoSlideView.swift in Sources */,
 				605DA0C92C07097F00CC9450 /* ImagePreviewButton.swift in Sources */,
@@ -1015,6 +1049,7 @@
 				A1868C442C09B6C50020BF16 /* ChallengeDetailView.swift in Sources */,
 				6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */,
 				607FCBD42BFA648000BB2D04 /* Tab.swift in Sources */,
+				601BCF122D7B449C00138387 /* OtherUserProfileViewModel.swift in Sources */,
 				603CF4CB2D7057BF00A2D19E /* ImageChallengeSubmitService.swift in Sources */,
 				6090A5F52D53AC3300A01429 /* AppVersionManager.swift in Sources */,
 				6011891F2C3E94380070F2AD /* AuthUser.swift in Sources */,
@@ -1032,6 +1067,7 @@
 				60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */,
 				60ADF9BF2D59D41E00556958 /* Font++.swift in Sources */,
 				60004AD92D42373300CD2254 /* Banner.swift in Sources */,
+				601BCF102D7B43F000138387 /* OtherUserProfileView.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				A11D88F72C916DE500846122 /* Icon.swift in Sources */,
 				602988222D041DDC00903806 /* RepeatType.swift in Sources */,

--- a/ILSANG/Sources/Global/View/ProgressBar.swift
+++ b/ILSANG/Sources/Global/View/ProgressBar.swift
@@ -1,0 +1,28 @@
+//
+//  ProgressBar.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 3/8/25.
+//
+
+import SwiftUI
+
+struct ProgressBar: View {
+    let progress: Double
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .frame(width: geometry.size.width, height: 8)
+                    .cornerRadius(6)
+                    .foregroundColor(.gray100)
+                
+                Rectangle()
+                    .frame(width: CGFloat(progress) * geometry.size.width, height: 8)
+                    .cornerRadius(6)
+                    .foregroundColor(.accent)
+            }
+        }
+    }
+}

--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct Challenge: Decodable, Hashable {
     let challengeId: String
+    let customerId: String?
     let userNickName: String?
     let missionTitle: String?
     let receiptImageId, status: String
@@ -18,6 +19,7 @@ struct Challenge: Decodable, Hashable {
     
     enum CodingKeys: String, CodingKey {
         case challengeId
+        case customerId
         case userNickName
         case missionTitle
         case receiptImageId
@@ -28,5 +30,5 @@ struct Challenge: Decodable, Hashable {
         case hateCnt
     }
     
-    static let challengeMockData = Challenge(challengeId: "", userNickName: "일상유저123", missionTitle: "바닐라라떼 마시기", receiptImageId: "", status: "", questImageId: "", createdAt: "2024-01-01'T'00:00:00", likeCnt: 3, hateCnt: 0)
+    static let challengeMockData = Challenge(challengeId: "", customerId: "", userNickName: "일상유저123", missionTitle: "바닐라라떼 마시기", receiptImageId: "", status: "", questImageId: "", createdAt: "2024-01-01'T'00:00:00", likeCnt: 3, hateCnt: 0)
 }

--- a/ILSANG/Sources/Model/TopRank.swift
+++ b/ILSANG/Sources/Model/TopRank.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct TopRank: Decodable {
+    let customerId: String
     let lank: Int
     let xpSum: Int
     let nickname: String

--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -25,6 +25,11 @@ final class ChallengeNetwork {
         return await Network.requestData(url: url+"challenge", method: .get, parameters: parameters, withToken: true)
     }
     
+    func getChallenges(page: Int, size: Int, userId: String) async -> Result<ResponseWithPage<[Challenge]>, Error> {
+        let parameters: Parameters = ["userDataOnly": true, "status": "APPROVED", "userId": userId, "page": page, "size": size]
+        return await Network.requestData(url: url+"challenge", method: .get, parameters: parameters, withToken: true)
+    }
+    
     func postChallenge(questId: String, imageId: String) async -> Result<ResponseWithEmpty, Error> {
         let bodyData: [String: Any] = [
             "questId": questId,

--- a/ILSANG/Sources/Network/UserNetwork.swift
+++ b/ILSANG/Sources/Network/UserNetwork.swift
@@ -15,6 +15,10 @@ final class UserNetwork {
         return await Network.requestData(url: url, method: .get, parameters: nil, withToken: true)
     }
     
+    func getUser(customerId: String) async -> Result<Response<User>, Error> {
+        return await Network.requestData(url: url, method: .get, parameters: ["customerId": customerId], withToken: true)
+    }
+    
     func putUser(nickname: String) async -> Bool {
         let body = ["nickname": nickname]
         let bodyData = body.convertToJsonData()

--- a/ILSANG/Sources/Network/XPNetwork.swift
+++ b/ILSANG/Sources/Network/XPNetwork.swift
@@ -20,4 +20,8 @@ final class XPNetwork {
     func getXpStats() async -> Result<Response<XpStats>,Error> {
         return await Network.requestData(url: statsUrl, method: .get, parameters: nil, withToken: true)
     }
+    
+    func getXpStats(customerId: String) async -> Result<Response<XpStats>,Error> {
+        return await Network.requestData(url: statsUrl, method: .get, parameters: ["customerId": customerId], withToken: true)
+    }
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
@@ -22,7 +22,11 @@ struct ApprovalItemContentView: View {
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: 16) {
-                profileView(nickname: item.nickname, time: item.time)
+                NavigationLink {
+                    OtherUserProfileView(customerId: item.customerId)
+                } label: {
+                    profileView(nickname: item.nickname, time: item.time)
+                }
                 
                 Text(item.title)
                     .font(.system(size: 23, weight: .bold))

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 ✅ 이모지 에셋 변경
 ✅ 이모지 불러오기(idx 0, 1..<)
 ✅ 이모지 활성&비활성
-❌ 이모지 카운트 +-
+✅ 이모지 카운트 +-
 ✅ 공유하기 & 신고하기 UI 추가
 ✅ 공유하기 & 신고하기 기능 추가
 ✅ 페이지네이션
@@ -309,6 +309,7 @@ final class ApprovalViewModel {
 
 struct ApprovalViewModelItem: Identifiable {
     let id: String
+    let customerId: String
     let title: String
     var image: UIImage?
     var imageId: String
@@ -320,6 +321,7 @@ struct ApprovalViewModelItem: Identifiable {
     
     init(
         id: String = UUID().uuidString,
+        customerId: String,
         title: String,
         image: UIImage? = nil,
         imageId: String,
@@ -330,6 +332,7 @@ struct ApprovalViewModelItem: Identifiable {
         emoji: Emoji?
     ) {
         self.id = id
+        self.customerId = customerId
         self.title = title
         self.image = image
         self.imageId = imageId
@@ -342,6 +345,7 @@ struct ApprovalViewModelItem: Identifiable {
     
     init(challenge: Challenge) {
         self.id = challenge.challengeId
+        self.customerId = challenge.customerId ?? ""
         self.title = challenge.missionTitle ?? ""
         self.image = nil
         self.imageId = challenge.receiptImageId
@@ -354,6 +358,7 @@ struct ApprovalViewModelItem: Identifiable {
     }
     
     static var failedData = ApprovalViewModelItem(
+        customerId: "",
         title: "불러올 수 없습니다",
         imageId: "",
         nickname: "",
@@ -364,9 +369,9 @@ struct ApprovalViewModelItem: Identifiable {
     )
     
     static var mockDataList = [
-        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상1", time: "3시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상2", time: "1시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상3", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상4", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false))
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상1", time: "3시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상2", time: "1시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상3", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상4", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false))
     ]
 }

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -258,7 +258,11 @@ struct HomeView: View {
                 ScrollView(.horizontal) {
                     HStack(spacing: 8) {
                         ForEach(Array(vm.userRankList.enumerated()), id: \.offset) { idx, rank in
-                            RankingItemView(topRank: rank, style: .vertical)
+                            NavigationLink {
+                                OtherUserProfileView(customerId: rank.customerId)
+                            } label: {
+                                RankingItemView(topRank: rank, style: .vertical)
+                            }
                         }
                     }
                     .padding(.horizontal, LayoutConstants.horizontalPadding)

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeListItemView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/ChallengeListItemView.swift
@@ -1,0 +1,58 @@
+//
+//  ChallengeListItemView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 3/8/25.
+//
+
+import SwiftUI
+
+struct ChallengeListItemView: View {
+    let challenge: ChallengeViewModelItem
+    
+    var body: some View {
+        ZStack {
+            Group {
+                if let image = challenge.challengeImage {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    Image(uiImage: .logoWithAlpha)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 100)
+                }
+            }
+            .scaledToFill()
+            .frame(height: 172)
+            .frame(maxWidth: .infinity)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .frame(height: 85)
+                    .foregroundStyle(
+                        .linearGradient(
+                            colors: [.clear, .black.opacity(0.8)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .opacity(challenge.challengeImage == nil ? 0.3 : 1)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            
+            VStack(alignment: .leading, spacing: 6) {
+                Spacer()
+                Text(challenge.missionTitle ?? "")
+                    .font(.system(size: 23, weight: .bold))
+                    .foregroundColor(.white)
+                
+                Text(challenge.createdAt.timeAgoCreatedAt())
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundColor(.gray200)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+        }
+    }
+}

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -21,7 +21,7 @@ struct MyPageChallengeList: View {
                 LazyVStack(spacing: 9) {
                     ForEach(Array(vm.challengeList.enumerated()), id: \.offset) { idx, challenge in
                         NavigationLink(destination: ChallengeDetailView(vm: vm, idx: idx)) {
-                            challengeListItemView(challenge: challenge)
+                            ChallengeListItemView(challenge: challenge)
                         }
                     }
                     
@@ -45,52 +45,6 @@ struct MyPageChallengeList: View {
             if vm.challengeList.isEmpty {
                 EmptyView(title: "수행한 퀘스트가 없어요!")
             }
-        }
-    }
-    
-    private func challengeListItemView(challenge: ChallengeViewModelItem) -> some View {
-        ZStack {
-            Group {
-                if let image = challenge.challengeImage {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                } else {
-                    Image(uiImage: .logoWithAlpha)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 100)
-                }
-            }
-            .scaledToFill()
-            .frame(height: 172)
-            .frame(maxWidth: .infinity)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .frame(height: 85)
-                    .foregroundStyle(
-                        .linearGradient(
-                            colors: [.clear, .black.opacity(0.8)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .opacity(challenge.challengeImage == nil ? 0.3 : 1)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            
-            VStack(alignment: .leading, spacing: 6) {
-                Spacer()
-                Text(challenge.missionTitle ?? "")
-                    .font(.system(size: 23, weight: .bold))
-                    .foregroundColor(.white)
-                
-                Text(challenge.createdAt.timeAgoCreatedAt())
-                    .font(.system(size: 13, weight: .regular))
-                    .foregroundColor(.gray200)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(20)
         }
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageInfo/MyPagePointSectionView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageInfo/MyPagePointSectionView.swift
@@ -59,22 +59,6 @@ struct MyPagePointSectionView: View {
         .background(.white)
         .cornerRadius(12)
     }
-    
-    private func ProgressBar(progress: Double) -> some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                Rectangle()
-                    .frame(width: geometry.size.width, height: 8)
-                    .cornerRadius(6)
-                    .foregroundColor(.gray100)
-                
-                Rectangle()
-                    .frame(width: CGFloat(progress) * geometry.size.width, height: 8)
-                    .cornerRadius(6)
-                    .foregroundColor(.accent)
-            }
-        }
-    }
 }
 
 #Preview {

--- a/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageProfile.swift
@@ -15,7 +15,7 @@ struct MyPageProfile: View {
         NavigationLink(destination: ChangeNickNameView()) {
             HStack {
                 // 프로필 이미지
-                ProfileImageView(profileImage: nil)
+                ProfileImageView(profileImage: nil, isEditMode: true)
                 
                 // 프로필 상세 - 닉네임, 레벨
                 VStack (alignment: .leading, spacing: 4) {
@@ -35,10 +35,7 @@ struct MyPageProfile: View {
 
 struct ProfileImageView: View {
     var profileImage: UIImage?
-    
-    init(profileImage: UIImage? = nil) {
-        self.profileImage = profileImage
-    }
+    var isEditMode: Bool = false
     
     var body: some View {
         Group {
@@ -55,12 +52,14 @@ struct ProfileImageView: View {
         .frame(width: 57, height: 57)
         .clipShape(Circle())
         .overlay(alignment: .bottomTrailing) {
-            Image("profileEdit")
-                .padding(3)
-                .frame(width: 18, height: 18)
-                .background(.black)
-                .clipShape(.circle)
-                .offset(x: 0, y: 4)
+            if isEditMode {
+                Image("profileEdit")
+                    .padding(3)
+                    .frame(width: 18, height: 18)
+                    .background(.black)
+                    .clipShape(.circle)
+                    .offset(x: 0, y: 4)
+            }
         }
         .frame(height: 61)
     }

--- a/ILSANG/Sources/Views/Profile/OtherUserChallengeDetailView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserChallengeDetailView.swift
@@ -1,0 +1,25 @@
+//
+//  OtherUserChallengeDetailView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 3/8/25.
+//
+
+import SwiftUI
+
+struct OtherUserChallengeDetailView: View {
+    @Environment(\.dismiss) var dismiss
+    let challenge: ChallengeViewModelItem
+    
+    var body: some View {
+        VStack {
+            NavigationTitleView(title: "챌린지 정보", isSeparatorHidden: false) {
+                dismiss()
+            }
+            .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
+            
+            ChallengeImageView(missionImage: challenge.challengeImage ?? .logo, challengeData: challenge)
+        }
+        .navigationBarBackButtonHidden()
+    }
+}

--- a/ILSANG/Sources/Views/Profile/OtherUserChallengeList.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserChallengeList.swift
@@ -1,0 +1,48 @@
+//
+//  OtherUserChallengeList.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 3/8/25.
+//
+
+import SwiftUI
+
+struct OtherUserChallengeList: View {
+    @ObservedObject var vm: OtherUserProfileViewModel
+    
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 9) {
+                ForEach(Array(vm.challengeList.enumerated()), id: \.offset) { idx, challenge in
+                    NavigationLink {
+                        OtherUserChallengeDetailView(challenge: challenge)
+                    } label: {
+                        ChallengeListItemView(challenge: challenge)
+                    }
+                }
+                
+                if vm.hasMorePage() {
+                    ProgressView()
+                        .padding(.top, 12)
+                        .task {
+                            await vm.challengePaginationManager.loadData(isRefreshing: false)
+                        }
+                }
+            }
+            .padding(.bottom, 72)
+        }
+        .refreshable {
+            await vm.challengePaginationManager.loadData(isRefreshing: true)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay {
+            if vm.challengeList.isEmpty {
+                EmptyView(title: "수행한 퀘스트가 없어요!")
+            }
+        }
+    }
+}
+
+#Preview {
+    OtherUserChallengeList(vm: OtherUserProfileViewModel(customerId: "CUS00000000", userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork()))
+}

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
@@ -1,0 +1,112 @@
+//
+//  OtherUserProfileView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 3/8/25.
+//
+
+import SwiftUI
+
+struct OtherUserProfileView: View {
+    @StateObject var vm: OtherUserProfileViewModel
+    @Environment(\.dismiss) var dismiss
+    
+    init(customerId: String) {
+        _vm = StateObject(wrappedValue: OtherUserProfileViewModel(customerId: customerId, userNetwork: UserNetwork(), challengeNetwork: ChallengeNetwork(), imageNetwork: ImageNetwork(), xpNetwork: XPNetwork()))
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            header  // 타이틀
+            content // 프로필 & 능력별 포인트 & 도전내역 목록
+        }
+        .background(Color.background)
+        .navigationBarBackButtonHidden(true)
+        .task {
+            await vm.loadInitialData()
+        }
+    }
+    
+    private var header: some View {
+        NavigationTitleView(title: "프로필 정보", isSeparatorHidden: false) {
+            dismiss()
+        }
+        .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
+    }
+    
+    private var content: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                userProfileSection
+                xpStatPolygonSection
+                challengeSection
+            }
+            .padding(.top, 16)
+            .padding(.horizontal, 20)
+        }
+    }
+    
+    private var userProfileSection: some View {
+        HStack(spacing: 16) {
+            // 프로필 이미지
+            ProfileImageView(profileImage: nil)
+            
+            // 프로필 상세 - 닉네임, 레벨
+            VStack(alignment: .leading, spacing: 4) {
+                Text(vm.userData?.nickname ?? "일상")
+                    .styledFont(.heading2)
+                    .foregroundStyle(.gray500)
+                    .multilineTextAlignment(.leading)
+                HStack(alignment: .center, spacing: 6) {
+                    Text("LV.\(vm.currentLv)")
+                        .styledFont(.heading2)
+                        .foregroundStyle(.primary500)
+                    Text("|")
+                        .styledFont(.regular, size: 13, lineHeight: 18, tracking: -0.3)
+                        .foregroundStyle(.gray100)
+                    Text("\(vm.userData?.xpPoint ?? 0)XP")
+                        .styledFont(.semibold, size: 13, lineHeight: 20, tracking: -0.3)
+                        .foregroundStyle(.gray400)
+                        .offset(y: 0.4)
+                }
+                
+                ProgressBar(progress: vm.progress)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.white)
+        )
+    }
+    
+    private var xpStatPolygonSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("능력별 포인트")
+                .styledFont(.heading2)
+                .foregroundColor(.gray400)
+                .padding(.leading, 4)
+            
+            OtherUserXpStatView(xpPoint: vm.userData?.xpPoint, xpStats: vm.xpStats)
+                .zIndex(10)
+        }
+    }
+    
+    private var challengeSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("수행한 챌린지")
+                .styledFont(.heading2)
+                .foregroundColor(.gray400)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 4)
+            
+            OtherUserChallengeList(vm: vm)
+        }
+    }
+}
+
+#Preview {
+    OtherUserProfileView(customerId: "IUS0000000")
+}
+

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
@@ -1,0 +1,142 @@
+//
+//  OtherUserProfileViewModel.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 3/8/25.
+//
+
+import Foundation
+import UIKit
+
+@MainActor
+final class OtherUserProfileViewModel: ObservableObject {
+    @Published var userData: User?
+    
+    @Published var xpStats: [XpStat: Int] = [:]
+    @Published var challengeList: [ChallengeViewModelItem] = []
+    
+    lazy var challengePaginationManager = PaginationManager<ChallengeViewModelItem>(
+        size: 10,
+        threshold: 7,
+        loadPage: { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await loadChallengeListWithImage(page: page, size: 10)
+        }
+    )
+    
+    let customerId: String
+    private let userNetwork: UserNetwork
+    private let challengeNetwork: ChallengeNetwork
+    private let imageNetwork: ImageNetwork
+    private let xpNetwork: XPNetwork
+    
+    var currentLv: Int {
+        XpLevelCalculator.convertXPtoLv(xp: userData?.xpPoint)
+    }
+    var progress: Double {
+        let levelData = XpLevelCalculator.xpProgressInCurrentLevel(xp: userData?.xpPoint ?? 0, level: currentLv)
+        return XpLevelCalculator.calculateProgress(currentValue: levelData.currentLevelXP, totalValue: levelData.requiredXPForNextLevel)
+    }
+    
+    init(customerId: String, userNetwork: UserNetwork, challengeNetwork: ChallengeNetwork, imageNetwork: ImageNetwork, xpNetwork: XPNetwork) {
+        self.customerId = customerId
+        
+        self.userNetwork = userNetwork
+        self.challengeNetwork = challengeNetwork
+        self.imageNetwork = imageNetwork
+        self.xpNetwork = xpNetwork
+    }
+    
+    func loadInitialData() async {
+        await fetchUser(customerId: customerId)
+        await fetchXpStats(customerId: customerId)
+        await challengePaginationManager.loadData(isRefreshing: true)
+    }
+    
+    @discardableResult @MainActor
+    func loadChallengeListWithImage(page: Int, size: Int) async -> ([ChallengeViewModelItem], Int) {
+        let getChallengeList = await fetchChallenges(page: page, size: size)
+        let newChallengeList = getChallengeList.data
+        
+        if page == 0 {
+            self.challengeList = newChallengeList
+        } else {
+            self.challengeList += newChallengeList
+        }
+        
+        await withTaskGroup(of: (Int, UIImage?).self) { group in
+            for (index, challenge) in newChallengeList.enumerated() {
+                group.addTask {
+                    let imageId = challenge.challengeImageId
+                    let image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+                    return (index, image)
+                }
+            }
+            
+            for await (index, image) in group {
+                if let image = image {
+                    if page == 0 {
+                        self.challengeList[index].challengeImage = image
+                    } else {
+                        self.challengeList[challengeList.count - newChallengeList.count + index].challengeImage = image
+                    }
+                }
+            }
+        }
+        
+        return (challengeList, getChallengeList.total)
+    }
+    
+    private func fetchChallenges(page: Int, size: Int) async -> (data: [ChallengeViewModelItem], total: Int) {
+        let response = await challengeNetwork.getChallenges(page: page, size: size, userId: customerId)
+        
+        switch response {
+        case .success(let res):
+            // 데이터 초기화: 이미지가 없는 상태로 미리 표시
+            return (res.data.map {ChallengeViewModelItem.init(challenge: $0)}, res.total)
+        case .failure(let error):
+            Log("챌린지 조회 실패: \(error)")
+            return ([], 0)
+        }
+    }
+    
+    @MainActor
+    func fetchUser(customerId: String) async {
+        let res = await userNetwork.getUser(customerId: customerId)
+        
+        switch res {
+        case .success(let model):
+            self.userData = model.data
+        case .failure(let error):
+            self.userData = nil
+            Log("사용자 정보 조회 실패: \(error)")
+        }
+    }
+    
+    @MainActor
+    func fetchXpStats(customerId: String) async {
+        let res = await xpNetwork.getXpStats(customerId: customerId)
+        
+        switch res {
+        case .success(let model):
+            let xpData = model.data
+            self.xpStats = [
+                .strength: xpData.strengthStat,
+                .intellect: xpData.intellectStat,
+                .fun: xpData.funStat,
+                .charm: xpData.charmStat,
+                .sociability: xpData.sociabilityStat
+            ]
+        case .failure(let error):
+            Log("XP 스탯 조회 실패: \(error)")
+        }
+    }
+    
+    func getImage(imageId: String) async -> UIImage? {
+        await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+    }
+    
+    func hasMorePage() -> Bool {
+        challengePaginationManager.canLoadMoreData()
+    }
+}

--- a/ILSANG/Sources/Views/Profile/OtherUserXpStatView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserXpStatView.swift
@@ -1,0 +1,103 @@
+//
+//  OtherUserXpStatView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 3/8/25.
+//
+
+import SwiftUI
+
+struct OtherUserXpStatView: View {
+    let xpPoint: Int?
+    let xpStats: [XpStat: Int]
+    
+    @State private var touchedIdx: Int? = nil
+    
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12).fill(.white)
+            
+            StatLabels(width: 185)
+                .zIndex(13)
+                .padding(.top, 44)
+            
+            PentagonGraphView(
+                xpPoint: xpPoint ?? 10,
+                xpStats: xpStats,
+                width: 185
+            )
+            .padding(28)
+            .padding(.top, 16)
+        }
+    }
+    
+    // 스탯 레이블 위치 지정
+    private func StatLabels(width: CGFloat) -> some View {
+        ForEach(Array(XpStat.allCases.enumerated()), id: \.element) { index, stat in
+            let angle = calculateAngle(index: index, totalCount: XpStat.sortedStat.count)
+            let labelPoint = calculateLabelPosition(width: width, angle: angle)
+            
+            ZStack {
+                PentagonStatLabel(xpStat: stat)
+                    .position(x: labelPoint.x, y: labelPoint.y)
+                    .onTapGesture {
+                        touchedIdx = (touchedIdx == index) ? nil : index
+                    }
+                
+                if touchedIdx == index, let point = xpStats[stat] {
+                    PopoverStatLabel(stat: stat, statPoint: point)
+                        .position(x: labelPoint.x, y: labelPoint.y - 25) // 위치 조정
+                        .zIndex(3)
+                }
+            }
+            .padding(.top, 20)
+        }
+        .frame(width: width, alignment: .center)
+    }
+    
+    private func calculateAngle(index: Int, totalCount: Int) -> CGFloat {
+        return (CGFloat(index) / CGFloat(totalCount)) * 2 * .pi - .pi / 2
+    }
+    
+    private func calculateLabelPosition(width: CGFloat, angle: CGFloat) -> CGPoint {
+        let radius = width / 2
+        return CGPoint(
+            x: width / 2 + (radius + 36) * cos(angle),
+            y: width / 2 + (radius + 14) * sin(angle) - 16
+        )
+    }
+    
+    private func PentagonStatLabel(xpStat: XpStat) -> some View {
+        HStack(spacing: 0) {
+            Image(xpStat.image)
+                .resizable()
+                .scaledToFit()
+                .frame(height: 20)
+                .frame(width: 30, height: 30)
+            Text(xpStat.headerText)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.gray500)
+        }
+    }
+    
+    private func PopoverStatLabel(stat: XpStat, statPoint: Int) -> some View {
+        VStack(spacing: 0) {
+            Text("\(stat.headerText): \(statPoint) P")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.white)
+                .padding(8)
+                .background(.accent)
+                .cornerRadius(8)
+            
+            Polygon(count: 3, cornerRadius: 2)
+                .frame(width: 18, height: 18)
+                .foregroundColor(.accent)
+                .offset(y: 8)
+                .rotationEffect(.degrees(180))
+        }
+    }
+}
+
+#Preview {
+    OtherUserXpStatView(xpPoint: 140, xpStats: [.charm: 10, .fun: 40, .sociability: 50, .intellect: 40])
+}

--- a/ILSANG/Sources/Views/Ranking/RankingItemView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingItemView.swift
@@ -72,6 +72,7 @@ fileprivate struct RankingHorizontalItemView: View {
             VStack (alignment: .leading, spacing: 4) {
                 Text(rank.nickname)
                     .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(.black)
                 
                 if let xpType = rank.xpType {
                     Text("\(convertStat(xpType)) : \(rank.score)p")

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -64,7 +64,11 @@ extension RankingView {
             LazyVStack(spacing: 12) {
                 if let ranks = vm.userRank[vm.selectedXpStat] {
                     ForEach(Array(ranks.enumerated()), id: \.element.customerId) { idx, rank in
-                        RankingItemView(idx: idx + 1, statRank: rank, style: .horizontal)
+                        NavigationLink {
+                            OtherUserProfileView(customerId: rank.customerId)
+                        } label: {
+                            RankingItemView(idx: idx + 1, statRank: rank, style: .horizontal)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### close #288

### ✏️ 개요
앱 내 인터랙션 추가에 따라 다른 사용자의 정보(프로필, 스탯, 도전 내역)을 조회할 수 있도록 개선합니다.
이를 위해 기존 API의 응답 모델에 사용자 아이디 필드를 추가합니다.
앱 전반에서 다른 유저의 프로필 UI를 클릭하면 해당 사용자의 정보 화면이 표시되도록 구현합니다.

### 💻 작업 사항
- 기존 API 응답 모델 수정
- 프로필 UI 구현
- 화면 이동 구현

### 📱결과 화면(optional)

![Simulator Screen Recording - iPhone 12 Pro - 2025-03-08 at 15 10 59](https://github.com/user-attachments/assets/457dfb14-7e35-44ba-b79e-6dcf34d70887)
