### PR TITLE
[Feat/#374] 내지역: 지역조회 API 연결 및 내지역 로컬 저장

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		600657DC2DBCCBAA0022D117 /* MyPageInfoCardBottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600657DB2DBCCBAA0022D117 /* MyPageInfoCardBottomView.swift */; };
 		600657E02DBCFEE80022D117 /* HonorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600657DF2DBCFEE20022D117 /* HonorView.swift */; };
 		600657E42DBD2DF50022D117 /* MyPageHonorManageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600657E32DBD2DF50022D117 /* MyPageHonorManageView.swift */; };
-		600D63982E48E5BC009FE14F /* MetroArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D63972E48E5A9009FE14F /* MetroArea.swift */; };
+		600D63982E48E5BC009FE14F /* MetroAreaResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D63972E48E5A9009FE14F /* MetroAreaResponse.swift */; };
 		600D639C2E48E83F009FE14F /* AreaSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D639B2E48E83F009FE14F /* AreaSelectionView.swift */; };
 		600D639E2E490D14009FE14F /* IllsangZoneSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D639D2E490D14009FE14F /* IllsangZoneSelectionView.swift */; };
 		600D83A42C7B1FA4005C93E2 /* PaginationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */; };
@@ -137,6 +137,7 @@
 		6091972E2E5A22A800F1D81B /* SeasonTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6091972D2E5A22A800F1D81B /* SeasonTimerView.swift */; };
 		609197302E5AE4CB00F1D81B /* payboocOTFExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 6091972F2E5AE4CB00F1D81B /* payboocOTFExtraBold.otf */; };
 		609197322E5AE7F300F1D81B /* RankingDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609197312E5AE7F300F1D81B /* RankingDetailViewModel.swift */; };
+		609197342E5B2AA500F1D81B /* AreaNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609197332E5B2AA500F1D81B /* AreaNetwork.swift */; };
 		60924DC92C48C00E00221072 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60924DC82C48C00E00221072 /* Quest.swift */; };
 		60943FE62C0A38FB00C8A714 /* ApprovalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */; };
 		609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */; };
@@ -270,7 +271,7 @@
 		600657DB2DBCCBAA0022D117 /* MyPageInfoCardBottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageInfoCardBottomView.swift; sourceTree = "<group>"; };
 		600657DF2DBCFEE20022D117 /* HonorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HonorView.swift; sourceTree = "<group>"; };
 		600657E32DBD2DF50022D117 /* MyPageHonorManageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHonorManageView.swift; sourceTree = "<group>"; };
-		600D63972E48E5A9009FE14F /* MetroArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetroArea.swift; sourceTree = "<group>"; };
+		600D63972E48E5A9009FE14F /* MetroAreaResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetroAreaResponse.swift; sourceTree = "<group>"; };
 		600D639B2E48E83F009FE14F /* AreaSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaSelectionView.swift; sourceTree = "<group>"; };
 		600D639D2E490D14009FE14F /* IllsangZoneSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IllsangZoneSelectionView.swift; sourceTree = "<group>"; };
 		600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationManager.swift; sourceTree = "<group>"; };
@@ -392,6 +393,7 @@
 		6091972D2E5A22A800F1D81B /* SeasonTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonTimerView.swift; sourceTree = "<group>"; };
 		6091972F2E5AE4CB00F1D81B /* payboocOTFExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = payboocOTFExtraBold.otf; sourceTree = "<group>"; };
 		609197312E5AE7F300F1D81B /* RankingDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingDetailViewModel.swift; sourceTree = "<group>"; };
+		609197332E5B2AA500F1D81B /* AreaNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaNetwork.swift; sourceTree = "<group>"; };
 		60924DC82C48C00E00221072 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalViewModel.swift; sourceTree = "<group>"; };
 		609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestImageWithTagView.swift; sourceTree = "<group>"; };
@@ -530,7 +532,6 @@
 		600211E62C1EED2B000CC02E /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				600D63972E48E5A9009FE14F /* MetroArea.swift */,
 				60C6B4DB2C2D042700926C0E /* Image.swift */,
 				600211E72C1EED40000CC02E /* Emoji.swift */,
 				A1FF91712C257E9A00F03E4B /* User.swift */,
@@ -785,6 +786,7 @@
 				60C6B4D42C2C565700926C0E /* ChallengeNetwork.swift */,
 				60D8972A2E53B5AE006A8480 /* MissionHistoryNetwork.swift */,
 				605736192D8AC6F000CF7051 /* QuizNetwork.swift */,
+				609197332E5B2AA500F1D81B /* AreaNetwork.swift */,
 				A1C642292C33F55A004954CA /* QuestNetwork.swift */,
 				605445C92DD36E440005742D /* HonorNetwork.swift */,
 				60FF5ECA2E4BB4A6007A5B40 /* SeasonNetwork.swift */,
