### PR TITLE
[Feat/#396] 광역지역조회 API 호출 이후 메모리 캐시 처리

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		600657DC2DBCCBAA0022D117 /* MyPageInfoCardBottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600657DB2DBCCBAA0022D117 /* MyPageInfoCardBottomView.swift */; };
 		600657E02DBCFEE80022D117 /* HonorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600657DF2DBCFEE20022D117 /* HonorView.swift */; };
 		600657E42DBD2DF50022D117 /* MyPageHonorManageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600657E32DBD2DF50022D117 /* MyPageHonorManageView.swift */; };
-		600D63982E48E5BC009FE14F /* MetroAreaResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D63972E48E5A9009FE14F /* MetroAreaResponse.swift */; };
+		600D63982E48E5BC009FE14F /* AreaResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D63972E48E5A9009FE14F /* AreaResponse.swift */; };
 		600D639C2E48E83F009FE14F /* AreaSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D639B2E48E83F009FE14F /* AreaSelectionView.swift */; };
 		600D639E2E490D14009FE14F /* IllsangZoneSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D639D2E490D14009FE14F /* IllsangZoneSelectionView.swift */; };
 		600D83A42C7B1FA4005C93E2 /* PaginationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */; };
@@ -158,6 +158,9 @@
 		6091975F2E5DEA2B00F1D81B /* BannerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6091975E2E5DEA2B00F1D81B /* BannerRepository.swift */; };
 		609197612E5DEB5600F1D81B /* BannerViewModelItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609197602E5DEB5600F1D81B /* BannerViewModelItem.swift */; };
 		609197632E5DEC0F00F1D81B /* Banner+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609197622E5DEC0F00F1D81B /* Banner+UIMapper.swift */; };
+		609197652E5E02CD00F1D81B /* AreaRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609197642E5E02CD00F1D81B /* AreaRepository.swift */; };
+		609197672E5E069600F1D81B /* Area.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609197662E5E069400F1D81B /* Area.swift */; };
+		609197692E5E06FB00F1D81B /* AreaResponse+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609197682E5E06F300F1D81B /* AreaResponse+Mapping.swift */; };
 		60924DC92C48C00E00221072 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60924DC82C48C00E00221072 /* Quest.swift */; };
 		60943FE62C0A38FB00C8A714 /* ApprovalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */; };
 		609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */; };
@@ -290,7 +293,7 @@
 		600657DB2DBCCBAA0022D117 /* MyPageInfoCardBottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageInfoCardBottomView.swift; sourceTree = "<group>"; };
 		600657DF2DBCFEE20022D117 /* HonorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HonorView.swift; sourceTree = "<group>"; };
 		600657E32DBD2DF50022D117 /* MyPageHonorManageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHonorManageView.swift; sourceTree = "<group>"; };
-		600D63972E48E5A9009FE14F /* MetroAreaResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetroAreaResponse.swift; sourceTree = "<group>"; };
+		600D63972E48E5A9009FE14F /* AreaResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaResponse.swift; sourceTree = "<group>"; };
 		600D639B2E48E83F009FE14F /* AreaSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaSelectionView.swift; sourceTree = "<group>"; };
 		600D639D2E490D14009FE14F /* IllsangZoneSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IllsangZoneSelectionView.swift; sourceTree = "<group>"; };
 		600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationManager.swift; sourceTree = "<group>"; };
@@ -433,6 +436,9 @@
 		6091975E2E5DEA2B00F1D81B /* BannerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerRepository.swift; sourceTree = "<group>"; };
 		609197602E5DEB5600F1D81B /* BannerViewModelItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewModelItem.swift; sourceTree = "<group>"; };
 		609197622E5DEC0F00F1D81B /* Banner+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Banner+UIMapper.swift"; sourceTree = "<group>"; };
+		609197642E5E02CD00F1D81B /* AreaRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaRepository.swift; sourceTree = "<group>"; };
+		609197662E5E069400F1D81B /* Area.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Area.swift; sourceTree = "<group>"; };
+		609197682E5E06F300F1D81B /* AreaResponse+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AreaResponse+Mapping.swift"; sourceTree = "<group>"; };
 		60924DC82C48C00E00221072 /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalViewModel.swift; sourceTree = "<group>"; };
 		609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestImageWithTagView.swift; sourceTree = "<group>"; };
@@ -1120,7 +1126,7 @@
 				60D8973C2E57504C006A8480 /* RecommendQuestResponse.swift */,
 				60D8973A2E57503F006A8480 /* MissionResponse.swift */,
 				60D897382E575038006A8480 /* RewardResponse.swift */,
-				600D63972E48E5A9009FE14F /* MetroAreaResponse.swift */,
+				600D63972E48E5A9009FE14F /* AreaResponse.swift */,
 				60D897262E5374F8006A8480 /* UserTitleResponse.swift */,
 				6091975A2E5DE8C800F1D81B /* BannerResponse.swift */,
 				6091974D2E5C27D000F1D81B /* Rank */,
