### PR TITLE
[Ref/#379] 인증 화면: 기존 API 재연결 (미션히스토리 랜덤 조회/신고)

### DIFF
--- a/ILSANG/Sources/Domain/Repository/MissionHistoryRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/MissionHistoryRepository.swift
@@ -25,8 +25,9 @@ final class MissionHistoryRepository {
         }
     }
     
-    func patchMissionHistory(missionHistoryId: Int) async -> Result<Void, Error> {
-        let res = await network.patchMissionHistory(missionHistoryId: missionHistoryId)
+    // 신고하기
+    func putMissionHistory(missionHistoryId: Int) async -> Result<Void, Error> {
+        let res = await network.putMissionHistory(missionHistoryId: missionHistoryId)
         switch res {
         case .success:
             return .success(Void())

--- a/ILSANG/Sources/Network/MissionHistoryNetwork.swift
+++ b/ILSANG/Sources/Network/MissionHistoryNetwork.swift
@@ -13,11 +13,11 @@ final class MissionHistoryNetwork {
     
     func getRandomMissionHistories(page: Int, size: Int = 10) async -> Result<ResponseWithPage<[MissionHistoryResponse]>, Error> {
         let parameters: Parameters = ["page": page, "size": size]
-        return await Network.requestData(url: url+"history/random", method: .get, parameters: parameters, withToken: true)
+        return await Network.requestData(url: url+"/history/random", method: .get, parameters: parameters)
     }
     
-    func patchMissionHistory(missionHistoryId: Int) async -> Result<ResponseWithEmpty, Error> {
-        let parameters: Parameters = ["missionHistoryId": "\(missionHistoryId)", "status": "REPORTED"]
-        return await Network.requestData(url: url+"history/status", method: .patch, parameters: parameters, withToken: true)
+    /// 신고하기
+    func putMissionHistory(missionHistoryId: Int) async -> Result<ResponseWithEmpty, Error> {
+        return await Network.requestData(url: url+"/history/\(missionHistoryId)", method: .put)
     }
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -305,7 +305,7 @@ final class ApprovalViewModel {
     
     private func reportChallenge() async {
         guard let missionHistoryId = self.selectedChallenge?.id else { return }
-        let result = await missionHistoryRepository.patchMissionHistory(missionHistoryId: missionHistoryId)
+        let result = await missionHistoryRepository.putMissionHistory(missionHistoryId: missionHistoryId)
         switch result {
         case .success:
             await loadInitialData() // TODO: 해당 챌린지를 목록에서 지우기


### PR DESCRIPTION
#### close #379 

### ✏️ 개요
인증 화면의 기존 API를 재연결합니다.

### 💻 작업 사항
- 미션히스토리 랜덤 조회
- 미션히스토리 신고