### PR TITLE
[Ref/#343] QuestViewModelItem 생성 방식 개선을 위한 빌더 패턴 도입

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		606292DD2C19EAB00098B6D2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 606292DC2C19EAB00098B6D2 /* Alamofire */; };
 		606694F02DDA29E40000E368 /* AnimatedPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606694EF2DDA29E40000E368 /* AnimatedPopup.swift */; };
 		606694F32DDA2B140000E368 /* HonorAcquisitionPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606694F22DDA2B140000E368 /* HonorAcquisitionPopup.swift */; };
+		606694F52DDB25D00000E368 /* QuestViewModelItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606694F42DDB25D00000E368 /* QuestViewModelItemBuilder.swift */; };
 		606C21CC2CC6B4FC00803947 /* SubmitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C21CB2CC6B4FC00803947 /* SubmitStatusView.swift */; };
 		606C87AF2C0B9B8C002D5C3E /* ApprovalItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C87AE2C0B9B8C002D5C3E /* ApprovalItemView.swift */; };
 		606C87B12C0CC89B002D5C3E /* 2406_TERMS_OF_USE.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 606C87B02C0CC89B002D5C3E /* 2406_TERMS_OF_USE.pdf */; };
@@ -310,6 +311,7 @@
 		606292D72C19E70A0098B6D2 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		606694EF2DDA29E40000E368 /* AnimatedPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedPopup.swift; sourceTree = "<group>"; };
 		606694F22DDA2B140000E368 /* HonorAcquisitionPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HonorAcquisitionPopup.swift; sourceTree = "<group>"; };
+		606694F42DDB25D00000E368 /* QuestViewModelItemBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestViewModelItemBuilder.swift; sourceTree = "<group>"; };
 		606C21CB2CC6B4FC00803947 /* SubmitStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitStatusView.swift; sourceTree = "<group>"; };
 		606C87AE2C0B9B8C002D5C3E /* ApprovalItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalItemView.swift; sourceTree = "<group>"; };
 		606C87B02C0CC89B002D5C3E /* 2406_TERMS_OF_USE.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = 2406_TERMS_OF_USE.pdf; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */,
 				607FCBE82BFE418600BB2D04 /* QuestViewModel.swift */,
 				607FCBE62BFD12B100BB2D04 /* QuestViewModelItem.swift */,
+				606694F42DDB25D00000E368 /* QuestViewModelItemBuilder.swift */,
 				607FCBE32BFD124900BB2D04 /* QuestItemView.swift */,
 				604687AD2D216EAC0056E394 /* QuestStyle.swift */,
 				605E813E2D9FE36800ECDB15 /* QuestDetail */,
@@ -1297,6 +1300,7 @@
 				605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */,
 				6060B2EA2C08947B0083944D /* Image++.swift in Sources */,
 				A1F0ADC02CD738C30068E0A6 /* Polygon.swift in Sources */,
+				606694F52DDB25D00000E368 /* QuestViewModelItemBuilder.swift in Sources */,
 				605445C82DD36D5E0005742D /* MyPageHonorManageViewModel.swift in Sources */,
 				603F04132C26ADC6008A2332 /* CommonResponse.swift in Sources */,
 				607FCBE42BFD124900BB2D04 /* QuestItemView.swift in Sources */,

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -172,209 +172,90 @@ class QuestViewModelItem: Hashable, Identifiable {
     }
 }
 
