### PR TITLE
[Feat/#295] 마이탭 - 활동로그 비활성화

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -1254,7 +1254,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1461,7 +1461,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1505,7 +1505,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.4;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Challenge: Decodable, Hashable {
     let challengeId: String
     let customerId: String?
+    let userProfileImageId: String?
     let userNickName: String?
     let missionTitle: String?
     let receiptImageId, status: String
@@ -20,6 +21,7 @@ struct Challenge: Decodable, Hashable {
     enum CodingKeys: String, CodingKey {
         case challengeId
         case customerId
+        case userProfileImageId = "userProfileImage"
         case userNickName
         case missionTitle
         case receiptImageId
@@ -30,5 +32,5 @@ struct Challenge: Decodable, Hashable {
         case hateCnt
     }
     
-    static let challengeMockData = Challenge(challengeId: "", customerId: "", userNickName: "일상유저123", missionTitle: "바닐라라떼 마시기", receiptImageId: "", status: "", questImageId: "", createdAt: "2024-01-01'T'00:00:00", likeCnt: 3, hateCnt: 0)
+    static let challengeMockData = Challenge(challengeId: "", customerId: "", userProfileImageId: nil, userNickName: "일상유저123", missionTitle: "바닐라라떼 마시기", receiptImageId: "", status: "", questImageId: "", createdAt: "2024-01-01'T'00:00:00", likeCnt: 3, hateCnt: 0)
 }

--- a/ILSANG/Sources/Model/StatRank.swift
+++ b/ILSANG/Sources/Model/StatRank.swift
@@ -10,12 +10,21 @@ struct StatRank: Decodable {
     let xpPoint: Int
     let customerId: String
     let nickname: String
+    let profileImageId: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case xpType
+        case xpPoint
+        case customerId
+        case nickname
+        case profileImageId = "profileImage"
+    }
 }
 
 extension StatRank {
     static let mockDataList: [StatRank] = [
-        StatRank(xpType: "CHARM", xpPoint: 200, customerId: "1234-5678-91011", nickname: "TestUser1"),
-        StatRank(xpType: "STRENGTH", xpPoint: 150, customerId: "2234-5678-91011", nickname: "TestUser2"),
-        StatRank(xpType: "CHARM", xpPoint: 300, customerId: "3234-5678-91011", nickname: "TestUser3")
+        StatRank(xpType: "CHARM", xpPoint: 200, customerId: "1234-5678-91011", nickname: "TestUser1", profileImageId: nil),
+        StatRank(xpType: "STRENGTH", xpPoint: 150, customerId: "2234-5678-91011", nickname: "TestUser2", profileImageId: nil),
+        StatRank(xpType: "CHARM", xpPoint: 300, customerId: "3234-5678-91011", nickname: "TestUser3", profileImageId: nil)
     ]
 }

--- a/ILSANG/Sources/Model/TopRank.swift
+++ b/ILSANG/Sources/Model/TopRank.swift
@@ -12,4 +12,13 @@ struct TopRank: Decodable {
     let lank: Int
     let xpSum: Int
     let nickname: String
+    let profileImageId: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case customerId
+        case lank
+        case xpSum
+        case nickname
+        case profileImageId = "profileImage"
+    }
 }

--- a/ILSANG/Sources/Service/UserService.swift
+++ b/ILSANG/Sources/Service/UserService.swift
@@ -70,6 +70,7 @@ final class UserService: ObservableObject {
             await updateLoginStatus(false)
             return false
         }
+        dump(authUser)
         guard let user = await authService.loginWithChannel(user: authUser, channel: AuthChannel.fromString(value: authChannel)!) else {
             // try await logout()
             return false

--- a/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
@@ -85,9 +85,10 @@ struct ApprovalItemContentView: View {
     
     private func profileView(nickname: String, time: String) -> some View {
         HStack(spacing: 10) {
-            Image(.profileCircle)
+            Image(uiImage: item.profileImage ?? .profileCircle)
                 .resizable()
                 .frame(width: 35, height: 35)
+                .clipShape(Circle())
             VStack(alignment: .leading, spacing: 3) {
                 Text(nickname)
                     .font(.system(size: 14, weight: .semibold))

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -113,19 +113,27 @@ final class ApprovalViewModel {
     private func enrichChallengesWithImageAndEmoji(
         _ challenges: [ApprovalViewModelItem]
     ) async -> [ApprovalViewModelItem] {
-        await withTaskGroup(of: (Int, UIImage?, Emoji?).self) { group in
+        return await withTaskGroup(of: (Int, UIImage?, UIImage?, Emoji?).self) { group in
             for (index, challenge) in challenges.enumerated() {
                 group.addTask {
-                    let image = await ImageCacheService.shared.loadImageAsync(imageId: challenge.imageId)
-                    let emoji = await self.getEmoji(challengeId: challenge.id)
-                    return (index, image, emoji)
+                    async let challengeImage = ImageCacheService.shared.loadImageAsync(imageId: challenge.imageId)
+                    async let profileImage: UIImage? = {
+                        guard let profileImageId = challenge.profileImageId else { return nil }
+                        return await ImageCacheService.shared.loadImageAsync(imageId: profileImageId)
+                    }()
+                    async let emoji = self.getEmoji(challengeId: challenge.id)
+                    
+                    return (index, await challengeImage, await profileImage, await emoji)
                 }
             }
             
             var enrichedChallenges = challenges
-            for await (index, image, emoji) in group {
-                if let image = image {
-                    enrichedChallenges[index].image = image
+            for await (index, challengeImage, profileImage, emoji) in group {
+                if let challengeImage = challengeImage {
+                    enrichedChallenges[index].image = challengeImage
+                }
+                if let profileImage = profileImage {
+                    enrichedChallenges[index].profileImage = profileImage
                 }
                 if let emoji = emoji {
                     enrichedChallenges[index].emoji = emoji
@@ -311,6 +319,8 @@ struct ApprovalViewModelItem: Identifiable {
     let id: String
     let customerId: String
     let title: String
+    var profileImageId: String?
+    var profileImage: UIImage?
     var image: UIImage?
     var imageId: String
     var nickname: String
@@ -323,6 +333,8 @@ struct ApprovalViewModelItem: Identifiable {
         id: String = UUID().uuidString,
         customerId: String,
         title: String,
+        profileImageId:String?,
+        profileImage: UIImage?,
         image: UIImage? = nil,
         imageId: String,
         nickname: String,
@@ -334,6 +346,8 @@ struct ApprovalViewModelItem: Identifiable {
         self.id = id
         self.customerId = customerId
         self.title = title
+        self.profileImageId = profileImageId
+        self.profileImage = profileImage
         self.image = image
         self.imageId = imageId
         self.nickname = nickname
@@ -347,6 +361,8 @@ struct ApprovalViewModelItem: Identifiable {
         self.id = challenge.challengeId
         self.customerId = challenge.customerId ?? ""
         self.title = challenge.missionTitle ?? ""
+        self.profileImage = nil
+        self.profileImageId = challenge.userProfileImageId
         self.image = nil
         self.imageId = challenge.receiptImageId
         // TODO: nickname 옵셔널 해제
@@ -360,6 +376,9 @@ struct ApprovalViewModelItem: Identifiable {
     static var failedData = ApprovalViewModelItem(
         customerId: "",
         title: "불러올 수 없습니다",
+        profileImageId: nil,
+        profileImage: nil,
+        image: nil,
         imageId: "",
         nickname: "",
         time: "",
@@ -369,9 +388,9 @@ struct ApprovalViewModelItem: Identifiable {
     )
     
     static var mockDataList = [
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상1", time: "3시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상2", time: "1시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상3", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", imageId: "IMRE2024061314275774", nickname: "일상4", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false))
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상1", time: "3시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상2", time: "1시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상3", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상4", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false))
     ]
 }

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -68,9 +68,10 @@ struct HomeView: View {
             Button {
                 sharedState.selectedTab = .mypage /// 마이 탭으로 이동
             } label: {
-                Image(.profileCircle)
+                Image(uiImage: vm.userProfileImage ?? .profileCircle)
                     .resizable()
                     .frame(width: 36, height: 36)
+                    .clipShape(Circle())
             }
         }
         .padding(.horizontal, LayoutConstants.horizontalPadding)

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -15,6 +15,7 @@ enum ViewStatus {
 
 final class HomeViewModel: ObservableObject {
     @Published var viewStatus: ViewStatus = .loading
+    @Published var userProfileImage: UIImage?
     var recommendQuestTitle: String {
         if let nickname = UserService.shared.currentUser?.nickname {
             return nickname + "님을 위한 추천 퀘스트"
@@ -23,7 +24,7 @@ final class HomeViewModel: ObservableObject {
         }
     }
     @Published var mainBanners: [Banner] = []
-    @Published var userRankList: [TopRank] = [] // 10개
+    @Published var userRankList: [TopRankViewModelItem] = [] // 10개
     @Published var largestRewardQuestList: [XpStat: [QuestViewModelItem]] = [:] // 3*5개
     @Published var recommendQuestList: [QuestViewModelItem] = [] //QuestViewModelItem.mockQuestList // 10개
     @Published var popularQuestList: [QuestViewModelItem] = QuestViewModelItem.mockQuestList // 4n개
@@ -132,8 +133,12 @@ final class HomeViewModel: ObservableObject {
             try? await loadUncompleteQuestList()
             self.showRecommendRewardQuest = true
             self.showPopularRewardQuest = true
-
         }
+
+        if let userProfileImage = UserService.shared.currentUser?.profileImage {
+            self.userProfileImage = await ImageCacheService.shared.loadImageAsync(imageId: userProfileImage)
+        }
+
         changeViewStatus(.loaded)
     }
     
@@ -215,7 +220,25 @@ final class HomeViewModel: ObservableObject {
         
         switch res {
         case .success(let rank):
-            self.userRankList = rank.data
+            self.userRankList = rank.data.map({ TopRankViewModelItem(rank: $0) })
+            // TODO: 유틸 함수로 만들기
+            await withTaskGroup(of: (Int, UIImage?).self) { group in
+                for (index, rank) in userRankList.enumerated() {
+                    group.addTask {
+                        guard let imageId = rank.profileImageId else { return (index, nil) }
+                        let image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+                        return (index, image)
+                    }
+                }
+                
+                /// UI 업데이트
+                for await (index, image) in group {
+                    await MainActor.run {
+                        self.userRankList[index].profileImage = image
+                    }
+                }
+            }
+            
         case .failure(let error):
             throw error
         }
@@ -309,5 +332,32 @@ final class HomeViewModel: ObservableObject {
     func onQuestApprovalTapped() {
         showQuestSheet = false
         showSubmitRouterView = true
+    }
+}
+
+struct TopRankViewModelItem {
+    let customerId: String
+    let lank: Int
+    let xpSum: Int
+    let nickname: String
+    let profileImageId: String?
+    var profileImage: UIImage?
+    
+    init(customerId: String, lank: Int, xpSum: Int, nickname: String, profileImageId: String?, profileImage: UIImage?) {
+        self.customerId = customerId
+        self.lank = lank
+        self.xpSum = xpSum
+        self.nickname = nickname
+        self.profileImageId = profileImageId
+        self.profileImage = profileImage
+    }
+    
+    init(rank: TopRank) {
+        self.customerId = rank.customerId
+        self.lank = rank.lank
+        self.xpSum = rank.xpSum
+        self.nickname = rank.nickname
+        self.profileImageId = rank.profileImageId
+        self.profileImage = nil
     }
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -25,19 +25,19 @@ struct MyPageActiveList: View {
                         MyPageListItemView(title: xpLog.title, detail: xpLog.createDate.timeAgoSinceCreation(), point: xpLog.xpPoint)
                     }
                     
-                    if vm.hasMorePage(for: .xpLog) {
-                        ProgressView()
-                            .padding(.top, 12)
-                            .task {
-                                await vm.xpLogPaginationManager.loadData(isRefreshing: false)
-                            }
-                    }
+//                    if vm.hasMorePage(for: .xpLog) {
+//                        ProgressView()
+//                            .padding(.top, 12)
+//                            .task {
+//                                await vm.xpLogPaginationManager.loadData(isRefreshing: false)
+//                            }
+//                    }
                 }
                 .padding(.bottom, 60)
             }
-            .refreshable {
-                await vm.xpLogPaginationManager.loadData(isRefreshing: true)
-            }
+//            .refreshable {
+//                await vm.xpLogPaginationManager.loadData(isRefreshing: true)
+//            }
         }
         .overlay {
             if vm.xpLogList.isEmpty {

--- a/ILSANG/Sources/Views/MyPage/MyPageTabView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageTabView.swift
@@ -49,13 +49,13 @@ struct MyPageTabItemView: View {
 
 enum MyPageTab: CaseIterable {
     case quest
-    case activity
+    // case activity
     case info
     
     var title: String {
         switch self {
-        case .quest: return "퀘스트"
-        case .activity: return "활동"
+        case .quest: return "챌린지"
+            // case .activity: return "활동"
         case .info: return "내 정보"
         }
     }
@@ -63,7 +63,7 @@ enum MyPageTab: CaseIterable {
     var icon: String {
         switch self {
         case .quest: return "📜"
-        case .activity: return "⛳️"
+            // case .activity: return "⛳️"
         case .info: return "🎖️"
         }
     }

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -65,8 +65,8 @@ struct MyPageView: View {
         switch vm.selectedTab {
         case .quest:
             MyPageChallengeList(vm: vm)
-        case .activity:
-            MyPageActiveList(vm: vm)
+//        case .activity:
+//            MyPageActiveList(vm: vm)
         case .info:
             MyPageInfoView(xpPoint: vm.userData?.xpPoint, xpStats: vm.xpStats)
         }

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -28,14 +28,14 @@ final class MyPageViewModel: ObservableObject {
         }
     )
     
-    lazy var xpLogPaginationManager = PaginationManager<XpLog>(
-        size: 10,
-        threshold: 7,
-        loadPage: { [weak self] page in
-            guard let self = self else { return ([], 0) }
-            return await loadXpLogList(page: page, size: 10)
-        }
-    )
+//    lazy var xpLogPaginationManager = PaginationManager<XpLog>(
+//        size: 10,
+//        threshold: 7,
+//        loadPage: { [weak self] page in
+//            guard let self = self else { return ([], 0) }
+//            return await loadXpLogList(page: page, size: 10)
+//        }
+//    )
     
     private let userNetwork: UserNetwork
     private let challengeNetwork: ChallengeNetwork
@@ -61,7 +61,7 @@ final class MyPageViewModel: ObservableObject {
     func loadInitialData() async {
         // TODO: 도전내역 등록했을 때 재호출하도록 수정
         await challengePaginationManager.loadData(isRefreshing: true)
-        await xpLogPaginationManager.loadData(isRefreshing: true)
+        // await xpLogPaginationManager.loadData(isRefreshing: true)
     }
     
     @discardableResult @MainActor
@@ -98,18 +98,18 @@ final class MyPageViewModel: ObservableObject {
         return (challengeList, getChallengeList.total)
     }
     
-    @discardableResult @MainActor
-    func loadXpLogList(page: Int, size: Int) async -> ([XpLog], Int) {
-        let getXpLogList = await fetchXpLog(page: page, size: size)
-        
-        if page == 0 {
-            self.xpLogList = getXpLogList.data
-        } else {
-            self.xpLogList += getXpLogList.data
-        }
-        
-        return (xpLogList, getXpLogList.total)
-    }
+//    @discardableResult @MainActor
+//    func loadXpLogList(page: Int, size: Int) async -> ([XpLog], Int) {
+//        let getXpLogList = await fetchXpLog(page: page, size: size)
+//        
+//        if page == 0 {
+//            self.xpLogList = getXpLogList.data
+//        } else {
+//            self.xpLogList += getXpLogList.data
+//        }
+//        
+//        return (xpLogList, getXpLogList.total)
+//    }
     
     private func fetchChallenges(page: Int, size: Int) async -> (data: [ChallengeViewModelItem], total: Int) {
         let response = await challengeNetwork.getChallenges(page: page, size: size)
@@ -124,17 +124,17 @@ final class MyPageViewModel: ObservableObject {
         }
     }
     
-    private func fetchXpLog(page: Int, size: Int) async -> (data: [XpLog], total: Int) {
-        let res = await xpNetwork.getXpHistory(page: page, size: size)
-        
-        switch res {
-        case .success(let model):
-            return (model.data, model.total)
-        case .failure(let error):
-            Log("XP 로그 조회 실패: \(error)")
-            return ([], 0)
-        }
-    }
+//    private func fetchXpLog(page: Int, size: Int) async -> (data: [XpLog], total: Int) {
+//        let res = await xpNetwork.getXpHistory(page: page, size: size)
+//        
+//        switch res {
+//        case .success(let model):
+//            return (model.data, model.total)
+//        case .failure(let error):
+//            Log("XP 로그 조회 실패: \(error)")
+//            return ([], 0)
+//        }
+//    }
     
     @MainActor
     func fetchUser() async {
@@ -188,13 +188,13 @@ final class MyPageViewModel: ObservableObject {
         switch type {
         case .challenge:
             return challengePaginationManager.canLoadMoreData()
-        case .xpLog:
-            return xpLogPaginationManager.canLoadMoreData()
+//        case .xpLog:
+//            return xpLogPaginationManager.canLoadMoreData()
         }
     }
     
     enum PaginationDataType {
         case challenge
-        case xpLog
+//        case xpLog
     }
 }

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
@@ -49,7 +49,7 @@ struct OtherUserProfileView: View {
     private var userProfileSection: some View {
         HStack(spacing: 16) {
             // 프로필 이미지
-            ProfileImageView(profileImage: nil)
+            ProfileImageView(profileImage: vm.userProfileIamge)
             
             // 프로필 상세 - 닉네임, 레벨
             VStack(alignment: .leading, spacing: 4) {

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 @MainActor
 final class OtherUserProfileViewModel: ObservableObject {
     @Published var userData: User?
+    @Published var userProfileIamge: UIImage?
     
     @Published var xpStats: [XpStat: Int] = [:]
     @Published var challengeList: [ChallengeViewModelItem] = []
@@ -107,6 +108,7 @@ final class OtherUserProfileViewModel: ObservableObject {
         switch res {
         case .success(let model):
             self.userData = model.data
+            self.userProfileIamge = await ImageCacheService.shared.loadImageAsync(imageId: model.data.profileImage ?? "")
         case .failure(let error):
             self.userData = nil
             Log("사용자 정보 조회 실패: \(error)")

--- a/ILSANG/Sources/Views/Ranking/RankingItemView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingItemView.swift
@@ -12,6 +12,8 @@ struct Rank {
     let nickname: String
     var xpType: String? = nil
     let score: Int
+    var profileImageId: String?
+    var profileIamge: UIImage?
 }
 
 struct RankingItemView: View {
@@ -23,13 +25,13 @@ struct RankingItemView: View {
         case vertical
     }
     
-    init(topRank: TopRank, style: RankingItemStyle) {
-        self.rank = Rank(idx: topRank.lank, nickname: topRank.nickname, score: topRank.xpSum)
+    init(topRank: TopRankViewModelItem, style: RankingItemStyle) {
+        self.rank = Rank(idx: topRank.lank, nickname: topRank.nickname, score: topRank.xpSum, profileImageId: topRank.profileImageId, profileIamge: topRank.profileImage)
         self.style = style
     }
     
-    init(idx: Int, statRank: StatRank, style: RankingItemStyle) {
-        self.rank = Rank(idx: idx, nickname: statRank.nickname, xpType: statRank.xpType, score: statRank.xpPoint)
+    init(idx: Int, statRank: StatRankViewModelItem, style: RankingItemStyle) {
+        self.rank = Rank(idx: idx, nickname: statRank.nickname, xpType: statRank.xpType, score: statRank.xpPoint, profileImageId: statRank.profileImageId, profileIamge: statRank.profileImage)
         self.style = style
     }
     
@@ -60,14 +62,21 @@ fileprivate struct RankingHorizontalItemView: View {
                     .font(.system(size: 15, weight: .bold))
                     .foregroundStyle(.gray500)
             }
-            
-            Text("😍")
-                .font(.system(size: 23, weight: .bold))
-                .frame(width: 48, height: 48)
-                .background(
-                    Circle().fill(Color.backgroundBlue)
-                )
-                .padding(.horizontal, UIDevice.isSEDevice ? 16 : 24)
+            if let profileIamge = rank.profileIamge {
+                Image(uiImage: profileIamge)
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .clipShape(Circle())
+                    .padding(.horizontal, UIDevice.isSEDevice ? 16 : 24)
+            } else {
+                Text("😍")
+                    .font(.system(size: 23, weight: .bold))
+                    .frame(width: 48, height: 48)
+                    .background(
+                        Circle().fill(Color.backgroundBlue)
+                    )
+                    .padding(.horizontal, UIDevice.isSEDevice ? 16 : 24)
+            }
             
             VStack (alignment: .leading, spacing: 4) {
                 Text(rank.nickname)
@@ -119,13 +128,21 @@ fileprivate struct RankingVerticalItemView: View {
     
     var body: some View {
         VStack(spacing: 6) {
-            Text("😍")
-                .font(.system(size: 23, weight: .bold))
-                .frame(width: 64, height: 64)
-                .background(
-                    Circle().fill(Color.backgroundBlue)
-                )
-                .padding(6)
+            if let profileIamge = rank.profileIamge {
+                Image(uiImage: profileIamge)
+                    .resizable()
+                    .frame(width: 64, height: 64)
+                    .clipShape(Circle())
+                    .padding(6)
+            } else {
+                Text("😍")
+                    .font(.system(size: 23, weight: .bold))
+                    .frame(width: 64, height: 64)
+                    .background(
+                        Circle().fill(Color.backgroundBlue)
+                    )
+                    .padding(6)
+            }
             
             // 랭킹 아이콘 & 순위
             let idx = rank.idx

--- a/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
@@ -19,7 +19,7 @@ class RankingViewModel: ObservableObject {
     
     @Published var viewStatus: ViewStatus = .loading
     @Published var selectedXpStat: XpStat = .strength
-    @Published var userRank: [XpStat: [StatRank]] = Dictionary(uniqueKeysWithValues: XpStat.allCases.map { ($0, []) })
+    @Published var userRank: [XpStat: [StatRankViewModelItem]] = Dictionary(uniqueKeysWithValues: XpStat.allCases.map { ($0, []) })
     
     private let rankNetwork: RankNetwork
     
@@ -41,7 +41,22 @@ class RankingViewModel: ObservableObject {
         
         switch res {
         case .success(let response):
-            self.userRank[xpStat] = response.data
+            let items = await withTaskGroup(of: (Int, StatRankViewModelItem).self) { group in
+                for (index, rank) in response.data.enumerated() {
+                    group.addTask {
+                        let item = await StatRankViewModelItem(rank: rank)
+                        return (index, item)
+                    }
+                }
+                
+                var results = Array<StatRankViewModelItem?>(repeating: nil, count: response.data.count)
+                for await (index, item) in group {
+                    results[index] = item
+                }
+                
+                return results.compactMap { $0 } // nil 제거
+            }
+            self.userRank[xpStat] = items
             changeViewStatus(.loaded)
         case .failure:
             changeViewStatus(.error)
@@ -55,3 +70,31 @@ class RankingViewModel: ObservableObject {
     }
 }
 
+import UIKit
+
+struct StatRankViewModelItem {
+    let xpType: String
+    let xpPoint: Int
+    let customerId: String
+    let nickname: String
+    let profileImageId: String?
+    let profileImage: UIImage?
+    
+    init(xpType: String, xpPoint: Int, customerId: String, nickname: String, profileImageId: String?, profileImage: UIImage?) {
+        self.xpType = xpType
+        self.xpPoint = xpPoint
+        self.customerId = customerId
+        self.nickname = nickname
+        self.profileImageId = profileImageId
+        self.profileImage = profileImage
+    }
+    
+    init(rank: StatRank) async {
+        self.xpType = rank.xpType
+        self.xpPoint = rank.xpPoint
+        self.customerId = rank.customerId
+        self.nickname = rank.nickname
+        self.profileImageId = rank.profileImageId
+        self.profileImage = await ImageCacheService.shared.loadImageAsync(imageId: rank.profileImageId ?? "")
+    }
+}


### PR DESCRIPTION
#### close #295

### ✏️ 개요
마이탭의 활동로그를 비활성화합니다.

### 💻 작업 사항
- 마이탭 활동로그 비활성화
- 마이탭 - 세그먼트 타이틀 수정(퀘스트 >> 챌린지)
- 마케팅 버전 수정

### 📱결과 화면(optional)
| AS-IS | TO-BE |
|--------|--------|
| ![IMG_2849](https://github.com/user-attachments/assets/b5d13a0e-6ded-4b7d-8024-df0531f33034) | ![IMG_2850](https://github.com/user-attachments/assets/28a06649-b758-4a4d-8d44-8168967fe877) | 

