### PR TITLE
[Fix/#415] 시즌 팝업 TabView 노출시 중복 문제 해결

### DIFF
--- a/ILSANG/Sources/Global/View/SeasonPopupContainerView.swift
+++ b/ILSANG/Sources/Global/View/SeasonPopupContainerView.swift
@@ -9,13 +9,20 @@ import SwiftUI
 
 struct SeasonPopupContainerView: View {
     @EnvironmentObject private var manager: SeasonManager
-    @State private var isPresented = false
+    @State private var isPresented: Bool? = nil
     
     var onTapShowRank: () -> Void
     
     var body: some View {
-        if manager.shouldShowPopup, let currentSeason = manager.currentSeason {
-            AnimatedPopup(isPresented: $isPresented) {
+        let showPopup = isPresented ?? manager.shouldShowPopup
+        
+        if showPopup, let currentSeason = manager.currentSeason {
+            AnimatedPopup(isPresented: Binding(
+                get: { self.isPresented ?? true },
+                set: { newValue in
+                    self.isPresented = false
+                }
+            )) {
                 SeasonOpenPopup(
                     season: currentSeason.seasonNumber,
                     seasonStartDate: currentSeason.startDate,
@@ -27,6 +34,7 @@ struct SeasonPopupContainerView: View {
                             }
                             isPresented = false
                         }
+                        self.isPresented = false
                     }) { neverShow in
                         withAnimation {
                             if neverShow {
@@ -34,11 +42,14 @@ struct SeasonPopupContainerView: View {
                             }
                             isPresented = false
                         }
+                        self.isPresented = false
                         onTapShowRank()
                     }
             }
             .onAppear {
-                isPresented = true
+                if isPresented == nil {
+                    isPresented = true
+                }
             }
         }
     }


### PR DESCRIPTION
#### close #415 

### ✏️ 개요
앱 실행 시 시즌 팝업이 탭 전환마다 반복 노출되는 문제 수정

### 💻 작업 사항
- 시즌 팝업(SeasonPopupContainerView)이 TabView 전환 시마다 다시 나타나는 현상 수정
- 팝업 노출 여부를 Bool? 로 관리하여 앱 최초 실행 시 한 번만 표시되도록 로직 개선
- manager.shouldShowPopup와 isPresented 상태를 조합하여 중복 표시 방지