-// TODO: mockdata, 팩토리 패턴 적용
 extension QuestViewModelItem {
     static let mockImageId = "IMQU2024071520500801"
     
-    static let mockData: QuestViewModelItem = QuestViewModelItem(
-        id: "11",
-        image: .img0,
-        imageId: mockImageId,
-        mainImageId: mockImageId,
-        missionId: "1",
-        missionType: .image,
-        missionTitle: "아메리카노 15잔 마시기",
-        writer: "이디야커피",
-        rewardDic: [.charm: 30, .intellect: 100, .fun: 5],
-        type: "DEFAULT",
-        target: "NONE",
-        expireDate: "2030-12-30T00:00:00",
-        challengeImageIds: [],
-        challengeImages: [],
-        customerRank: 1,
-        favoriteYn: false
-    )
+    static let mockData: QuestViewModelItem = QuestViewModelItemBuilder()
+        .setMissionTitle("러닝 30분하기")
+        .setRewardDic([.fun: 15, .strength: 5])
+        .setFavoriteYn(true)
+        .setChallengeImageIds([.init(challengeId: "CH001", receiptImage: "", status: "")])
+        .build()
     
-    static let mockRepeatData: QuestViewModelItem = QuestViewModelItem(
-        id: "11",
-        image: .img0,
-        imageId: mockImageId,
-        mainImageId: mockImageId,
-        missionId: "1",
-        missionType: .image,
-        missionTitle: "아메리카노 15잔 마시기",        writer: "이디야커피",
-        rewardDic: [.charm: 30, .intellect: 100, .fun: 5],
-        type: "REPEAT",
-        target: "DAILY",
-        expireDate: "2030-12-30T00:00:00",
-        challengeImageIds: [],
-        challengeImages: [],
-        customerRank: 1,
-        favoriteYn: false
-    )
-    
-    static let mockRepeat2Data: QuestViewModelItem = QuestViewModelItem(
-        id: "11",
-        image: .img0,
-        imageId: mockImageId,
-        mainImageId: mockImageId,
-        missionId: "1",
-        missionType: .image,
-        missionTitle: "아메리카노 15잔 마시기",        writer: "이디야커피",
-        rewardDic: [.charm: 30, .intellect: 100, .fun: 5],
-        type: "REPEAT",
-        target: "DAILY",
-        expireDate: "2030-12-30T00:00:00",
-        challengeImageIds: [],
-        challengeImages: [],
-        customerRank: 1,
-        favoriteYn: false
-    )
+    static let mockRepeatData: QuestViewModelItem = QuestViewModelItemBuilder()
+        .setMissionTitle("러닝 30분하기")
+        .setRepeatType(.daily)
+        .setRewardDic([.fun: 15, .strength: 5])
+        .setFavoriteYn(true)
+        .setChallengeImageIds([.init(challengeId: "CH001", receiptImage: "", status: "")])
+        .setCustomerRank(2)
+        .build()
     
     static let mockQuestList: [QuestViewModelItem] = [
-        QuestViewModelItem(
-            id: "9f8aacc9-a221-491b-98c1-f9d7d35a67fb",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "이디야커피",
-            rewardDic: [.charm: 3, .strength: 25],
-            type: "REPEAT",
-            target: "MONTHLY",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        ),
-        QuestViewModelItem(
-            id: "9f8aacc9-98c1-f9d7d35a67fb",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "이디야커피",
-            rewardDic: [.charm: 3, .fun: 25, .sociability: 20, .strength: 25],
-            type: "REPEAT",
-            target: "DAILY",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        ),
-        QuestViewModelItem(
-            id: "9f8aacc9-a221-4-f9d7d35a67fb",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "이디야커피",
-            rewardDic: [.charm: 30],
-            type: "REPEAT",
-            target: "WEEKLY",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        ),
-        QuestViewModelItem(
-            id: "13",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "투썸플레이스",
-            rewardDic: [.charm: 20, .sociability: 100, .strength: 25],
-            type: "DEFAULT",
-            target: "NONE",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        ),
-        QuestViewModelItem(
-            id: "9f89d7d35a67fb",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "이디야커피",
-            rewardDic: [.charm: 3, .strength: 25],
-            type: "REPEAT",
-            target: "MONTHLY",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        ),
-        QuestViewModelItem(
-            id: "9f8aac7fb",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "이디야커피",
-            rewardDic: [.charm: 3, .fun: 25, .sociability: 20, .strength: 25],
-            type: "REPEAT",
-            target: "DAILY",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        ),
-        QuestViewModelItem(
-            id: "9f8aacc9-23421-4-fd35a67fb",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "이디야커피",
-            rewardDic: [.charm: 30],
-            type: "REPEAT",
-            target: "WEEKLY",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        ),
-        QuestViewModelItem(
-            id: "212132",
-            image: .img0,
-            imageId: mockImageId,
-            mainImageId: mockImageId,
-            missionId: "1",
-            missionType: .image,
-            missionTitle: "아메리카노 15잔 마시기",
-            writer: "투썸플레이스",
-            rewardDic: [.charm: 20, .sociability: 100, .strength: 25],
-            type: "DEFAULT",
-            target: "NONE",
-            expireDate: "2030-12-30T00:00:00",
-            challengeImageIds: [],
-            challengeImages: [],
-            customerRank: 1,
-            favoriteYn: false
-        )
+        QuestViewModelItemBuilder()
+            .setMissionTitle("미라클모닝 실천하기")
+            .setRepeatType(.daily)
+            .setRewardDic([.strength: 15, .intellect: 5])
+            .setFavoriteYn(true)
+            .setChallengeImageIds([.init(challengeId: "CH001", receiptImage: "", status: "")])
+            .setCustomerRank(2)
+            .build(),
+        
+        QuestViewModelItemBuilder()
+            .setMissionTitle("가족 사랑 지킴이")
+            .setRepeatType(.weekly)
+            .setMissionType(.quiz(.ox))
+            .setRewardDic([.sociability: 20, .charm: 10])
+            .setCustomerRank(3)
+            .build(),
+        
+        QuestViewModelItemBuilder()
+            .setMissionTitle("감정 코칭 마스터")
+            .setRewardDic([.intellect: 15, .charm: 5])
+            .setFavoriteYn(true)
+            .setMissionType(.quiz(.text))
+            .build(),
+        
+        QuestViewModelItemBuilder()
+            .setMissionTitle("미션 타이틀")
+            .setWriter("루틴디자이너")
+            .setRepeatType(.weekly)
+            .setRewardDic([.intellect: 20])
+            .setFavoriteYn(true)
+            .setCustomerRank(2)
+            .build(),
+        
+        QuestViewModelItemBuilder()
+            .setId("quest-106")
+            .setMissionTitle("🎨 취미탐험가")
+            .setWriter("취미부스터")
+            .setRepeatType(.monthly)
+            .setRewardDic([.fun: 30, .intellect: 5])
+            .setFavoriteYn(true)
+            .setCustomerRank(3)
+            .build(),
+        
+        QuestViewModelItemBuilder()
+            .setId("quest-107")
+            .setMissionTitle("📚 가계부 전략가")
+            .setWriter("절약미학자")
+            .setRepeatType(.weekly)
+            .setRewardDic([.intellect: 25])
+            .setCustomerRank(5)
+            .build(),
+        
+        QuestViewModelItemBuilder()
+            .setMissionTitle("운동 30분하기")
+            .setRepeatType(.daily)
+            .setRewardDic([.fun: 15, .strength: 15])
+            .setFavoriteYn(true)
+            .setCustomerRank(1)
+            .build(),
+        
+        QuestViewModelItemBuilder()
+            .setMissionTitle("카페라떼 마시기")
+            .setRewardDic([.fun: 20])
+            .setFavoriteYn(true)
+            .build()
     ]
 }

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -20,6 +20,7 @@ class QuestViewModelItem: Hashable, Identifiable {
     let id: String
     var image: UIImage?
     let imageId: String?
+    let mainImage: UIImage?
     let mainImageId: String?
     let missionId: String
     let missionType: MissionType
@@ -38,6 +39,7 @@ class QuestViewModelItem: Hashable, Identifiable {
         id: String,
         image: UIImage? = nil,
         imageId: String,
+        mainImage: UIImage? = nil,
         mainImageId: String,
         missionId: String,
         missionType: MissionType,
@@ -55,6 +57,7 @@ class QuestViewModelItem: Hashable, Identifiable {
         self.id = id
         self.image = image
         self.imageId = imageId
+        self.mainImage = mainImage
         self.mainImageId = mainImageId
         self.missionId = missionId
         self.missionType = missionType
@@ -74,6 +77,7 @@ class QuestViewModelItem: Hashable, Identifiable {
         self.id = quest.questId
         self.image = nil
         self.imageId = quest.imageId
+        self.mainImage = nil
         self.mainImageId = quest.mainImageId
         self.missionId = quest.missionId
         self.missionType = MissionType(rawValue: quest.missionType) ?? .image
@@ -213,6 +217,7 @@ extension QuestViewModelItem {
             .setMissionTitle("감정 코칭 마스터")
             .setRewardDic([.intellect: 15, .charm: 5])
             .setFavoriteYn(true)
+            .setMainImage(.logo)
             .setMissionType(.quiz(.text))
             .build(),
         

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItemBuilder.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItemBuilder.swift
@@ -1,0 +1,138 @@
+//
+//  QuestViewModelItemBuilder.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 5/19/25.
+//
+
+import UIKit
+
+final class QuestViewModelItemBuilder {
+    private var id: String = UUID().uuidString
+    private var image: UIImage? = nil
+    private var imageId: String = QuestViewModelItem.mockImageId
+    private var mainImageId: String = "default_main_image_id"
+    private var missionId: String = UUID().uuidString
+    private var missionType: QuestViewModelItem.MissionType = .image
+    private var missionTitle: String = "기본 미션 제목"
+    private var writer: String = "일상"
+    private var rewardDic: [XpStat: Int] = [:]
+    private var type: String = "NORMAL" // REPEAT
+    private var target: String = "NONE" // DAILY, WEEKLY, MONTHLY
+    private var expireDate: String = "2030-12-30T00:00:00"
+    private var challengeImageIds: [ChallengeImage] = []
+    private var challengeImages: [UIImage] = []
+    private var customerRank: Int = 0
+    private var favoriteYn: Bool = false
+    
+    enum MissionTarget: String {
+        case none = "NONE", daily = "DAILY", weekly = "WEEKLY", monthly = "MONTHLY"
+    }
+    
+    func setId(_ id: String) -> Self {
+        self.id = id
+        return self
+    }
+    
+    func setImage(_ image: UIImage?) -> Self {
+        self.image = image
+        return self
+    }
+    
+    func setImageId(_ imageId: String) -> Self {
+        self.imageId = imageId
+        return self
+    }
+    
+    func setMainImageId(_ mainImageId: String) -> Self {
+        self.mainImageId = mainImageId
+        return self
+    }
+    
+    func setMissionId(_ missionId: String) -> Self {
+        self.missionId = missionId
+        return self
+    }
+    
+    func setMissionType(_ missionType: QuestViewModelItem.MissionType) -> Self {
+        self.missionType = missionType
+        return self
+    }
+    
+    func setMissionTitle(_ missionTitle: String) -> Self {
+        self.missionTitle = missionTitle
+        return self
+    }
+    
+    func setWriter(_ writer: String) -> Self {
+        self.writer = writer
+        return self
+    }
+    
+    func setRewardDic(_ rewardDic: [XpStat: Int]) -> Self {
+        self.rewardDic = rewardDic
+        return self
+    }
+    
+    func setNormalType() -> Self {
+        self.type = "NORMAL"
+        self.target = "NONE"
+        return self
+    }
+    
+    func setRepeatType(_ target: MissionTarget) -> Self {
+        self.type = "REPEAT"
+        self.target = target.rawValue
+        return self
+    }
+    
+    func setExpireDate(_ expireDate: String) -> Self {
+        self.expireDate = expireDate
+        return self
+    }
+    
+    func setChallengeImageIds(_ challengeImageIds: [ChallengeImage]) -> Self {
+        self.challengeImageIds = challengeImageIds
+        return self
+    }
+    
+    func setChallengeImages(_ challengeImages: [UIImage]) -> Self {
+        self.challengeImages = challengeImages
+        return self
+    }
+    
+    func setCustomerRank(_ customerRank: Int) -> Self {
+        if self.type != "REPEAT" {
+            Log("Warning: customerRank는 REPEAT 퀘스트에만 적용됩니다.")
+            return self
+        }
+        self.customerRank = customerRank
+        return self
+    }
+    
+    func setFavoriteYn(_ favoriteYn: Bool) -> Self {
+        self.favoriteYn = favoriteYn
+        return self
+    }
+        
+    func build() -> QuestViewModelItem {
+        return QuestViewModelItem(
+            id: id,
+            image: image,
+            imageId: imageId,
+            mainImageId: mainImageId,
+            missionId: missionId,
+            missionType: missionType,
+            missionTitle: missionTitle,
+            writer: writer,
+            rewardDic: rewardDic,
+            type: type,
+            target: target,
+            expireDate: expireDate,
+            challengeImageIds: challengeImageIds,
+            challengeImages: challengeImages,
+            customerRank: customerRank,
+            favoriteYn: favoriteYn
+        )
+    }
+}

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItemBuilder.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItemBuilder.swift
@@ -11,6 +11,7 @@ final class QuestViewModelItemBuilder {
     private var id: String = UUID().uuidString
     private var image: UIImage? = nil
     private var imageId: String = QuestViewModelItem.mockImageId
+    private var mainImage: UIImage? = nil
     private var mainImageId: String = "default_main_image_id"
     private var missionId: String = UUID().uuidString
     private var missionType: QuestViewModelItem.MissionType = .image
@@ -46,6 +47,11 @@ final class QuestViewModelItemBuilder {
     
     func setMainImageId(_ mainImageId: String) -> Self {
         self.mainImageId = mainImageId
+        return self
+    }
+    
+    func setMainImage(_ image: UIImage?) -> Self {
+        self.mainImage = mainImage
         return self
     }
     
@@ -120,6 +126,7 @@ final class QuestViewModelItemBuilder {
             id: id,
             image: image,
             imageId: imageId,
+            mainImage: mainImage,
             mainImageId: mainImageId,
             missionId: missionId,
             missionType: missionType,


### PR DESCRIPTION
#### close #343 

### ✏️ 개요
퀘스트 객체가 복잡해짐에 따라 다양한 케이스를 유연하게 구성할 수 있도록, 빌더 패턴을 도입합니다.

### 💻 작업 사항
- QuestViewModelItem 빌더 패턴 도입
- [QuestViewModelItem - mainImage 추가](https://github.com/TeamFair/ILSANG-iOS/commit/1be3480beda784f9f545b26d5cbb23818f484a01)