### PR TITLE
[Design/#354] 메인 배너 컴포넌트 디자인 개선

### DIFF
--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -137,8 +137,8 @@ struct HomeView: View {
     }
     
     private var mainBannerSection: some View {
-        let height: CGFloat = .screenWidth / 11 * 10
-        return TabView {
+        let height: CGFloat = .screenWidth / 3 * 2
+        return TabView(selection: $vm.currentBanner) {
             ForEach(Array(vm.mainBanners.enumerated()), id: \.offset) { idx, item in
                 if let bannerImage = item.image {
                     Image(uiImage: bannerImage)
@@ -146,7 +146,6 @@ struct HomeView: View {
                         .scaledToFill()
                         .frame(maxWidth: .infinity)
                         .frame(height: height)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
                         .onTapGesture {
                             AnalyticsService.logEvent(.homeBannerClick(bannerId: item.id))
                             if let tab = vm.getTabFromURL(from: item.description) { /// 해당하는 탭으로 이동
@@ -155,6 +154,24 @@ struct HomeView: View {
                         }
                 }
             }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            HStack(alignment: .center, spacing: 5) {
+                Text("\(vm.currentBanner+1)")
+                    .styledFont(.badge2)
+                    .frame(minWidth: 7)
+                    .foregroundStyle(.white)
+                Rectangle()
+                    .frame(width: 1, height: 8)
+                Text("\(vm.mainBanners.count)")
+                    .styledFont(.badge2)
+                    .frame(minWidth: 7)
+            }
+            .foregroundStyle(.gray200)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 10)
+            .roundedBackground(cornerRadius: 20, bgColor: .black.opacity(0.7))
+            .padding(20)
         }
         .frame(height: height)
         .tabViewStyle(.page(indexDisplayMode: .never))

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -30,6 +30,7 @@ final class HomeViewModel {
     var recommendQuestList: [QuestViewModelItem] = [] //QuestViewModelItem.mockQuestList // 10개
     var popularQuestList: [QuestViewModelItem] = QuestViewModelItem.mockQuestList // 4n개
     
+    var currentBanner: Int = 0
     var selectedXpStat: XpStat = .strength
     
     var showQuestSheet: Bool = false


### PR DESCRIPTION
#### close #354 

### ✏️ 개요
홈 탭의 배너 영역 디자인을 변경했습니다.

### 💻 작업 사항
- 배너 스타일 수정
   - 배너 컴포넌트 cornerRadius 제거
   - 배너 이미지 비율 3:2로 수정
   - 배너 컴포넌트 갯수 표시 및 업데이트

### 📱결과 화면(optional)
| AS-IS | TO-BE |
|--------|--------|
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/1bfdf763-6b23-4c48-8289-d6aaa0813669" />  | <img width="350" alt="image" src="https://github.com/user-attachments/assets/8745369a-5995-4758-b99c-3d22a3d06a3d" /> | 
