### PR TITLE
[Ref/#385] 퀘스트 미션 제출 API 재연결

### DIFF
--- a/ILSANG/Sources/Domain/Entity/Quest.swift
+++ b/ILSANG/Sources/Domain/Entity/Quest.swift
@@ -14,7 +14,7 @@ struct Quest {
     let questType: QuestType?
     let repeatFrequency: RepeatType?
     let rewards: [Reward]?
-    let missions: [Mission]?
+    let missions: [Mission]
     let expireDate: Date?
     let imageId: String
     let mainImageId: String?

--- a/ILSANG/Sources/Domain/Mapper/BaseQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/BaseQuestResponse+Mapping.swift
@@ -19,7 +19,7 @@ extension BaseQuestResponse: DomainConvertible {
             questType: self.questType.flatMap { QuestType(rawValue: $0) },
             repeatFrequency: self.repeatFrequency.flatMap { RepeatType(rawValue: $0) },
             rewards: rewards.map { $0.toDomain() },
-            missions: nil,
+            missions: [],
             expireDate: date,
             imageId: imageId,
             mainImageId: mainImageId,

--- a/ILSANG/Sources/Domain/Mapper/LargeRewardQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/LargeRewardQuestResponse+Mapping.swift
@@ -19,7 +19,7 @@ extension LargeRewardQuestResponse: DomainConvertible {
             questType: nil,
             repeatFrequency: nil,
             rewards: rewards.map { $0.toDomain() },
-            missions: nil,
+            missions: [],
             expireDate: date,
             imageId: imageId,
             mainImageId: mainImageId,

--- a/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
@@ -19,7 +19,7 @@ extension PopularQuestResponse: DomainConvertible {
             questType: QuestType(rawValue: questType),
             repeatFrequency: self.repeatFrequency.flatMap { RepeatType(rawValue: $0) },
             rewards: nil,
-            missions: nil,
+            missions: [],
             expireDate: date,
             imageId: imageId,
             mainImageId: mainImageId,

--- a/ILSANG/Sources/Domain/Mapper/RecommendQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/RecommendQuestResponse+Mapping.swift
@@ -16,7 +16,7 @@ extension RecommendQuestResponse: DomainConvertible {
             questType: nil,
             repeatFrequency: nil,
             rewards: nil,
-            missions: nil,
+            missions: [],
             expireDate: nil,
             imageId: imageId,
             mainImageId: mainImageId,

--- a/ILSANG/Sources/Model/Quiz.swift
+++ b/ILSANG/Sources/Model/Quiz.swift
@@ -6,7 +6,8 @@
 //
 
 struct Quiz: Decodable {
-    let quizId, question, hint: String
+    let quizId: Int
+    let question, hint: String
     let answers: [Answer]
 }
 

--- a/ILSANG/Sources/Network/Base/CommonResponse.swift
+++ b/ILSANG/Sources/Network/Base/CommonResponse.swift
@@ -35,17 +35,9 @@ extension ResponseWithPage: Decodable where T: Decodable {}
 
 struct ResponseWithoutData: Decodable {
     let data: [String: String]?
-    let errorStatus: String?
-    let errMessage: String?
-    let status: String
-    let message: String
-    
-    init(data: [String: String], errorStatus: String?, errMessage: String?, status: String, message: String) {
+   
+    init(data: [String: String]) {
         self.data = data
-        self.errorStatus = errorStatus
-        self.errMessage = errMessage
-        self.status = status
-        self.message = message
     }
 }
 

--- a/ILSANG/Sources/Network/ChallengeNetwork.swift
+++ b/ILSANG/Sources/Network/ChallengeNetwork.swift
@@ -22,16 +22,28 @@ final class ChallengeNetwork {
         return await Network.requestData(url: url+"challenge", method: .get, parameters: parameters, withToken: true)
     }
     
-    func postChallenge(questId: Int, imageId: String) async -> Result<ResponseWithEmpty, Error> {
+    func postQuizChallenge(missionId: Int, quizId: Int, answer: String) async -> Result<ResponseWithoutData, Error> {
         let bodyData: [String: Any] = [
-            "questId": "\(questId)",
-            "receiptImageId": imageId
+            "missionId": "\(missionId)",
+            "quizId": "\(quizId)",
+            "answer": answer
         ]
-        
-        guard let jsonData = bodyData.convertToJsonData() else {
+        return await postChallenge(body: bodyData)
+    }
+    
+    func postPhotoChallenge(missionId: Int, imageId: String) async -> Result<ResponseWithoutData, Error> {
+        let bodyData: [String: Any] = [
+            "missionId": "\(missionId)",
+            "imageId": imageId
+        ]
+        return await postChallenge(body: bodyData)
+    }
+    
+    private func postChallenge(body: [String: Any]) async -> Result<ResponseWithoutData,Error> {
+        guard let bodyData = body.convertToJsonData() else {
             return .failure(NetworkError.requestFailed("Fail to convert data"))
         }
-        return await Network.requestData(url: url+"challenge", method: .post, parameters: nil, body: jsonData, withToken: true)
+        return await Network.requestData(url: url+"/mission", method: .post, body: bodyData)
     }
     
     func deleteChallenge(challengeId: String) async -> Bool {

--- a/ILSANG/Sources/Network/HonorNetwork.swift
+++ b/ILSANG/Sources/Network/HonorNetwork.swift
@@ -19,7 +19,7 @@ struct MockHonorNetwork: HonorNetworkProtocol {
     }
     
     func readHonorHistory(historyId: String) async -> Result<ResponseWithoutData, Error> {
-        .success(.init(data: [:], errorStatus: "", errMessage: "", status: "", message: ""))
+        .success(.init(data: [:]))
     }
 }
 

--- a/ILSANG/Sources/Network/QuizNetwork.swift
+++ b/ILSANG/Sources/Network/QuizNetwork.swift
@@ -17,21 +17,4 @@ final class QuizNetwork {
     func getRandomQuiz(missionId: Int) async -> Result<Response<Quiz>, Error> {
         return await Network.requestData(url: url+"mission/\(missionId)/quiz/random", method: .get, parameters: nil, withToken: true)
     }
-    
-    func postQuizChallenge(questId: Int, quizId: String, answer: String) async -> Result<ResponseWithoutData, Error> {
-        let bodyData: [String: Any] = [
-            "questId": "\(questId)",
-            "answers": [
-                [
-                    "quizId": quizId,
-                    "answer": answer
-                ]
-            ]
-        ]
-        
-        guard let jsonData = bodyData.convertToJsonData() else {
-            return .failure(NetworkError.requestFailed("Fail to convert data"))
-        }
-        return await Network.requestData(url: url+"challenge/quiz", method: .post, parameters: nil, body: jsonData, withToken: true)
-    }
 }

--- a/ILSANG/Sources/Service/ImageChallengeSubmitService.swift
+++ b/ILSANG/Sources/Service/ImageChallengeSubmitService.swift
@@ -18,14 +18,14 @@ final class ImageChallengeSubmitService {
     }
     
     /// 도전 과제 제출 실행
-    func execute(questId: Int, image: UIImage?) async -> Bool {
+    func execute(missionId: Int, image: UIImage?) async -> Bool {
         guard let image = image else { return false }
         
         // 1. 이미지 업로드
         guard let imageId = await postImage(image) else { return false }
         
         // 2. 챌린지 제출
-        return await postChallenge(questId: questId, imageId: imageId)
+        return await postChallenge(missionId: missionId, imageId: imageId)
     }
     
     /// 이미지 업로드
@@ -39,8 +39,8 @@ final class ImageChallengeSubmitService {
     }
     
     /// 챌린지 제출
-    private func postChallenge(questId: Int, imageId: String) async -> Bool {
-        let result = await challengeNetwork.postChallenge(questId: questId, imageId: imageId)
+    private func postChallenge(missionId: Int, imageId: String) async -> Bool {
+        let result = await challengeNetwork.postPhotoChallenge(missionId: missionId, imageId: imageId)
         switch result {
         case .success:
             await cleanUpImages(except: imageId)

--- a/ILSANG/Sources/Views/Home/BannerDetailView.swift
+++ b/ILSANG/Sources/Views/Home/BannerDetailView.swift
@@ -67,14 +67,15 @@ struct BannerDetailView: View {
         .fullScreenCover(isPresented: $viewModel.showQuestEngageView) {
             if let selectedQuest = viewModel.selectedQuest {
                 let quizNetwork = QuizNetwork()
-
+                let challengeNetwork = ChallengeNetwork()
+                
                 QuestEngageView(
                     vm: QuestEngageViewModel(quest: selectedQuest, quizNetwork: quizNetwork),
                     submitVM: SubmitRouterViewModel(
                         selectedImage: nil,
                         selectedQuest: selectedQuest,
-                        submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: ChallengeNetwork()),
-                        quizNetwork: quizNetwork
+                        submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: challengeNetwork),
+                        challengeNetwork: challengeNetwork
                     )
                 )
             }

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -97,6 +97,7 @@ struct HomeView: View {
             }
         }
         .navigationDestination(isPresented: $vm.showQuestEngageView) {
+            let challengeNetwork = ChallengeNetwork()
             QuestEngageView(
                 vm: QuestEngageViewModel(
                     quest: vm.selectedQuest,
@@ -105,8 +106,8 @@ struct HomeView: View {
                 submitVM: SubmitRouterViewModel(
                     selectedImage: nil,
                     selectedQuest: vm.selectedQuest,
-                    submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: ChallengeNetwork()),
-                    quizNetwork: QuizNetwork()
+                    submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: challengeNetwork),
+                    challengeNetwork: challengeNetwork
                 )
             )
         }

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -340,6 +340,13 @@ final class HomeViewModel {
     
     func onQuestTapped(quest: QuestViewModelItem) {
         selectedQuest = quest
+        Task {
+            let questDetail = try await questRepository.getQuestDetail(questId: quest.id)
+                .get()
+                .toQuestItem()
+            self.selectedQuest = questDetail
+        }
+        
         if illsangZoneCode == nil && shouldShowIllsangZoneWarning {
             isQuestSheetPending = true // 일상존 선택 후 다시 열기 위해 기록
             alertType = .illsangZoneNotSelected

--- a/ILSANG/Sources/Views/Quest/Camera/CameraView.swift
+++ b/ILSANG/Sources/Views/Quest/Camera/CameraView.swift
@@ -121,5 +121,7 @@ struct CameraPreviewView: UIViewRepresentable {
 }
 
 #Preview {
-    CameraView(submitViewModel: SubmitRouterViewModel(selectedQuest: .mockData, submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: ChallengeNetwork()), quizNetwork: QuizNetwork()))
+    let challengeNetwork = ChallengeNetwork()
+    
+    CameraView(submitViewModel: SubmitRouterViewModel(selectedQuest: .mockData, submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: challengeNetwork), challengeNetwork:challengeNetwork))
 }

--- a/ILSANG/Sources/Views/Quest/Camera/ImagePreviewButton.swift
+++ b/ILSANG/Sources/Views/Quest/Camera/ImagePreviewButton.swift
@@ -89,13 +89,14 @@ struct ImageDataTransferable: Transferable {
 }
 
 #Preview {
+    let challengeNetwork = ChallengeNetwork()
     ImagePreviewButton(
         submitViewModel: SubmitRouterViewModel(
             selectedQuest: .mockData,
             submitService: ImageChallengeSubmitService(
                 imageNetwork: ImageNetwork(),
-                challengeNetwork: ChallengeNetwork()
-            ), quizNetwork: QuizNetwork()
+                challengeNetwork: challengeNetwork
+            ), challengeNetwork: challengeNetwork
         )
     )
 }

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailView.swift
@@ -58,7 +58,7 @@ struct QuestDetailView: View {
                 .padding(.bottom, CGFloat.isSmallDevice ? 8 : 16)
         }
         .task {
-            await vm.fetchQuestDetail()
+            await vm.updateChallengeImages()
         }
         .sheet(isPresented: $vm.showImageSheetView, content: {
             ImageFullScreenView(image: vm.selectedImage) {

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
@@ -25,21 +25,9 @@ class QuestDetailViewModel {
         self.onUpdate = onUpdate
     }
     
-    func fetchQuestDetail() async {
+    func updateChallengeImages() async {
         isLoading = true
-        
-        do {
-            await quest.updateChallengeImages()
-
-            let questDetail = try await questRepository.getQuestDetail(questId: quest.id)
-                .get()
-                .toQuestItem()
-            await questDetail.updateChallengeImages()
-            self.quest = questDetail
-        } catch {
-            Log("퀘스트 상세정보 불러오기 실패")
-        }
-        
+        await quest.updateChallengeImages()
         isLoading = false
     }
     

--- a/ILSANG/Sources/Views/Quest/QuestEngage/QuestEngageView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestEngage/QuestEngageView.swift
@@ -95,7 +95,7 @@ struct QuestEngageView: View {
             submitService: ImageChallengeSubmitService(
                 imageNetwork: ImageNetwork(),
                 challengeNetwork: ChallengeNetwork()
-            ), quizNetwork: QuizNetwork()
+            ), challengeNetwork: ChallengeNetwork()
         )
     )
     // QuestEngageView(vm: QuestEngageViewModel(quest: .mockRepeatData, questNetwork: QuestNetwork()))

--- a/ILSANG/Sources/Views/Quest/QuestEngage/QuizView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestEngage/QuizView.swift
@@ -124,8 +124,8 @@ struct QuizView: View, KeyboardReadable {
 
 #Preview {
     VStack {
-        QuizView(missionType: .quiz(.ox), quiz: Quiz(quizId: "1", question: "질문", hint: "힌드", answers: [.init(content: "답")]), selectedAnswer: .constant("answer"), isKeyboardVisible: .constant(true))
-        QuizView(missionType: .quiz(.text), quiz: Quiz(quizId: "1", question: "질문", hint: "힌드", answers: [.init(content: "답")]), selectedAnswer: .constant("answer"), isKeyboardVisible: .constant(true))
+        QuizView(missionType: .quiz(.ox), quiz: Quiz(quizId: 1, question: "질문", hint: "힌드", answers: [.init(content: "답")]), selectedAnswer: .constant("answer"), isKeyboardVisible: .constant(true))
+        QuizView(missionType: .quiz(.text), quiz: Quiz(quizId: 1, question: "질문", hint: "힌드", answers: [.init(content: "답")]), selectedAnswer: .constant("answer"), isKeyboardVisible: .constant(true))
     }
     .padding()
     .background(Color.background)

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -81,15 +81,15 @@ struct QuestView: View {
                 .interactiveDismissDisabled()
         }
         .navigationDestination(isPresented: $vm.showQuestEngageView) {
-            let quizNetwork = QuizNetwork()
+            let challengeNetwork = ChallengeNetwork()
             
-            return QuestEngageView(
-                vm: QuestEngageViewModel(quest: vm.selectedQuest, quizNetwork: quizNetwork),
+            QuestEngageView(
+                vm: QuestEngageViewModel(quest: vm.selectedQuest, quizNetwork: QuizNetwork()),
                 submitVM: SubmitRouterViewModel(
                     selectedImage: nil,
                     selectedQuest: vm.selectedQuest,
-                    submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: ChallengeNetwork()),
-                    quizNetwork: quizNetwork
+                    submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: challengeNetwork),
+                    challengeNetwork: challengeNetwork
                 )
             )
         }

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -365,6 +365,13 @@ class QuestViewModel: ObservableObject {
     func onQuestTapped(quest: QuestViewModelItem) {
         AnalyticsService.logEvent(.questItemClick(questId: quest.id, questType: quest.questType?.rawValue.uppercased() ?? ""))
         selectedQuest = quest
+        Task {
+            let questDetail = try await questRepository.getQuestDetail(questId: quest.id)
+                .get()
+                .toQuestItem()
+            self.selectedQuest = questDetail
+        }
+        
         DispatchQueue.main.asyncAfter(deadline: .now()+0.3) {
             self.showQuestSheet = true
         }

--- a/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModelItem.swift
@@ -31,7 +31,7 @@ class QuestViewModelItem: Hashable, Identifiable {
     let questType: QuestType?
     let repeatType: RepeatType?
     let rewards: [Reward]?
-    var missions: [Mission]?
+    var missions: [Mission]
     let expireDate: Date?
     let imageId: String?
     var image: UIImage?
@@ -47,7 +47,7 @@ class QuestViewModelItem: Hashable, Identifiable {
         questType: QuestType?,
         repeatType: RepeatType?,
         rewards: [Reward]?,
-        missions: [Mission]?,
+        missions: [Mission],
         expireDate: Date?,
         imageId: String?,
         image: UIImage?,
@@ -72,12 +72,12 @@ class QuestViewModelItem: Hashable, Identifiable {
         self.favoriteYn = favoriteYn
     }
     
-    var missionType: MissionType { missions?.first?.type ?? .photo }
+    var missionType: MissionType { missions.first?.type ?? .photo }
     var challengeImages: [UIImage] = []
-    var missionId: Int { missions?.first?.id ?? 0}
+    var missionId: Int { missions.first?.id ?? 0}
     
     func updateChallengeImages() async {
-        guard let missions else { return }
+//        guard let missions else { return }
         
         let challengeImageIds = missions
             .compactMap { $0.exampleImageIds }

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitAlertView.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitAlertView.swift
@@ -47,5 +47,7 @@ struct SubmitAlertView: View {
 }
 
 #Preview {
-    SubmitAlertView(vm: SubmitRouterViewModel(selectedImage: nil, selectedQuest: .mockData, submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: ChallengeNetwork()), quizNetwork: QuizNetwork()))
+    let challengeNetwork = ChallengeNetwork()
+
+    SubmitAlertView(vm: SubmitRouterViewModel(selectedImage: nil, selectedQuest: .mockData, submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: challengeNetwork), challengeNetwork: challengeNetwork))
 }

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitRouterView.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitRouterView.swift
@@ -14,7 +14,9 @@ struct SubmitRouterView: View {
     @Environment(\.dismiss) var dismiss
 
     init(selectedQuest: QuestViewModelItem) {
-        _vm = StateObject(wrappedValue: SubmitRouterViewModel(selectedQuest: selectedQuest, submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: ChallengeNetwork()), quizNetwork: QuizNetwork()))
+        let challengeNetwork = ChallengeNetwork()
+
+        _vm = StateObject(wrappedValue: SubmitRouterViewModel(selectedQuest: selectedQuest, submitService: ImageChallengeSubmitService(imageNetwork: ImageNetwork(), challengeNetwork: challengeNetwork), challengeNetwork: challengeNetwork))
     }
 
     var body: some View {

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitRouterViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitRouterViewModel.swift
@@ -14,37 +14,35 @@ class SubmitRouterViewModel: ObservableObject {
     @Published var submitStatus: SubmitStatus = .inProgress
     
     private let submitService: ImageChallengeSubmitService
-    private let quizNetwork: QuizNetwork
+    private let challengeNetwork: ChallengeNetwork
 
     let selectedQuest: QuestViewModelItem
     private var submitTask: Task<Void, Never>?
     
-    init(selectedImage: UIImage? = nil, selectedQuest: QuestViewModelItem, submitService: ImageChallengeSubmitService, quizNetwork: QuizNetwork) {
+    init(selectedImage: UIImage? = nil, selectedQuest: QuestViewModelItem, submitService: ImageChallengeSubmitService, challengeNetwork: ChallengeNetwork) {
         self.selectedImage = selectedImage
         self.selectedQuest = selectedQuest
         self.submitService = submitService
-        self.quizNetwork = quizNetwork
+        self.challengeNetwork = challengeNetwork
     }
     
     /// 제출 요청
-    func submit(userAnswer: String? = nil, quizId: String? = nil) {
+    func submit(userAnswer: String? = nil, quizId: Int? = nil) {
         self.showSubmitAlertView = true
         self.startSubmitTask(userAnswer: userAnswer, quizId: quizId)
     }
     
     /// 제출 작업 시작
-    private func startSubmitTask(userAnswer: String?, quizId: String?) {
+    private func startSubmitTask(userAnswer: String?, quizId: Int?) {
         if submitTask == nil || submitTask?.isCancelled == true {
             submitTask = Task {
-                switch selectedQuest.missions?.first?.type {
+                switch selectedQuest.missionType {
                 case .quiz:
                     if let userAnswer, let quizId {
                         await self.postChallengeWithQuiz(userAnswer: userAnswer, quizId: quizId)
                     }
                 case .photo:
                     await self.postChallengeWithImage()
-                case .none:
-                    return
                 }
             }
         }
@@ -73,7 +71,7 @@ class SubmitRouterViewModel: ObservableObject {
     func postChallengeWithImage() async {
         submitStatus = .inProgress
         
-        let isSuccess = await submitService.execute(questId: selectedQuest.id, image: selectedImage)
+        let isSuccess = await submitService.execute(missionId: selectedQuest.missionId, image: selectedImage)
         
         if isSuccess {
             AnalyticsService.logEvent(.questSubmitClick(questId: selectedQuest.id, questType: selectedQuest.questType?.rawValue.uppercased() ?? ""))
@@ -84,8 +82,8 @@ class SubmitRouterViewModel: ObservableObject {
     }
     
     @MainActor
-    func postChallengeWithQuiz(userAnswer: String, quizId: String) async {
-        let response = await quizNetwork.postQuizChallenge(questId: selectedQuest.id, quizId: quizId, answer: userAnswer)
+    func postChallengeWithQuiz(userAnswer: String, quizId: Int) async {
+        let response = await challengeNetwork.postQuizChallenge(missionId: selectedQuest.missionId, quizId: quizId, answer: userAnswer)
         
         switch response {
         case .success:


### PR DESCRIPTION
#### close #385 

### ✏️ 개요
퀘스트 미션 제출 플로우에 사용되는 API를 재연결합니다.

### 💻 작업 사항
- 퀘스트 디테일 화면 표시 전 디테일 API 조회하도록 변경
