### PR TITLE
[Fix/#404] 인기 퀘스트 반복 타입 초기화 누락 수정

### DIFF
--- a/ILSANG/Sources/Domain/Enum/RepeatType.swift
+++ b/ILSANG/Sources/Domain/Enum/RepeatType.swift
@@ -13,7 +13,6 @@ enum RepeatType: String, Hashable, CustomStringConvertible, CaseIterable {
     case monthly
     
     init?(param: String) {
-        print(param)
         self.init(rawValue: param.lowercased())
     }
     

--- a/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
@@ -17,7 +17,7 @@ extension PopularQuestResponse: DomainConvertible {
             title: title,
             writer: writerName,
             questType: QuestType(rawValue: questType),
-            repeatFrequency: self.repeatFrequency.flatMap { RepeatType(rawValue: $0) },
+            repeatFrequency: repeatFrequency.flatMap { RepeatType(param: $0) },
             rewards: nil,
             missions: [],
             expireDate: date,


### PR DESCRIPTION
#### close #404 

### ✏️ 개요
인기퀘스트의 반복 타입 초기화 실패 문제를 해결합니다.

### 💻 작업 사항
- 인기퀘스트 반복타입 초기화 재설정

### 📱결과 화면(optional)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b13ab380-ef55-489b-b7fa-e0f757845055" />
