### PR TITLE
[Feat/#299] 홈탭 - 큰보상퀘스트 - 전체보기 선택 시 퀘스트탭 - 기본 퀘스트로 설정

### DIFF
--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -43,7 +43,9 @@ struct QuestView: View {
             vm.closeFilterPicker()
         }
         .onReceive(sharedState.$selectedXpStat) { newValue in
+            // 외부에서 스탯 변경 시 기본 탭으로 변경
             vm.selectedXpStat = newValue
+            vm.selectedHeader = .default
         }
         .sheet(isPresented: $vm.showQuestSheet) {
             QuestDetailView(quest: vm.selectedQuest) {


### PR DESCRIPTION
#### close #299

### ✏️ 개요

> [홈 > 큰 보상 퀘스트 > 전체 보기]
> 클릭 시 기존에 유저가 퀘스트탭(기본/반복/완료)에서 있던 곳으로 갑니다! 
> 클릭 시 `기본`퀘스트로 항상 가도록 설정 부탁드립니다!


### 💻 작업 사항
- `큰 보상 퀘스트-전체보기` 선택 시 퀘스트 탭의 헤더 = `기본 퀘스트`로 설정