### PR TITLE
[Ref/#409] 프로필 이미지 삭제 API 재연결

### DIFF
--- a/ILSANG/Sources/Network/UserNetwork.swift
+++ b/ILSANG/Sources/Network/UserNetwork.swift
@@ -96,8 +96,9 @@ final class UserNetwork {
     
     /// 서버에서 프로필 이미지 연결 해제 & 이미지 삭제 처리
     func deleteUserImage() async -> Bool {
-        let res: Result<ResponseWithoutData, Error> = await Network.requestData(url: url+"/profile/image", method: .delete, parameters: nil, withToken: true)
-        
+        let body = ["imageId": nil] as [String : Any?]
+        let bodyData = body.convertToJsonData()
+        let res: Result<ResponseWithoutData, Error> = await Network.requestData(url: url+"/profile/image", method: .put, body: bodyData)
         switch res {
         case.success:
             return true


### PR DESCRIPTION
#### close #409 

### ✏️ 개요
API 스펙 변경에 따라 프로필 이미지 삭제 API를 재연결합니다.

### 💻 작업 사항
프로필 이미지 삭제 API 재연결