### PR TITLE
[Feat/#339] 사용자 정보에 칭호 추가 대응

### DIFF
--- a/ILSANG/Sources/Model/Challenge.swift
+++ b/ILSANG/Sources/Model/Challenge.swift
@@ -18,6 +18,7 @@ struct Challenge: Decodable, Hashable {
     let questImageId: String?
     let createdAt: String
     let likeCnt, hateCnt: Int
+    let honor: Title?
     
     enum CodingKeys: String, CodingKey {
         case challengeId
@@ -31,7 +32,8 @@ struct Challenge: Decodable, Hashable {
         case createdAt
         case likeCnt
         case hateCnt
+        case honor = "title"
     }
     
-    static let challengeMockData = Challenge(challengeId: "", customerId: "", userProfileImageId: nil, userNickName: "일상유저123", missionTitle: "바닐라라떼 마시기", receiptImageId: "", status: "", questImageId: "", createdAt: "2024-01-01'T'00:00:00", likeCnt: 3, hateCnt: 0)
+    static let challengeMockData = Challenge(challengeId: "", customerId: "", userProfileImageId: nil, userNickName: "일상유저123", missionTitle: "바닐라라떼 마시기", receiptImageId: "", status: "", questImageId: "", createdAt: "2024-01-01'T'00:00:00", likeCnt: 3, hateCnt: 0, honor: nil)
 }

--- a/ILSANG/Sources/Model/User.swift
+++ b/ILSANG/Sources/Model/User.swift
@@ -14,7 +14,7 @@ struct User: Decodable {
     let title: Title?
 }
 
-struct Title: Decodable {
+struct Title: Decodable, Hashable {
     let id: String
     let name: String
     let type: String

--- a/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
@@ -25,7 +25,7 @@ struct ApprovalItemContentView: View {
                 NavigationLink {
                     OtherUserProfileView(customerId: item.customerId)
                 } label: {
-                    profileView(nickname: item.nickname, time: item.time)
+                    profileView(nickname: item.nickname, honor: item.honor)
                 }
                 
                 Text(item.title)
@@ -58,6 +58,12 @@ struct ApprovalItemContentView: View {
                         }
                 }
                 
+                Text(item.time)
+                    .font(.system(size: 12, weight: .regular))
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .foregroundStyle(.gray500)
+                    .padding(.trailing, 8)
+                
                 HStack(spacing: 16) {
                     emojiView(imageName: .thumbsUp, count: item.likeCnt, alignment: .top)
                     emojiView(imageName: .thumbsDown, count: item.hateCnt, alignment: .bottom)
@@ -83,17 +89,18 @@ struct ApprovalItemContentView: View {
         }
     }
     
-    private func profileView(nickname: String, time: String) -> some View {
+    private func profileView(nickname: String, honor: Title?) -> some View {
         HStack(spacing: 10) {
             Image(uiImage: item.profileImage ?? .profileCircle)
                 .resizable()
                 .frame(width: 35, height: 35)
                 .clipShape(Circle())
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 6) {
                 Text(nickname)
                     .font(.system(size: 14, weight: .semibold))
-                Text(time)
-                    .font(.system(size: 12, weight: .regular))
+                if let honor, let grade = HonorGrade(rawValue: honor.type) {
+                    HonorIconView(honorTitle: honor.name, grade: grade, imageSize: 20, spacing: 4, font: .badge1, fgColor: .gray500)
+                }
             }
             .foregroundStyle(.gray500)
         }

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -328,6 +328,7 @@ struct ApprovalViewModelItem: Identifiable {
     var likeCnt: Int
     var hateCnt: Int
     var emoji: Emoji?
+    let honor: Title?
     
     init(
         id: String = UUID().uuidString,
@@ -341,7 +342,8 @@ struct ApprovalViewModelItem: Identifiable {
         time: String,
         likeCnt: Int,
         hateCnt: Int,
-        emoji: Emoji?
+        emoji: Emoji?,
+        honor: Title?
     ) {
         self.id = id
         self.customerId = customerId
@@ -355,6 +357,7 @@ struct ApprovalViewModelItem: Identifiable {
         self.likeCnt = likeCnt
         self.hateCnt = hateCnt
         self.emoji = emoji
+        self.honor = honor
     }
     
     init(challenge: Challenge) {
@@ -371,6 +374,7 @@ struct ApprovalViewModelItem: Identifiable {
         self.likeCnt = challenge.likeCnt
         self.hateCnt = challenge.hateCnt
         self.emoji = nil // Emoji(isLike: false, isHate: false) // TODO: 수정
+        self.honor = challenge.honor
     }
     
     static var failedData = ApprovalViewModelItem(
@@ -384,13 +388,14 @@ struct ApprovalViewModelItem: Identifiable {
         time: "",
         likeCnt: 0,
         hateCnt: 0,
-        emoji: nil
+        emoji: nil,
+        honor: nil
     )
     
     static var mockDataList = [
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상1", time: "3시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상2", time: "1시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상3", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false)),
-        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상4", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false))
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상1", time: "3시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false), honor: nil),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상2", time: "1시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false), honor: nil),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상3", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false), honor: nil),
+        ApprovalViewModelItem(customerId: "0000000", title: "바닐라라떼마시기", profileImageId: nil, profileImage: nil, imageId: "IMRE2024061314275774", nickname: "일상4", time: "2시간 전", likeCnt: 0, hateCnt: 0, emoji: Emoji(isLike: false, isHate: false), honor: nil)
     ]
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageActiveList.swift
@@ -41,7 +41,7 @@ struct MyPageActiveList: View {
         }
         .overlay {
             if vm.xpLogList.isEmpty {
-                EmptyView(title: "활동 내역이 없어요!")
+                EmptyStateView(message: "활동 내역이 없어요!", fontScale: .small)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageChallenge/MyPageChallengeList.swift
@@ -36,7 +36,7 @@ struct MyPageChallengeList: View {
         }
         .overlay {
             if vm.challengeList.isEmpty {
-                EmptyView(title: "수행한 퀘스트가 없어요!")
+                EmptyStateView(message: "수행한 퀘스트가 없어요!", fontScale: .small)
             }
         }
     }

--- a/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingView.swift
@@ -35,7 +35,7 @@ struct LegendRankingView: View {
             }
             
             if vm.historyRanks.isEmpty {
-                EmptyView(title: "해당 칭호를 획득한\n유저가 없어요")
+                EmptyStateView(message: "해당 칭호를 획득한\n유저가 없어요", fontScale: .big)
             } else {
                 ScrollView {
                     LazyVStack(spacing: 12) {

--- a/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingView.swift
@@ -24,17 +24,16 @@ struct LegendRankingView: View {
             }
             .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
             .overlay {
-                HStack(spacing: 8) {
-                    if let legendImage = HonorGrade.legend.image {
-                        Image(uiImage: legendImage)
-                            .resizable()
-                            .frame(18)
-                    }
-                    Text(vm.honorName)
-                        .styledFont(.bold, size: 17, lineHeight: 22)
-                        .foregroundStyle(.gray500)
-                }
+                HonorIconView(
+                    honorTitle: vm.honorName,
+                    grade: .legend,
+                    imageSize: 18,
+                    spacing: 8,
+                    font: .init(size: 17, weight: .bold, lineHeight: 22, tracking: 0),
+                    fgColor: .gray500
+                )
             }
+            
             if vm.historyRanks.isEmpty {
                 EmptyView(title: "해당 칭호를 획득한\n유저가 없어요")
             } else {

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -90,12 +90,27 @@ struct MyPageView: View {
     }
 }
 
-struct EmptyView: View {
-    var title: String = ""
+struct EmptyStateView: View {
+    var message: String
+    var fontScale: FontScale
+    
+    enum FontScale {
+        case big
+        case small
+        
+        var font: FontStyle {
+            switch self {
+            case .big:
+                return .init(size: 23, weight: .semibold, lineHeight: 33, tracking: 0)
+            case .small:
+                return .init(size: 17, weight: .medium, lineHeight: 20, tracking: 0)
+            }
+        }
+    }
     
     var body: some View {
-        Text(title)
-            .styledFont(.semibold, size: 23, lineHeight: 33)
+        Text(message)
+            .styledFont(fontScale.font)
             .foregroundColor(.gray300)
             .multilineTextAlignment(.center)
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ILSANG/Sources/Views/Profile/OtherUserChallengeList.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserChallengeList.swift
@@ -37,7 +37,7 @@ struct OtherUserChallengeList: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay {
             if vm.challengeList.isEmpty {
-                EmptyView(title: "수행한 퀘스트가 없어요!")
+                EmptyStateView(message: "수행한 퀘스트가 없어요!", fontScale: .small)
             }
         }
     }

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
@@ -50,27 +50,37 @@ struct OtherUserProfileView: View {
         HStack(spacing: 16) {
             // 프로필 이미지
             ProfileImageView(profileImage: vm.userProfileIamge, imageSize: 57)
+                .overlay {
+                    TagView(title: "LV.\(vm.currentLv)", tagStyle: .levelStroke)
+                        .offset(y: 24)
+                }
             
             // 프로필 상세 - 닉네임, 레벨
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 8) {
                 Text(vm.userData?.nickname ?? "일상")
                     .styledFont(.heading2)
                     .foregroundStyle(.gray500)
                     .multilineTextAlignment(.leading)
-                HStack(alignment: .center, spacing: 6) {
-                    Text("LV.\(vm.currentLv)")
-                        .styledFont(.heading2)
-                        .foregroundStyle(.primary500)
-                    Text("|")
-                        .styledFont(.regular, size: 13, lineHeight: 18, tracking: -0.3)
-                        .foregroundStyle(.gray100)
-                    Text("\(vm.userData?.xpPoint ?? 0)XP")
-                        .styledFont(.semibold, size: 13, lineHeight: 20, tracking: -0.3)
-                        .foregroundStyle(.gray400)
-                        .offset(y: 0.4)
-                }
                 
-                ProgressBar(progress: vm.progress)
+                if let honor = vm.userData?.title, let grade = HonorGrade(rawValue: honor.type)  {
+                    HonorIconView(
+                        honorTitle: honor.name,
+                        grade: grade,
+                        imageSize: 20,
+                        spacing: 4,
+                        font: .badge1,
+                        fgColor: .gray500
+                    )
+                }
+                                    
+                HStack(alignment: .center, spacing: 6) {
+                    ProgressBar(progress: vm.progress)
+                        .frame(height: 8)
+
+                    Text("\(vm.userData?.xpPoint ?? 0)XP")
+                        .styledFont(.bold, size: 13, lineHeight: 13, tracking: 0)
+                        .foregroundStyle(.primaryPurple)
+                }
             }
         }
         .padding(.horizontal, 16)


### PR DESCRIPTION
#### close #339

### ✏️ 개요
사용자 정보에 칭호가 추가되어 앱 전반에 걸쳐 칭호가 표시되어 수정된 UI를 적용합니다.

### 💻 작업 사항
- [x] 랭킹탭 칭호 UI 추가 (xpSum -> level 추가 대응) #338
- [x] 인증탭 칭호 UI 추가
- [x] 다른유저 프로필 칭호 UI 추가
- [x] API 수정 대응
    - ICH004 도전내역 랜덤 조회 : GET /api/customer/randomChallenge
    IUS003 customer XP 랭킹 조회 (사용자 totalXP 추가 대응)
    사용자 조회 (파라미터에 userId 적용)
- [x] EmptyView 뷰 이름 변경 & 스케일 추가

### 📱결과 화면(optional)
| 랭킹탭 | 인증탭 | 다른유저프로필 |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/6832e742-5e09-4bce-9899-6ed1c1e0ab01) | ![image](https://github.com/user-attachments/assets/908b1391-af1a-48fe-9e0d-c8218cfbfbf8) | ![image](https://github.com/user-attachments/assets/be363a08-6a19-4fa7-b7b3-e6370849c58e) | 