@@ -1051,6 +1053,7 @@
 				60D8973C2E57504C006A8480 /* RecommendQuestResponse.swift */,
 				60D8973A2E57503F006A8480 /* MissionResponse.swift */,
 				60D897382E575038006A8480 /* RewardResponse.swift */,
+				600D63972E48E5A9009FE14F /* MetroAreaResponse.swift */,
 				60D897262E5374F8006A8480 /* UserTitleResponse.swift */,
 			);
 			path = Response;
@@ -1412,6 +1415,7 @@
 				60D897472E576052006A8480 /* QuizType.swift in Sources */,
 				60ADF9C92D5A019B00556958 /* UIApplication.swift in Sources */,
 				605445C62DD36D1F0005742D /* HonorItem.swift in Sources */,
+				609197342E5B2AA500F1D81B /* AreaNetwork.swift in Sources */,
 				605445D02DD4366D0005742D /* HonorInfoPopupView.swift in Sources */,
 				60924DC92C48C00E00221072 /* Quest.swift in Sources */,
 				60A2ADF82DAE6B68007AC375 /* FAQView.swift in Sources */,
@@ -1492,7 +1496,7 @@
 				605334572D29BE3600599159 /* TutorialViewModel.swift in Sources */,
 				606694F02DDA29E40000E368 /* AnimatedPopup.swift in Sources */,
 				6044B7332C33F754002C13A0 /* ErrorView.swift in Sources */,
-				600D63982E48E5BC009FE14F /* MetroArea.swift in Sources */,
+				600D63982E48E5BC009FE14F /* MetroAreaResponse.swift in Sources */,
 				605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */,
 				6060B2EA2C08947B0083944D /* Image++.swift in Sources */,
 				606694F52DDB25D00000E368 /* QuestViewModelItemBuilder.swift in Sources */,

--- a/ILSANG/Sources/Global/View/RegionPickerView.swift
+++ b/ILSANG/Sources/Global/View/RegionPickerView.swift
@@ -12,21 +12,22 @@ struct RegionPickerView: View {
     let onTap: () -> Void
     
     var body: some View {
-        HStack(spacing: 4) {
-            Image(.illsangRegion)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 16)
-                .frame(30)
-            Button {
-                onTap()
-            } label: {
+        Button {
+            onTap()
+        } label: {
+            HStack(spacing: 4) {
+                Image(.illsangRegion)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 16)
+                    .frame(30)
                 Text(title)
-                    .styledFont(.tabBold)                
+                    .styledFont(.tabBold)
+                    .foregroundStyle(.gray500)
                 Image(.arrowUnder)
                     .frame(18)
+                    .foregroundStyle(.gray500)
             }
-            .foregroundStyle(.gray500)
         }
     }
 }

--- a/ILSANG/Sources/Model/MetroAreaResponse.swift
+++ b/ILSANG/Sources/Model/MetroAreaResponse.swift
@@ -1,0 +1,185 @@
+//
+//  MetroArea.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 8/10/25.
+//
+
+struct MetroAreaResponse: Equatable {
+    static func == (lhs: MetroAreaResponse, rhs: MetroAreaResponse) -> Bool {
+        lhs.code == rhs.code
+    }
+    
+    let code: String
+    let areaName: String
+    let commercialAreaModel: [CommercialArea]
+    
+    static let mockData: [MetroAreaResponse] = [
+        MetroAreaResponse(
+            code: "G01",
+            areaName: "경기남부",
+            commercialAreaModel: CommercialArea.mockDataList1
+        ), MetroAreaResponse(
+            code: "G02",
+            areaName: "경기북부",
+            commercialAreaModel: CommercialArea.mockDataList2
+        )
+    ]
+}
+
+struct CommercialArea: Equatable {
+    let code: String
+    let areaName: String
+    let description: String
+    let metroAreaCode: String
+    
+    static let mockDataList1: [CommercialArea] = [
+        CommercialArea(
+            code: "R100",
+            areaName: "서현",
+            description: "번화가,대학가",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R101",
+            areaName: "정자",
+            description: "분당중심상권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R102",
+            areaName: "야탑",
+            description: "상업지구,역세권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R103",
+            areaName: "미금",
+            description: "역세권,쇼핑몰",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R104",
+            areaName: "수내",
+            description: "주거밀집,근린상권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R105",
+            areaName: "판교",
+            description: "IT기업밀집,오피스상권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R106",
+            areaName: "이매",
+            description: "역세권,주거상권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R107",
+            areaName: "서판교",
+            description: "주거밀집,카페거리",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R108",
+            areaName: "구미동",
+            description: "주거밀집,근린상권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R109",
+            areaName: "정자동",
+            description: "역세권,음식점밀집",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R110",
+            areaName: "동판교",
+            description: "신도시,상업지구",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R111",
+            areaName: "백현동",
+            description: "레스토랑거리,고급상권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R112",
+            areaName: "운중동",
+            description: "주거단지,근린상권",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R113",
+            areaName: "금곡동",
+            description: "역세권,상업시설",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R114",
+            areaName: "야탑동",
+            description: "역세권,대형마트",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R115",
+            areaName: "서현동",
+            description: "중심상권,카페거리",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R116",
+            areaName: "수내동",
+            description: "주거단지,편의시설",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R117",
+            areaName: "정자동카페거리",
+            description: "카페거리,맛집밀집",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R118",
+            areaName: "판교테크노밸리",
+            description: "오피스상권,IT기업",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R119",
+            areaName: "이매동",
+            description: "역세권,학원가",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R120",
+            areaName: "삼평동",
+            description: "신도시,상업시설",
+            metroAreaCode: "G01"
+        ),
+        CommercialArea(
+            code: "R121",
+            areaName: "정자역광장",
+            description: "역광장,상권밀집",
+            metroAreaCode: "G01"
+        )
+    ]
+    
+    static let mockDataList2: [CommercialArea] = [
+        CommercialArea(
+            code: "S100",
+            areaName: "모란",
+            description: "번화가,대학가",
+            metroAreaCode: "G02"
+        ),
+        CommercialArea(
+            code: "S101",
+            areaName: "상대원",
+            description: "분당중심상권",
+            metroAreaCode: "G02"
+        )
+    ]
+}

