### PR TITLE
[Ref/#394] 퀘스트 즐겨찾기 등록/삭제 API 재연결

### DIFF
--- a/ILSANG/Sources/Network/FavoriteNetwork.swift
+++ b/ILSANG/Sources/Network/FavoriteNetwork.swift
@@ -13,7 +13,7 @@ final class FavoriteNetwork {
     func post(questId: Int) async -> Bool {
         let body = ["questId": "\(questId)"]
         let bodyData = body.convertToJsonData()
-        let res: Result<ResponseWithoutData, Error> = await Network.requestData(url: url+"/favorite", method: .post, parameters: nil, body: bodyData, withToken: true)
+        let res: Result<ResponseWithEmpty, Error> = await Network.requestData(url: url+"/favorite", method: .post, body: bodyData)
         switch res {
         case .success:
             return true
@@ -25,7 +25,7 @@ final class FavoriteNetwork {
     func delete(questId: Int) async -> Bool {
         let body = ["questId": "\(questId)"]
         let bodyData = body.convertToJsonData()
-        let res: Result<ResponseWithoutData, Error> = await Network.requestData(url: url+"/favorite", method: .delete, parameters: nil, body: bodyData, withToken: true)
+        let res: Result<ResponseWithEmpty, Error> = await Network.requestData(url: url+"/favorite", method: .delete, body: bodyData)
         switch res {
         case .success:
             return true


### PR DESCRIPTION
#### close #394 

### ✏️ 개요
퀘스트 즐겨찾기 등록/삭제 API를 재연결합니다.

### 💻 작업 사항
- 퀘스트 즐겨찾기 등록/삭제 API 응답 구조 변경