### PR TITLE
[Feat/#311] 퀘스트탭 - 완료: 이벤트 날짜 태그 안보이도록 수정

### DIFF
--- a/ILSANG/Sources/Views/Quest/Component/StatGridView.swift
+++ b/ILSANG/Sources/Views/Quest/Component/StatGridView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct StatGridView: View {
     let rewardDic: [XpStat: Int]
     let expireDate: String?
+    let showEventTagView: Bool
     
     var body: some View {
         if rewardDic.filter({ $0.value > 0 }).count <= 2 {
@@ -54,7 +55,7 @@ struct StatGridView: View {
     
     @ViewBuilder
     private var eventTagView: some View {
-        if let tagTitle = expireDate?.timeAgoSinceDate(withYear: false) {
+        if let tagTitle = expireDate?.timeAgoSinceDate(withYear: false), showEventTagView {
             TagView(title: "~"+tagTitle, tagStyle: .eventDate)
         }
     }
@@ -62,6 +63,6 @@ struct StatGridView: View {
 
 
 #Preview {
-    StatGridView(rewardDic: [.charm: 225, .fun: 0, .intellect: 392, .strength: 20, .sociability: 20], expireDate: nil)
+    StatGridView(rewardDic: [.charm: 225, .fun: 0, .intellect: 392, .strength: 20, .sociability: 20], expireDate: nil, showEventTagView: false)
         .padding(.horizontal, 20)
 }

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -81,7 +81,11 @@ struct DefaultQuestView<Style: DefaultQuestStyleProtocol>: View {
                         .font(.system(size: 13, weight: .regular))
                         .foregroundColor(.gray400)
                         .padding(.bottom, 4)
-                    StatGridView(rewardDic: quest.rewardDic, expireDate: quest.type == "EVENT" ? quest.expireDate : nil)
+                    StatGridView(
+                        rewardDic: quest.rewardDic,
+                        expireDate: quest.type == "EVENT" ? quest.expireDate : nil,
+                        showEventTagView: Style.self != CompletedStyle.self 
+                    )
                 }
                 Spacer(minLength: 0)
                 style.trailingView()


### PR DESCRIPTION
#### relate #311

### 💻 작업 사항
이벤트 날짜 태그는 퀘스트-이벤트 탭에서만 확인할 수 있도록 수정했습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/user-attachments/assets/56ea13df-903a-4e22-8b0d-cbae7fe3cdfd" width = "300"> 
<img src = "https://github.com/user-attachments/assets/4b4230e4-8611-4313-b438-399d73fa02a4" width = "300"> 