--- a/ILSANG/Sources/Network/AreaNetwork.swift
+++ b/ILSANG/Sources/Network/AreaNetwork.swift
@@ -1,0 +1,17 @@
+//
+//  AreaNetwork.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 8/24/25.
+//
+
+
+import Alamofire
+
+final class AreaNetwork {
+    private let url: String = APIManager.makeURL(NoTarget(path: "area/metro", version: 1))
+    
+    func getMetroArea() async -> Result<[MetroAreaResponse], Error> {
+        return await Network.requestData(url: url, method: .get)
+    }
+}

--- a/ILSANG/Sources/Network/Response/MetroAreaResponse.swift
+++ b/ILSANG/Sources/Network/Response/MetroAreaResponse.swift
@@ -5,29 +5,30 @@
 //  Created by Lee Jinhee on 8/10/25.
 //
 
-struct MetroArea: Equatable {
-    static func == (lhs: MetroArea, rhs: MetroArea) -> Bool {
+struct MetroAreaResponse: Decodable, Equatable {
+    static func == (lhs: MetroAreaResponse, rhs: MetroAreaResponse) -> Bool {
         lhs.code == rhs.code
     }
     
     let code: String
     let areaName: String
-    let commercialAreaModel: [CommercialArea]
+    let commercialAreas: [CommercialArea]
     
-    static let mockData: [MetroArea] = [
-        MetroArea(
+    static let mockData: [MetroAreaResponse] = [
+        MetroAreaResponse(
             code: "G01",
             areaName: "경기남부",
-            commercialAreaModel: CommercialArea.mockDataList1
-        ), MetroArea(
+            commercialAreas: CommercialArea.mockDataList1
+        ), MetroAreaResponse(
             code: "G02",
             areaName: "경기북부",
-            commercialAreaModel: CommercialArea.mockDataList2
+            commercialAreas: CommercialArea.mockDataList2
         )
     ]
 }
 
-struct CommercialArea: Equatable {
+// TODO: CommercialAreaResponse로 변경
+struct CommercialArea: Equatable, Codable {
     let code: String
     let areaName: String
     let description: String

--- a/ILSANG/Sources/Views/Area/AreaSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/AreaSelectionView.swift
@@ -9,13 +9,13 @@ import SwiftUI
 
 struct AreaSelectionView: View {
     
-    let areas: [MetroArea]
-    
+    @State var areas: [MetroAreaResponse]
     @State var selectedMetroIdx: Int = 0
     @State var selectedCommercialArea: CommercialArea?
     
     var onChangeSelectedCommercial: ((CommercialArea) -> ())
-    
+    let areaNetwork = AreaNetwork()
+
     var body: some View {
         HStack(spacing: 0) {
             // 일상지역
@@ -27,9 +27,18 @@ struct AreaSelectionView: View {
             VStack(spacing: 0) {
                 commercialAreaHeader(title: areas[selectedMetroIdx].areaName)
                 horizontalDivider
-                commercialAreaList(areas[selectedMetroIdx].commercialAreaModel)
+                commercialAreaList(areas[selectedMetroIdx].commercialAreas)
             }
             .padding(.leading, 8)
+        }
+        .task {
+            let result = await areaNetwork.getMetroArea()
+            switch result {
+            case .success(let res):
+                areas = res
+            case .failure:
+                Log("지역 조회 실패")
+            }
         }
         .background(.white)
     }
@@ -46,7 +55,7 @@ struct AreaSelectionView: View {
         .background(Color.background)
     }
     
-    private func metroAreaButton(_ area: MetroArea, isSelected: Bool) -> some View {
+    private func metroAreaButton(_ area: MetroAreaResponse, isSelected: Bool) -> some View {
         Button {
             if let idx = areas.firstIndex(of: area) {
                 selectedMetroIdx = idx
@@ -130,5 +139,5 @@ struct AreaSelectionView: View {
 }
 
 #Preview {
-    AreaSelectionView(areas: MetroArea.mockData, selectedCommercialArea: nil, onChangeSelectedCommercial: {_ in })
+    AreaSelectionView(areas: MetroAreaResponse.mockData, selectedCommercialArea: nil, onChangeSelectedCommercial: {_ in })
 }

--- a/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
@@ -84,7 +84,7 @@ struct IllsangZoneSelectionView: View {
 
 
 class IllsangZoneSelectionViewModel: ObservableObject {
-    let areas: [MetroArea] = MetroArea.mockData
+    let areas: [MetroAreaResponse] = MetroAreaResponse.mockData
 
     @Published var showAlert: Bool = false
     @Published var alertType: AlertType = .illsangZoneSetWarning

--- a/ILSANG/Sources/Views/Area/MyRegionAreaSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/MyRegionAreaSelectionView.swift
@@ -53,7 +53,7 @@ struct MyRegionAreaSelectionView: View {
 
 
 class MyRegionAreaSelectionViewModel: ObservableObject {
-    let areas: [MetroArea] = MetroArea.mockData
+    let areas: [MetroAreaResponse] = MetroAreaResponse.mockData
     @Published var selectedArea: CommercialArea?
 }
 

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -161,9 +161,6 @@ struct HomeView: View {
             RegionPickerView(title: sharedState.selectedCommercialArea.areaName) {
                 vm.showSelectMyRegionView = true
             }
-            .onChange(of: sharedState.selectedCommercialArea.areaName) { _, newValue in
-                vm.alertType = .myRegionChangeSuccess
-            }
             
             Spacer()
             Text("내 일상존: ")

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -158,10 +158,10 @@ struct HomeView: View {
     
     private var regionAndZoneSelectionView: some View {
         HStack(spacing: 4) {
-            RegionPickerView(title: vm.myRegionName ?? "") {
+            RegionPickerView(title: sharedState.selectedCommercialArea.areaName) {
                 vm.showSelectMyRegionView = true
             }
-            .onChange(of: vm.myRegionName) { _, newValue in
+            .onChange(of: sharedState.selectedCommercialArea.areaName) { _, newValue in
                 vm.alertType = .myRegionChangeSuccess
             }
             
@@ -455,7 +455,7 @@ struct HomeView: View {
         questRepository: QuestRepository(network: QuestNetwork()),
         rankNetwork: RankNetwork(),
         bannerNetwork: BannerNetwork(),
-        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork())
+        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: SharedState()
     )
     HomeView(vm: viewModel)
 }

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 enum ViewStatus {
     case error
@@ -93,13 +94,22 @@ final class HomeViewModel {
     private let bannerNetwork: BannerNetwork
     private let favoriteService: FavoriteService
     private let sharedState: SharedState
-
+    
+    private var cancellables = Set<AnyCancellable>()
+    
     init(questRepository: QuestRepositoryInterface, rankNetwork: RankNetwork, bannerNetwork: BannerNetwork, favoriteService: FavoriteService, sharedState: SharedState) {
         self.questRepository = questRepository
         self.rankNetwork = rankNetwork
         self.bannerNetwork = bannerNetwork
         self.favoriteService = favoriteService
         self.sharedState = sharedState
+        
+        sharedState.$selectedCommercialArea
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                Task { await self?.loadInitialData() } // TODO: 배너 제외 데이터 재로드
+            }
+            .store(in: &cancellables)
         
         Task {
             await loadInitialData()
@@ -386,8 +396,6 @@ final class HomeViewModel {
     func handleMyRegionSelection(_ area: CommercialArea) {
         sharedState.selectedCommercialArea = area
         self.alertType = .myRegionChangeSuccess
-        Task { await self.loadInitialData() }
-        // TODO: 배너 제외 데이터 재로드
     }
     
     /// "다시 보지 않기" 체크 여부 확인

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -62,9 +62,7 @@ final class HomeViewModel {
     var showSelectMyRegionView: Bool = false
     var showSelectIllsangZoneView: Bool = false
     var selectedBanner: Banner? = nil
-
-    var myRegionCode: String = "R100" // TODO: 초기값 서현역으로 설정
-    var myRegionName: String? = nil
+    
     var illsangZoneCode: String? = nil
     var illsangZoneName: String? = nil
     var alertType: AlertType? = nil
@@ -94,12 +92,14 @@ final class HomeViewModel {
     private let rankNetwork: RankNetwork
     private let bannerNetwork: BannerNetwork
     private let favoriteService: FavoriteService
-    
-    init(questRepository: QuestRepositoryInterface, rankNetwork: RankNetwork, bannerNetwork: BannerNetwork, favoriteService: FavoriteService) {
+    private let sharedState: SharedState
+
+    init(questRepository: QuestRepositoryInterface, rankNetwork: RankNetwork, bannerNetwork: BannerNetwork, favoriteService: FavoriteService, sharedState: SharedState) {
         self.questRepository = questRepository
         self.rankNetwork = rankNetwork
         self.bannerNetwork = bannerNetwork
         self.favoriteService = favoriteService
+        self.sharedState = sharedState
         
         Task {
             await loadInitialData()
@@ -211,7 +211,7 @@ final class HomeViewModel {
     
     @MainActor
     func loadPopularQuestList() async throws {
-        let res = await questRepository.getPopularQuests(commercialAreaCode: myRegionCode, page: 0, size: 8)
+        let res = await questRepository.getPopularQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: 0, size: 8)
         
         switch res {
         case .success(let response):
@@ -224,7 +224,7 @@ final class HomeViewModel {
     
     @MainActor
     func loadRecommendQuestList() async throws {
-        let res = await questRepository.getRecommendQuests(commercialAreaCode: myRegionCode, page: 0, size: 10)
+        let res = await questRepository.getRecommendQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: 0, size: 10)
         
         switch res {
         case .success(let response):
@@ -237,7 +237,7 @@ final class HomeViewModel {
     
     @MainActor
     func loadLargeRewardQuestList() async throws {
-        let res = await questRepository.getLargeRewardQuests(commercialAreaCode: myRegionCode, page: 0, size: 3)
+        let res = await questRepository.getLargeRewardQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: 0, size: 3)
 
         switch res {
         case .success(let quests):
@@ -384,10 +384,10 @@ final class HomeViewModel {
     
     // 내 지역 선택 완료 시
     func handleMyRegionSelection(_ area: CommercialArea) {
-        self.myRegionCode = area.code
-        self.myRegionName = area.areaName
+        sharedState.selectedCommercialArea = area
         self.alertType = .myRegionChangeSuccess
-        // TODO: 데이터 재로드
+        Task { await self.loadInitialData() }
+        // TODO: 배너 제외 데이터 재로드
     }
     
     /// "다시 보지 않기" 체크 여부 확인

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -9,31 +9,13 @@ import SwiftUI
 import Combine
 
 struct QuestView: View {
-    @StateObject var vm: QuestViewModel
     @EnvironmentObject var sharedState: SharedState
-
-    init() {
-        #if DEBUG
-        _vm = StateObject(
-            wrappedValue: QuestViewModel(
-                questRepository: MockQuestRepository(),
-                favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork())
-            )
-        )
-        #else
-        _vm = StateObject(
-            wrappedValue: QuestViewModel(
-                questRepository: QuestRepository(network: QuestNetwork()),
-                favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork())
-            )
-        )
-        #endif
-    }
+    @ObservedObject var vm: QuestViewModel
     
     var body: some View {
         VStack(spacing: 0) {
             headerView
-                
+            
             switch vm.viewStatus {
             case .loading:
                 ProgressView().frame(maxHeight: .infinity)
@@ -56,6 +38,13 @@ struct QuestView: View {
         ) { _ in
             vm.closeFilterPicker()
         }
+        .overlay(
+            Group {
+                if let alert = vm.alertType {
+                    alertView(alert)
+                }
+            }
+        )
         .sheet(isPresented: $vm.showQuestSheet) {
             let tall = vm.selectedQuest.questType == .repeat || vm.selectedQuest.missionType == .photo
             
@@ -79,6 +68,11 @@ struct QuestView: View {
         .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
             SubmitRouterView(selectedQuest: vm.selectedQuest)
                 .interactiveDismissDisabled()
+        }
+        .navigationDestination(isPresented: $vm.showSelectMyRegionView) {
+            MyRegionAreaSelectionView { area in
+                vm.handleMyRegionSelection(area)
+            }
         }
         .navigationDestination(isPresented: $vm.showQuestEngageView) {
             let challengeNetwork = ChallengeNetwork()
@@ -134,9 +128,9 @@ extension QuestView {
             }
             .onReceive(
                 vm.$selectedHeader
-                        .combineLatest(vm.questFilterState.$selectedValue)
-                        .combineLatest(vm.repeatFilterState.$selectedValue)
-                        .combineLatest(vm.eventFilterState.$selectedValue)
+                    .combineLatest(vm.questFilterState.$selectedValue)
+                    .combineLatest(vm.repeatFilterState.$selectedValue)
+                    .combineLatest(vm.eventFilterState.$selectedValue)
             ) { _ in
                 vm.closeFilterPicker()
                 withAnimation {
@@ -175,7 +169,7 @@ extension QuestView {
                 }
             case .completed: // 완료 퀘스트
                 ForEach(vm.currentQuests, id: \.id) { quest in
-                   CompletedQuestItemView(quest: quest)
+                    CompletedQuestItemView(quest: quest)
                 }
                 
                 if vm.hasMorePage(status: .completed) {
@@ -186,24 +180,35 @@ extension QuestView {
                 }
             }
         }
-        .padding(.top, vm.selectedHeader != .completed ? 70 : 0)
+        .padding(.top, vm.selectedHeader != .completed ? 100 : 0)
         .overlay(alignment: .top) {
-            Group {
-                if (vm.selectedHeader == .default) {
-                    filterPickerDefaultView
-                } else if (vm.selectedHeader == .repeat) {
-                    HStack(alignment: .top, spacing: 8) {
-                        filterPickerRepeatView
-                        filterPickerDefaultView
-                    }
-                } else if (vm.selectedHeader == .event) {
-                    filterPickerEventView
+            VStack(spacing: 16) {
+                RegionPickerView(title: sharedState.selectedCommercialArea.areaName) {
+                    vm.showSelectMyRegionView = true
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .onChange(of: sharedState.selectedCommercialArea.areaName) { _, _ in
+                    vm.alertType = .myRegionChangeSuccess
+                }
+                
+                Group {
+                    if (vm.selectedHeader == .default) {
+                        filterPickerDefaultView
+                    } else if (vm.selectedHeader == .repeat) {
+                        HStack(alignment: .top, spacing: 8) {
+                            filterPickerRepeatView
+                            filterPickerDefaultView
+                        }
+                    } else if (vm.selectedHeader == .event) {
+                        filterPickerEventView
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
             }
-            .padding(.top, 13)
-            .padding(.bottom, 16)
-            .padding(.trailing, 20)
-            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.horizontal, 20)
+//            .padding(.top, 16)
+            .padding(.top, 2)
+            .padding(.bottom, 12)
         }
         .padding(.bottom, 72)
     }
@@ -235,6 +240,18 @@ extension QuestView {
         )
     }
     
+    @ViewBuilder
+    private func alertView(_ alertType: AlertType) -> some View {
+        if alertType == .myRegionChangeSuccess {
+            SettingAlertView(
+                alertType: alertType,
+                onConfirm: {
+                    vm.alertType = nil
+                }
+            )
+        }
+    }
+    
     private var questListEmptyView: some View {
         ErrorView(
             title: vm.selectedHeader.emptyTitle,
@@ -256,5 +273,8 @@ extension QuestView {
 }
 
 #Preview {
-    QuestView()
+    QuestView(vm: QuestViewModel(
+        questRepository: MockQuestRepository(),
+        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: SharedState()
+    ))
 }

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -187,9 +187,6 @@ extension QuestView {
                     vm.showSelectMyRegionView = true
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .onChange(of: sharedState.selectedCommercialArea.areaName) { _, _ in
-                    vm.alertType = .myRegionChangeSuccess
-                }
                 
                 Group {
                     if (vm.selectedHeader == .default) {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -19,8 +19,10 @@ class QuestViewModel: ObservableObject {
     
     // TODO: 바뀔 때 api 요청하도록 수정 (refresh, init 고려)
     @Published var selectedHeader: QuestStatus = .default
-    @Published var commercialAreaCode: String = "R100" // TODO: 현재 지역 코드
-
+    
+    @Published var showSelectMyRegionView: Bool = false
+    @Published var alertType: AlertType? = nil
+    
     // 필터
     @Published var repeatFilterState: FilterPickerState<RepeatType>
     @Published var questFilterState: FilterPickerState<QuestFilterType>
@@ -117,8 +119,9 @@ class QuestViewModel: ObservableObject {
     
     private let questRepository: QuestRepositoryInterface
     private let favoriteService: FavoriteService
-
-    init(questRepository: QuestRepositoryInterface, favoriteService: FavoriteService) {
+    let sharedState: SharedState
+    
+    init(questRepository: QuestRepositoryInterface, favoriteService: FavoriteService, sharedState: SharedState) {
         self.questRepository = questRepository
         self.favoriteService = favoriteService
         
@@ -126,6 +129,9 @@ class QuestViewModel: ObservableObject {
         questFilterState = FilterPickerState(initialValue: QuestFilterType.popular)
         eventFilterState = FilterPickerState(initialValue: EventQuestFilterType.popular)
         repeatFilterState = FilterPickerState(initialValue: RepeatType.daily)
+                
+        self.sharedState = sharedState
+
         questFilterState.onSelectionChange = { [weak self] _ in
             guard let self = self else { return }
             Task { await self.defaultPaginationManager.loadData(isRefreshing: true) }
@@ -290,22 +296,21 @@ class QuestViewModel: ObservableObject {
     private func getQuestList(page: Int, size: Int, status: QuestStatus) async -> (data: [QuestViewModelItem], total: Int) {
         let result: Result<ResponseWithPage<[Quest]>, Error>
         
-        // TODO: orderRewardDesc 확인하기
         switch status {
         case .default:
             switch questFilterState.selectedValue {
             case .pointHighest:
-                result = await questRepository.getDefaultQuests(commercialAreaCode: commercialAreaCode, orderRewardDesc: false, page: page, size: size)
+                result = await questRepository.getDefaultQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, orderRewardDesc: false, page: page, size: size)
             case .pointLowest:
-                result = await questRepository.getDefaultQuests(commercialAreaCode: commercialAreaCode, orderRewardDesc: true, page: page, size: size)
+                result = await questRepository.getDefaultQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, orderRewardDesc: true, page: page, size: size)
             case .popular:
-                result = await questRepository.getDefaultQuests(commercialAreaCode: commercialAreaCode, orderRewardDesc: nil, page: page, size: size)
+                result = await questRepository.getDefaultQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, orderRewardDesc: nil, page: page, size: size)
             }
         case .repeat:
             switch questFilterState.selectedValue {
             case .pointHighest:
                 result = await questRepository.getRepeatQuests(
-                    commercialAreaCode: commercialAreaCode,
+                    commercialAreaCode: sharedState.selectedCommercialArea.code,
                     repeatFrequency: self.repeatFilterState.selectedValue,
                     orderRewardDesc: false,
                     page: page,
@@ -313,7 +318,7 @@ class QuestViewModel: ObservableObject {
                 )
             case .pointLowest:
                 result = await questRepository.getRepeatQuests(
-                    commercialAreaCode: commercialAreaCode,
+                    commercialAreaCode: sharedState.selectedCommercialArea.code,
                     repeatFrequency: self.repeatFilterState.selectedValue,
                     orderRewardDesc: true,
                     page: page,
@@ -321,7 +326,7 @@ class QuestViewModel: ObservableObject {
                 )
             case .popular:
                 result = await questRepository.getRepeatQuests(
-                    commercialAreaCode: commercialAreaCode,
+                    commercialAreaCode: sharedState.selectedCommercialArea.code,
                     repeatFrequency: self.repeatFilterState.selectedValue,
                     orderRewardDesc: nil,
                     page: page,
@@ -331,14 +336,14 @@ class QuestViewModel: ObservableObject {
         case .event:
             switch eventFilterState.selectedValue {
             case .pointHighest:
-                result = await questRepository.getEventQuests(commercialAreaCode: commercialAreaCode, orderRewardDesc: false, page: page, size: size)
+                result = await questRepository.getEventQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, orderRewardDesc: false, page: page, size: size)
             case .pointLowest:
-                result = await questRepository.getEventQuests(commercialAreaCode: commercialAreaCode, orderRewardDesc: true, page: page, size: size)
+                result = await questRepository.getEventQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, orderRewardDesc: true, page: page, size: size)
             case .popular, .upcoming:
-                result = await questRepository.getEventQuests(commercialAreaCode: commercialAreaCode, orderRewardDesc: nil, page: page, size: size)
+                result = await questRepository.getEventQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, orderRewardDesc: nil, page: page, size: size)
             }
         case .completed:
-            result = await questRepository.getCompletedQuests(commercialAreaCode: commercialAreaCode, page: page, size: size)
+            result = await questRepository.getCompletedQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: page, size: size)
         }
         
         switch result {
@@ -376,6 +381,13 @@ class QuestViewModel: ObservableObject {
             self.showQuestSheet = true
         }
     }
+    
+    func handleMyRegionSelection(_ area: CommercialArea) {
+        sharedState.selectedCommercialArea = area
+        self.alertType = .myRegionChangeSuccess
+        Task { await self.loadInitialData() }
+    }
+    
     
     /// 즐겨찾기 상태를 UI에 즉시 반영하고,  서버 반영은 디바운싱 처리
     func toggleFavoriteStatus(quest: QuestViewModelItem) {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 class QuestViewModel: ObservableObject {
     // TODO: API 요청 실패 시 에러상태로 변경하기
@@ -120,7 +121,8 @@ class QuestViewModel: ObservableObject {
     private let questRepository: QuestRepositoryInterface
     private let favoriteService: FavoriteService
     let sharedState: SharedState
-    
+    private var cancellables = Set<AnyCancellable>()
+
     init(questRepository: QuestRepositoryInterface, favoriteService: FavoriteService, sharedState: SharedState) {
         self.questRepository = questRepository
         self.favoriteService = favoriteService
@@ -144,6 +146,13 @@ class QuestViewModel: ObservableObject {
             guard let self = self else { return }
             Task { await self.repeatPaginationManager.loadData(isRefreshing: true) }
         }
+        
+        sharedState.$selectedCommercialArea
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                Task { await self?.loadInitialData() }
+            }
+            .store(in: &cancellables)
     }
     
     func loadDataIfNeeded() async {
@@ -385,7 +394,6 @@ class QuestViewModel: ObservableObject {
     func handleMyRegionSelection(_ area: CommercialArea) {
         sharedState.selectedCommercialArea = area
         self.alertType = .myRegionChangeSuccess
-        Task { await self.loadInitialData() }
     }
     
     

--- a/ILSANG/Sources/Views/Router/MainTabView.swift
+++ b/ILSANG/Sources/Views/Router/MainTabView.swift
@@ -11,12 +11,9 @@ struct MainTabView: View {
     @StateObject var sharedState = SharedState()
     @StateObject var honorAcquisitionManager = HonorAcquisitionManager(honorNetwork: defaultHonorNetwork)
     @StateObject var seasonManager = SeasonManager(seasonNetwork: defaultSeasonNetwork)
-    let viewModel = HomeViewModel(
-        questRepository: QuestRepository(network: QuestNetwork()),
-        rankNetwork: RankNetwork(),
-        bannerNetwork: BannerNetwork(),
-        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork())
-    )
+   
+    var homeViewModel: HomeViewModel
+    @StateObject var questViewModel: QuestViewModel
     
     static var defaultHonorNetwork: HonorNetworkProtocol {
         return HonorNetwork() // MockHonorNetwork()
@@ -25,6 +22,33 @@ struct MainTabView: View {
     static var defaultSeasonNetwork: SeasonNetworkProtocol {
         return SeasonNetwork() // MockSeasonNetwork()
     }
+    
+    init() {
+        let sharedState = SharedState()
+        _sharedState = StateObject(wrappedValue: sharedState)
+        
+        self.homeViewModel =  HomeViewModel(
+            questRepository: QuestRepository(network: QuestNetwork()),
+            rankNetwork: RankNetwork(),
+            bannerNetwork: BannerNetwork(),
+            favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
+            sharedState: sharedState
+        )
+        
+#if DEBUG
+           self._questViewModel = StateObject(wrappedValue: QuestViewModel(
+            questRepository: MockQuestRepository(),
+            favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: sharedState)
+           )
+           
+#else
+           self._questViewModel = StateObject(wrappedValue: QuestViewModel(
+            questRepository: QuestRepository(network: QuestNetwork()),
+            favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: sharedState)
+           )
+#endif
+          
+       }
     
     var body: some View {
         NavigationStack {
@@ -60,9 +84,9 @@ struct MainTabView: View {
     func createTabView(for tab: Tab) -> some View {
         switch tab {
         case .home:
-            HomeView(vm: viewModel)
+            HomeView(vm: homeViewModel)
         case .quest:
-            QuestView()
+            QuestView(vm: questViewModel)
         case .approval:
             ApprovalView()
         case .ranking:
@@ -75,4 +99,34 @@ struct MainTabView: View {
 
 class SharedState: ObservableObject {
     @Published var selectedTab: Tab = .home
+    @Published var selectedCommercialArea: CommercialArea {
+        didSet {
+            UserDefaults.standard.saveCommercialArea(selectedCommercialArea)
+        }
+    }
+    
+    init() {
+        self.selectedCommercialArea = UserDefaults.standard.loadCommercialArea()
+        ?? CommercialArea(code: "R100", areaName: "서현", description: "", metroAreaCode: "G01")
+    }
+}
+
+extension UserDefaults {
+    private enum Keys {
+        static let selectedCommercialArea = "selectedCommercialArea"
+    }
+
+    func saveCommercialArea(_ area: CommercialArea) {
+        if let data = try? JSONEncoder().encode(area) {
+            set(data, forKey: Keys.selectedCommercialArea)
+        }
+    }
+
+    func loadCommercialArea() -> CommercialArea? {
+        guard let data = data(forKey: Keys.selectedCommercialArea),
+              let area = try? JSONDecoder().decode(CommercialArea.self, from: data) else {
+            return nil
+        }
+        return area
+    }
 }


### PR DESCRIPTION
#### relate #374

### ✏️ 개요
현재지역 로컬 저장을 위해 광역지역전체조회 API를 연결합니다.

### 💻 작업 사항
- [x] 퀘스트 화면: 내지역 컴포넌트 추가 (내지역 화면 이동 및 선택 완료 후 알럿)
- [x] 광역지역전체 API 조회
- [x] 내지역 초기값 서현 설정
- [x] 내지역 변경 시 UserDefaults 저장 및 퀘스트 데이터 갱신 (홈&퀘스트 화면 동기화)
- [ ] 시즌 변경 시 재조회 후 로컬 저장