@@ -1142,6 +1148,7 @@
 		60D897192E537188006A8480 /* Entity */ = {
 			isa = PBXGroup;
 			children = (
+				609197662E5E069400F1D81B /* Area.swift */,
 				60924DC82C48C00E00221072 /* Quest.swift */,
 				60D8974A2E57645D006A8480 /* Reward.swift */,
 				60D897482E576302006A8480 /* Mission.swift */,
@@ -1159,6 +1166,7 @@
 				60D8971D2E5372B3006A8480 /* MissionHistoryRepository.swift */,
 				609197522E5C2E0500F1D81B /* RankRepository.swift */,
 				6091975E2E5DEA2B00F1D81B /* BannerRepository.swift */,
+				609197642E5E02CD00F1D81B /* AreaRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1176,6 +1184,7 @@
 				609197272E59EC7100F1D81B /* RewardResponse+Mapping.swift */,
 				60D8971F2E5372BE006A8480 /* MissionHistoryResponse+Mapping.swift */,
 				6091975C2E5DE9C100F1D81B /* BannerResponse+Mapping.swift */,
+				609197682E5E06F300F1D81B /* AreaResponse+Mapping.swift */,
 				609197392E5C263900F1D81B /* Rank */,
 			);
 			path = Mapper;
@@ -1573,6 +1582,7 @@
 				60D8973D2E57504C006A8480 /* RecommendQuestResponse.swift in Sources */,
 				604687A52D1FC36A0056E394 /* TitleWithContentView.swift in Sources */,
 				60FF5EC52E4949F8007A5B40 /* RegionPickerView.swift in Sources */,
+				609197692E5E06FB00F1D81B /* AreaResponse+Mapping.swift in Sources */,
 				A19628622C0763F90037C53A /* ProfileEditView.swift in Sources */,
 				601BCF1C2D7C150700138387 /* OtherUserChallengeDetailView.swift in Sources */,
 				605E81462D9FE6D800ECDB15 /* QuestDetailRepeatRankView.swift in Sources */,
@@ -1584,7 +1594,7 @@
 				605334572D29BE3600599159 /* TutorialViewModel.swift in Sources */,
 				606694F02DDA29E40000E368 /* AnimatedPopup.swift in Sources */,
 				6044B7332C33F754002C13A0 /* ErrorView.swift in Sources */,
-				600D63982E48E5BC009FE14F /* MetroAreaResponse.swift in Sources */,
+				600D63982E48E5BC009FE14F /* AreaResponse.swift in Sources */,
 				605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */,
 				6060B2EA2C08947B0083944D /* Image++.swift in Sources */,
 				606694F52DDB25D00000E368 /* QuestViewModelItemBuilder.swift in Sources */,
@@ -1668,6 +1678,7 @@
 				605E814A2D9FEB2300ECDB15 /* QuestDetailStatView.swift in Sources */,
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,
 				6091973E2E5C26C000F1D81B /* MetroAreaResponse+Mapping.swift in Sources */,
+				609197672E5E069600F1D81B /* Area.swift in Sources */,
 				60ADF9C22D59D47100556958 /* FontWithLineHeight.swift in Sources */,
 				606292D82C19E70A0098B6D2 /* Network.swift in Sources */,
 				605445CC2DD36EA30005742D /* TitleHistory.swift in Sources */,
@@ -1679,6 +1690,7 @@
 				600211EA2C1EEE6D000CC02E /* APITarget.swift in Sources */,
 				A1BB60282BFE129000AAADD4 /* MyPageChallengeList.swift in Sources */,
 				6011891D2C3E8B3B0070F2AD /* UserService.swift in Sources */,
+				609197652E5E02CD00F1D81B /* AreaRepository.swift in Sources */,
 				A196286D2C0859820037C53A /* TermsAndPolicyView.swift in Sources */,
 				605E813D2D9F1B9900ECDB15 /* QuestDetailViewModel.swift in Sources */,
 				60C0F4242CCE9B2F00DB19AB /* UIDevice++.swift in Sources */,

--- a/ILSANG/Sources/Domain/Entity/Area.swift
+++ b/ILSANG/Sources/Domain/Entity/Area.swift
@@ -1,0 +1,22 @@
+//
+//  Area.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 8/27/25.
+//
+
+struct MetroArea: Equatable {
+    static func == (lhs: MetroArea, rhs: MetroArea) -> Bool {
+        lhs.code == rhs.code
+    }
+    
+    let code: String
+    let areaName: String
+    let commercialAreas: [CommercialArea]
+}
+
+struct CommercialArea: Equatable, Codable {
+    let code: String
+    let areaName: String
+    let metroAreaCode: String
+}

--- a/ILSANG/Sources/Domain/Mapper/AreaResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/AreaResponse+Mapping.swift
@@ -1,0 +1,27 @@
+//
+//  AreaResponse+Mapping.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 8/27/25.
+//
+
+
+extension MetroAreaResponse {
+    func toDomain() -> MetroArea {
+        MetroArea(
+            code: code,
+            areaName: areaName,
+            commercialAreas: commercialAreas.map { $0.toDomain() }
+        )
+    }
+}
+
+extension CommercialAreaResponse {
+    func toDomain() -> CommercialArea {
+        CommercialArea(
+            code: code,
+            areaName: areaName,
+            metroAreaCode: metroAreaCode
+        )
+    }
+}

--- a/ILSANG/Sources/Domain/Repository/AreaRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/AreaRepository.swift
@@ -1,0 +1,41 @@
+//
+//  AreaRepositoryInterface.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 8/26/25.
+//
+
+import Foundation
+
+protocol AreaRepositoryInterface {
+    func getMetroAreas(forceRefresh: Bool) async -> Result<[MetroArea], Error>
+}
+
+final class AreaRepository: AreaRepositoryInterface {
+    private let network: AreaNetwork
+    private var memoryCache: [MetroArea]?
+
+    init(network: AreaNetwork) {
+        self.network = network
+    }
+
+    func getMetroAreas(forceRefresh: Bool = false) async -> Result<[MetroArea], Error> {
+        // 메모리 캐시
+        if let cached = memoryCache, !forceRefresh {
+            return .success(cached)
+        }
+
+        // TODO: 디스크 캐시
+
+        // 네트워크
+        let result = await network.getMetroAreas()
+        switch result {
+        case .success(let areas):
+            let metroAreas = areas.map { $0.toDomain() }
+            memoryCache = metroAreas
+            return .success(metroAreas)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/ILSANG/Sources/Network/AreaNetwork.swift
+++ b/ILSANG/Sources/Network/AreaNetwork.swift
@@ -11,7 +11,7 @@ import Alamofire
 final class AreaNetwork {
     private let url: String = APIManager.makeURL(NoTarget(path: "area/metro", version: 1))
     
-    func getMetroArea() async -> Result<[MetroAreaResponse], Error> {
+    func getMetroAreas() async -> Result<[MetroAreaResponse], Error> {
         return await Network.requestData(url: url, method: .get)
     }
 }

--- a/ILSANG/Sources/Network/Response/AreaResponse.swift
+++ b/ILSANG/Sources/Network/Response/AreaResponse.swift
@@ -5,163 +5,158 @@
 //  Created by Lee Jinhee on 8/10/25.
 //
 
-struct MetroAreaResponse: Decodable, Equatable {
-    static func == (lhs: MetroAreaResponse, rhs: MetroAreaResponse) -> Bool {
-        lhs.code == rhs.code
-    }
-    
+struct MetroAreaResponse: Codable {
     let code: String
     let areaName: String
-    let commercialAreas: [CommercialArea]
+    let commercialAreas: [CommercialAreaResponse]
     
     static let mockData: [MetroAreaResponse] = [
         MetroAreaResponse(
             code: "G01",
             areaName: "경기남부",
-            commercialAreas: CommercialArea.mockDataList1
+            commercialAreas: CommercialAreaResponse.mockDataList1
         ), MetroAreaResponse(
             code: "G02",
             areaName: "경기북부",
-            commercialAreas: CommercialArea.mockDataList2
+            commercialAreas: CommercialAreaResponse.mockDataList2
         )
     ]
 }
 
-// TODO: CommercialAreaResponse로 변경
-struct CommercialArea: Equatable, Codable {
+struct CommercialAreaResponse: Codable, Equatable {
     let code: String
     let areaName: String
     let description: String
     let metroAreaCode: String
     
-    static let mockDataList1: [CommercialArea] = [
-        CommercialArea(
+    static let mockDataList1: [CommercialAreaResponse] = [
+        CommercialAreaResponse(
             code: "R100",
             areaName: "서현",
             description: "번화가,대학가",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R101",
             areaName: "정자",
             description: "분당중심상권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R102",
             areaName: "야탑",
             description: "상업지구,역세권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R103",
             areaName: "미금",
             description: "역세권,쇼핑몰",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R104",
             areaName: "수내",
             description: "주거밀집,근린상권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R105",
             areaName: "판교",
             description: "IT기업밀집,오피스상권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R106",
             areaName: "이매",
             description: "역세권,주거상권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R107",
             areaName: "서판교",
             description: "주거밀집,카페거리",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R108",
             areaName: "구미동",
             description: "주거밀집,근린상권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R109",
             areaName: "정자동",
             description: "역세권,음식점밀집",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R110",
             areaName: "동판교",
             description: "신도시,상업지구",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R111",
             areaName: "백현동",
             description: "레스토랑거리,고급상권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R112",
             areaName: "운중동",
             description: "주거단지,근린상권",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R113",
             areaName: "금곡동",
             description: "역세권,상업시설",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R114",
             areaName: "야탑동",
             description: "역세권,대형마트",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R115",
             areaName: "서현동",
             description: "중심상권,카페거리",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R116",
             areaName: "수내동",
             description: "주거단지,편의시설",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R117",
             areaName: "정자동카페거리",
             description: "카페거리,맛집밀집",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R118",
             areaName: "판교테크노밸리",
             description: "오피스상권,IT기업",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R119",
             areaName: "이매동",
             description: "역세권,학원가",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R120",
             areaName: "삼평동",
             description: "신도시,상업시설",
             metroAreaCode: "G01"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "R121",
             areaName: "정자역광장",
             description: "역광장,상권밀집",
@@ -169,14 +164,14 @@ struct CommercialArea: Equatable, Codable {
         )
     ]
     
-    static let mockDataList2: [CommercialArea] = [
-        CommercialArea(
+    static let mockDataList2: [CommercialAreaResponse] = [
+        CommercialAreaResponse(
             code: "S100",
             areaName: "모란",
             description: "번화가,대학가",
             metroAreaCode: "G02"
         ),
-        CommercialArea(
+        CommercialAreaResponse(
             code: "S101",
             areaName: "상대원",
             description: "분당중심상권",

--- a/ILSANG/Sources/Views/Area/AreaSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/AreaSelectionView.swift
@@ -9,13 +9,11 @@ import SwiftUI
 
 struct AreaSelectionView: View {
     
-    @State var areas: [MetroAreaResponse]
-    @State var selectedMetroIdx: Int = 0
-    @State var selectedCommercialArea: CommercialArea?
+    let areas: [MetroArea]
+    @Binding var selectedMetroIdx: Int
+    @Binding var selectedCommercialArea: CommercialArea?
+    var onChangeSelectedCommercial: (CommercialArea) -> Void
     
-    var onChangeSelectedCommercial: ((CommercialArea) -> ())
-    let areaNetwork = AreaNetwork()
-
     var body: some View {
         HStack(spacing: 0) {
             // 일상지역
@@ -30,15 +28,6 @@ struct AreaSelectionView: View {
                 commercialAreaList(areas[selectedMetroIdx].commercialAreas)
             }
             .padding(.leading, 8)
-        }
-        .task {
-            let result = await areaNetwork.getMetroArea()
-            switch result {
-            case .success(let res):
-                areas = res
-            case .failure:
-                Log("지역 조회 실패")
-            }
         }
         .background(.white)
     }
@@ -55,7 +44,7 @@ struct AreaSelectionView: View {
         .background(Color.background)
     }
     
-    private func metroAreaButton(_ area: MetroAreaResponse, isSelected: Bool) -> some View {
+    private func metroAreaButton(_ area: MetroArea, isSelected: Bool) -> some View {
         Button {
             if let idx = areas.firstIndex(of: area) {
                 selectedMetroIdx = idx
@@ -139,5 +128,10 @@ struct AreaSelectionView: View {
 }
 
 #Preview {
-    AreaSelectionView(areas: MetroAreaResponse.mockData, selectedCommercialArea: nil, onChangeSelectedCommercial: {_ in })
+    AreaSelectionView(
+        areas: [MetroArea(code: "G01", areaName: "경기남부", commercialAreas: [.init(code: "S01", areaName: "서현", metroAreaCode: "S01")])],
+        selectedMetroIdx: .constant(0),
+        selectedCommercialArea: .constant(nil),
+        onChangeSelectedCommercial: { _ in }
+    )
 }

--- a/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
@@ -13,83 +13,102 @@ struct IllsangZoneSelectionView: View {
     
     var onSuccess: ((CommercialArea) -> Void)?
     
-    init(onSuccess: ((CommercialArea) -> Void)? = nil) {
-        self._viewModel = StateObject(wrappedValue: IllsangZoneSelectionViewModel())
+    init(areaRepository: AreaRepositoryInterface, onSuccess: ((CommercialArea) -> Void)? = nil) {
+        self._viewModel = StateObject(wrappedValue: IllsangZoneSelectionViewModel(areaRepository: areaRepository))
         self.onSuccess = onSuccess
     }
     
     var body: some View {
-        ZStack {
-            VStack(spacing: 0) {
-                NavigationTitleView(title: "일상존 선택") {
-                    dismiss()
-                }
-                .padding(.bottom, 8)
-                .padding(.horizontal, -20)
-                
-                AreaSelectionView(
-                    areas: viewModel.areas,
-                    onChangeSelectedCommercial: { area in
-                        viewModel.selectedArea = area
-                    }
-                )
+        VStack(spacing: 0) {
+            NavigationTitleView(title: "일상존 선택") {
+                dismiss()
             }
-            .navigationBarBackButtonHidden()
-            .padding(.horizontal, 20)
-            .safeAreaInset(edge: .bottom, alignment: .center) {
-                if viewModel.selectedArea != nil {
-                    PrimaryButton(title: "내 일상존 선택하기") {
-                        viewModel.showChangeWarning()
-                    }
-                    .padding(.horizontal, 20)
-                }
-            }
+            .padding(.bottom, 8)
+            .padding(.horizontal, -20)
             
-            if viewModel.showAlert {
-                switch viewModel.alertType {
-                case .illsangZoneSetWarning:
-                    SettingAlertView(
-                        alertType: viewModel.alertType,
-                        onCancel: { viewModel.showAlert = false },
-                        onConfirm: {
-                            let setSucc = viewModel.setIllsangZone()
-                            if setSucc {
-                                if let selectedArea = viewModel.selectedArea {
-                                    onSuccess?(selectedArea)
-                                    dismiss()
-                                }
-                            }
-                        }) {
-                            HStack(spacing: 0) {
-                                Text("현재 선택된 일상존: ")
-                                    .foregroundStyle(.gray500)
-                                Text(viewModel.selectedArea?.areaName ?? "없음")
-                                    .foregroundStyle(.primary500)
-                            }
-                            .styledFont(.regular, size: 13, lineHeight: 20)
-
-                        }
-                case .illsangZoneSetFailed:
-                    SettingAlertView(
-                        alertType: viewModel.alertType,
-                        onConfirm: { viewModel.showAlert = false }
-                    )
-                default: EmptyView()
+            AreaSelectionView(
+                areas: viewModel.areas,
+                selectedMetroIdx: $viewModel.selectedMetroIdx,
+                selectedCommercialArea: $viewModel.selectedArea,
+                onChangeSelectedCommercial: { area in
+                    viewModel.selectedArea = area
                 }
+            )
+        }
+        .task {
+            await viewModel.loadAreas()
+        }
+        .navigationBarBackButtonHidden()
+        .padding(.horizontal, 20)
+        .safeAreaInset(edge: .bottom, alignment: .center) {
+            if viewModel.selectedArea != nil {
+                PrimaryButton(title: "내 일상존 선택하기") {
+                    viewModel.showChangeWarning()
+                }
+                .padding(.horizontal, 20)
             }
         }
         
+        if viewModel.showAlert {
+            switch viewModel.alertType {
+            case .illsangZoneSetWarning:
+                SettingAlertView(
+                    alertType: viewModel.alertType,
+                    onCancel: { viewModel.showAlert = false },
+                    onConfirm: {
+                        let setSucc = viewModel.setIllsangZone()
+                        if setSucc {
+                            if let selectedArea = viewModel.selectedArea {
+                                onSuccess?(selectedArea)
+                                dismiss()
+                            }
+                        }
+                    }) {
+                        HStack(spacing: 0) {
+                            Text("현재 선택된 일상존: ")
+                                .foregroundStyle(.gray500)
+                            Text(viewModel.selectedArea?.areaName ?? "없음")
+                                .foregroundStyle(.primary500)
+                        }
+                        .styledFont(.regular, size: 13, lineHeight: 20)
+                        
+                    }
+            case .illsangZoneSetFailed:
+                SettingAlertView(
+                    alertType: viewModel.alertType,
+                    onConfirm: { viewModel.showAlert = false }
+                )
+            default: EmptyView()
+            }
+        }
     }
 }
 
 
+@MainActor
 class IllsangZoneSelectionViewModel: ObservableObject {
-    let areas: [MetroAreaResponse] = MetroAreaResponse.mockData
-
+    @Published var areas: [MetroArea] = []
+    @Published var selectedMetroIdx: Int = 0
+    @Published var selectedArea: CommercialArea?
     @Published var showAlert: Bool = false
     @Published var alertType: AlertType = .illsangZoneSetWarning
-    @Published var selectedArea: CommercialArea?
-
+    
+    private let areaRepository: AreaRepositoryInterface
+    
+    init(areaRepository: AreaRepositoryInterface) {
+        self.areaRepository = areaRepository
+    }
+    
+    func loadAreas() async {
+        let result = await areaRepository.getMetroAreas(forceRefresh: false)
+        switch result {
+        case .success(let res):
+            self.areas = res
+        case .failure:
+            Log("지역 조회 실패")
+        }
+    }
+    
     func showChangeWarning() {
         alertType = .illsangZoneSetWarning
         showAlert = true
@@ -97,8 +116,7 @@ class IllsangZoneSelectionViewModel: ObservableObject {
     
     func setIllsangZone() -> Bool {
         // TODO: 네트워크 요청
-         let result: Result<Void, Error> = .success(())
-//        let result: Result<Void, Error> = .failure(NetworkError.emptyResponse)
+        let result: Result<Void, Error> = .success(())
         switch result {
         case .success:
             return true
@@ -111,5 +129,5 @@ class IllsangZoneSelectionViewModel: ObservableObject {
 }
 
 #Preview {
-    IllsangZoneSelectionView()
+    IllsangZoneSelectionView(areaRepository: AreaRepository(network: AreaNetwork()))
 }

--- a/ILSANG/Sources/Views/Area/MyRegionAreaSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/MyRegionAreaSelectionView.swift
@@ -13,50 +13,73 @@ struct MyRegionAreaSelectionView: View {
     
     var onSuccess: ((CommercialArea) -> Void)?
     
-    init(onSuccess: ((CommercialArea) -> Void)? = nil) {
-        self._viewModel = StateObject(wrappedValue: MyRegionAreaSelectionViewModel())
+    init(areaRepository: AreaRepositoryInterface, onSuccess: ((CommercialArea) -> Void)? = nil) {
+        self._viewModel = StateObject(wrappedValue: MyRegionAreaSelectionViewModel(areaRepository: areaRepository))
         self.onSuccess = onSuccess
     }
-
+    
     var body: some View {
-        ZStack {
-            VStack(spacing: 0) {
-                NavigationTitleView(title: "내 지역") {
+        VStack(spacing: 0) {
+            NavigationTitleView(title: "내 지역") {
+                dismiss()
+            }
+            .padding(.bottom, 8)
+            .padding(.horizontal, -20)
+            
+            AreaSelectionView(
+                areas: viewModel.areas,
+                selectedMetroIdx: $viewModel.selectedMetroIdx,
+                selectedCommercialArea: $viewModel.selectedArea,
+                onChangeSelectedCommercial: { area in
+                    viewModel.selectedArea = area
+                }
+            )
+        }
+        .task {
+            await viewModel.loadAreas()
+        }
+        .navigationBarBackButtonHidden()
+        .padding(.horizontal, 20)
+        .safeAreaInset(edge: .bottom, alignment: .center) {
+            if viewModel.selectedArea != nil {
+                PrimaryButton(title: "내 지역 선택하기") {
+                    if let selectedArea = viewModel.selectedArea {
+                        onSuccess?(selectedArea)
+                    }
                     dismiss()
                 }
-                .padding(.bottom, 8)
-                .padding(.horizontal, -20)
-                
-                AreaSelectionView(
-                    areas: viewModel.areas,
-                    onChangeSelectedCommercial: { area in
-                        viewModel.selectedArea = area
-                    }
-                )
+                .padding(.horizontal, 20)
             }
-            .navigationBarBackButtonHidden()
-            .padding(.horizontal, 20)
-            .safeAreaInset(edge: .bottom, alignment: .center) {
-                if viewModel.selectedArea != nil {
-                    PrimaryButton(title: "내 지역 선택하기") {
-                        if let selectedArea = viewModel.selectedArea {
-                            onSuccess?(selectedArea)
-                        }
-                        dismiss()
-                    }
-                    .padding(.horizontal, 20)
-                }
-            }
+            
         }
     }
 }
 
 
+@MainActor
 class MyRegionAreaSelectionViewModel: ObservableObject {
-    let areas: [MetroAreaResponse] = MetroAreaResponse.mockData
+    @Published var areas: [MetroArea] = []
+    @Published var selectedMetroIdx: Int = 0
     @Published var selectedArea: CommercialArea?
+    
+    private let areaRepository: AreaRepositoryInterface
+    
+    init(areaRepository: AreaRepositoryInterface) {
+        self.areaRepository = areaRepository
+    }
+    
+    func loadAreas() async {
+        let result = await areaRepository.getMetroAreas(forceRefresh: false)
+        switch result {
+        case .success(let res):
+            self.areas = res
+        case .failure:
+            Log("지역 조회 실패")
+        }
+    }
 }
 
+
 #Preview {
-    MyRegionAreaSelectionView()
+    MyRegionAreaSelectionView(areaRepository: AreaRepository(network: AreaNetwork()))
 }

--- a/ILSANG/Sources/Views/Home/BannerDetailView.swift
+++ b/ILSANG/Sources/Views/Home/BannerDetailView.swift
@@ -13,18 +13,8 @@ struct BannerDetailView: View {
     @State var viewModel: BannerDetailViewModel
     @Environment(\.dismiss) var dismiss
     
-    init(banner: BannerViewModelItem, shouldShowIllsangZoneWarning: Bool, currentSeason: Int, viewModel: BannerDetailViewModel? = nil) {
-        if let viewModel = viewModel {
-            self._viewModel = State(wrappedValue: viewModel)
-        } else {
-            self._viewModel = State(wrappedValue: BannerDetailViewModel(
-                banner: banner,
-                shouldShowIllsangZoneWarning: shouldShowIllsangZoneWarning,
-                currentSeason: currentSeason,
-                questNetwork: QuestNetwork(),
-                favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork())
-            ))
-        }
+    init(viewModel: BannerDetailViewModel) {
+        _viewModel = State(wrappedValue: viewModel)
     }
     
     var body: some View {
@@ -58,8 +48,8 @@ struct BannerDetailView: View {
             }
         )
         // TODO: navigation으로 변경
-        .fullScreenCover(isPresented: $viewModel.showSelectIllsangZoneView) {
-            IllsangZoneSelectionView { area in
+        .navigationDestination(isPresented: $viewModel.showSelectIllsangZoneView) {
+            IllsangZoneSelectionView(areaRepository: viewModel.areaRepository) { area in
                 viewModel.handleIllsangZoneSelection(area)
             }
         }
@@ -347,15 +337,15 @@ struct QuestSortHelper {
 
 #Preview {
     BannerDetailView(
-        banner: BannerViewModelItem.init(
-            id: 1,
-            title: "TITLE",
-            navigationTitle: "내비게이션타이틀",
-            imageId: "",
-            description: "description",
-            image: .img0
-        ),
-        shouldShowIllsangZoneWarning: true,
-        currentSeason: 1
+        viewModel: BannerDetailViewModel(
+            banner: .init(id: 0, title: "title", navigationTitle: "일상", imageId: "", description: "", image: .img0),
+            shouldShowIllsangZoneWarning: false,
+            currentSeason: 1,
+            questRepository: QuestRepository(network: QuestNetwork()),
+            areaRepository: AreaRepository(network: AreaNetwork()),
+            favoriteService: FavoriteService(
+                favoriteNetwork: FavoriteNetwork()
+            )
+        )
     )
 }

--- a/ILSANG/Sources/Views/Home/BannerDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Home/BannerDetailViewModel.swift
@@ -68,12 +68,21 @@ class BannerDetailViewModel {
         }
     }
     
-    private let questNetwork: QuestNetwork
+    private let questRepository: QuestRepositoryInterface
+    let areaRepository: AreaRepositoryInterface
     private let favoriteService: FavoriteService
     
-    init(banner: BannerViewModelItem, shouldShowIllsangZoneWarning: Bool, currentSeason: Int, questNetwork: QuestNetwork, favoriteService: FavoriteService) {
+    init(
+        banner: BannerViewModelItem,
+        shouldShowIllsangZoneWarning: Bool,
+        currentSeason: Int,
+        questRepository: QuestRepositoryInterface,
+        areaRepository: AreaRepositoryInterface,
+        favoriteService: FavoriteService
+    ) {
         self.banner = banner
-        self.questNetwork = questNetwork
+        self.questRepository = questRepository
+        self.areaRepository = areaRepository
         self.favoriteService = favoriteService
         
         eventFilterState = FilterPickerState(initialValue: BannerEventQuestFilterType.popular)

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -85,15 +85,24 @@ struct HomeView: View {
                 .interactiveDismissDisabled()
         }
         .navigationDestination(item: $vm.selectedBanner) { banner in
-            BannerDetailView(banner: banner, shouldShowIllsangZoneWarning: vm.shouldShowIllsangZoneWarning, currentSeason: vm.currentSeason)
+            BannerDetailView(
+                viewModel: BannerDetailViewModel(
+                    banner: banner,
+                    shouldShowIllsangZoneWarning: vm.shouldShowIllsangZoneWarning,
+                    currentSeason: vm.currentSeason,
+                    questRepository: vm.questRepository,
+                    areaRepository: vm.areaRepository,
+                    favoriteService: vm.favoriteService
+                )
+            )
         }
         .navigationDestination(isPresented: $vm.showSelectMyRegionView) {
-            MyRegionAreaSelectionView { area in
+            MyRegionAreaSelectionView(areaRepository: vm.areaRepository) { area in
                 vm.handleMyRegionSelection(area)
             }
         }
         .navigationDestination(isPresented: $vm.showSelectIllsangZoneView) {
-            IllsangZoneSelectionView { area in
+            IllsangZoneSelectionView(areaRepository: vm.areaRepository) { area in
                 vm.handleIllsangZoneSelection(area)
             }
         }
@@ -453,6 +462,7 @@ struct HomeView: View {
         questRepository: QuestRepository(network: QuestNetwork()),
         rankRepository: RankRepository(network: RankNetwork()),
         bannerRepository: BannerRepository(network: BannerNetwork()),
+        areaRepository: AreaRepository(network: AreaNetwork()),
         favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: SharedState()
     )
     HomeView(vm: viewModel)

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -89,18 +89,27 @@ final class HomeViewModel {
     var showPopularRewardQuest: Bool = true
     var showRankList = true
     
-    private let questRepository: QuestRepositoryInterface
+    let questRepository: QuestRepositoryInterface
     private let rankRepository: RankRepositoryInterface
     private let bannerRepository: BannerRepositoryInterface
-    private let favoriteService: FavoriteService
+    let areaRepository: AreaRepositoryInterface
+    let favoriteService: FavoriteService
     private let sharedState: SharedState
     
     private var cancellables = Set<AnyCancellable>()
     
-    init(questRepository: QuestRepositoryInterface, rankRepository: RankRepositoryInterface, bannerRepository: BannerRepositoryInterface, favoriteService: FavoriteService, sharedState: SharedState) {
+    init(
+        questRepository: QuestRepositoryInterface,
+        rankRepository: RankRepositoryInterface,
+        bannerRepository: BannerRepositoryInterface,
+        areaRepository: AreaRepositoryInterface,
+        favoriteService: FavoriteService,
+        sharedState: SharedState
+    ) {
         self.questRepository = questRepository
         self.rankRepository = rankRepository
         self.bannerRepository = bannerRepository
+        self.areaRepository = areaRepository
         self.favoriteService = favoriteService
         self.sharedState = sharedState
         

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -70,7 +70,7 @@ struct QuestView: View {
                 .interactiveDismissDisabled()
         }
         .navigationDestination(isPresented: $vm.showSelectMyRegionView) {
-            MyRegionAreaSelectionView { area in
+            MyRegionAreaSelectionView(areaRepository: vm.areaRepository) { area in
                 vm.handleMyRegionSelection(area)
             }
         }
@@ -271,7 +271,7 @@ extension QuestView {
 
 #Preview {
     QuestView(vm: QuestViewModel(
-        questRepository: MockQuestRepository(),
+        questRepository: MockQuestRepository(), areaRepository: AreaRepository(network: AreaNetwork()),
         favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: SharedState()
     ))
 }

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -119,12 +119,14 @@ class QuestViewModel: ObservableObject {
     var lastRefreshTime: Date? = nil
     
     private let questRepository: QuestRepositoryInterface
+    let areaRepository: AreaRepositoryInterface
     private let favoriteService: FavoriteService
     let sharedState: SharedState
     private var cancellables = Set<AnyCancellable>()
 
-    init(questRepository: QuestRepositoryInterface, favoriteService: FavoriteService, sharedState: SharedState) {
+    init(questRepository: QuestRepositoryInterface, areaRepository: AreaRepositoryInterface, favoriteService: FavoriteService, sharedState: SharedState) {
         self.questRepository = questRepository
+        self.areaRepository = areaRepository
         self.favoriteService = favoriteService
         
         // 필터 설정

--- a/ILSANG/Sources/Views/Router/MainTabView.swift
+++ b/ILSANG/Sources/Views/Router/MainTabView.swift
@@ -31,12 +31,14 @@ struct MainTabView: View {
         let seasonManager = SeasonManager(seasonNetwork: MainTabView.defaultSeasonNetwork)
         _seasonManager = StateObject(wrappedValue: seasonManager)
         
-        let rankRespository = RankRepository(network: RankNetwork())
+        let rankRepository = RankRepository(network: RankNetwork())
+        let areaRepository = AreaRepository(network: AreaNetwork())
         
         self.homeViewModel = HomeViewModel(
             questRepository: QuestRepository(network: QuestNetwork()),
-            rankRepository: rankRespository,
+            rankRepository: rankRepository,
             bannerRepository: BannerRepository(network: BannerNetwork()),
+            areaRepository: areaRepository,
             favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
             sharedState: sharedState
         )
@@ -44,19 +46,21 @@ struct MainTabView: View {
 #if DEBUG
            self._questViewModel = StateObject(wrappedValue: QuestViewModel(
             questRepository: MockQuestRepository(),
+            areaRepository: areaRepository,
             favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: sharedState)
            )
            
 #else
            self._questViewModel = StateObject(wrappedValue: QuestViewModel(
             questRepository: QuestRepository(network: QuestNetwork()),
+            areaRepository: areaRepository,
             favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: sharedState)
            )
 #endif
         self._rankViewModel = StateObject(
             wrappedValue:
                 RankingViewModel(
-                    rankRepository: rankRespository,
+                    rankRepository: rankRepository,
                     seasonManager: seasonManager
                 )
         )
@@ -119,7 +123,7 @@ class SharedState: ObservableObject {
     
     init() {
         self.selectedCommercialArea = UserDefaults.standard.loadCommercialArea()
-        ?? CommercialArea(code: "R100", areaName: "서현", description: "", metroAreaCode: "G01")
+        ?? CommercialArea(code: "R100", areaName: "서현", metroAreaCode: "G01")
     }
 }
 


### PR DESCRIPTION
#### relate #396 

### ✏️ 개요
인증 화면과 마이 화면에서 지역명을 매핑하기 위해 지역 정보를 캐시 처리합니다.

### 💻 작업 사항
- 광역지역조회 API 호출 이후 캐시처리
- AreaRepository 추가