### PR TITLE
[Feat/#410] String Extension의 toISO8601Date 메서드에 KST 반영, 인증/랭킹화면 적용

### DIFF
--- a/ILSANG/Sources/Extension/String++.swift
+++ b/ILSANG/Sources/Extension/String++.swift
@@ -9,12 +9,14 @@ import Foundation
 
 extension String {
     /// 다양한 ISO8601 포맷을 시도하여 Date로 변환
-    func toISO8601Date() -> Date? {
+    func toISO8601Date(applyKST: Bool = true) -> Date? {
         // 소수점(밀리초) 제거
         let trimmed = self.components(separatedBy: ".").first ?? self
         
         let formatter = ISO8601DateFormatter()
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        if applyKST {
+            formatter.timeZone = TimeZone(identifier: "Asia/Seoul") // KST 반영
+        }
         
         // 시도할 포맷 옵션 목록
         let formats: [ISO8601DateFormatter.Options] = [

--- a/ILSANG/Sources/Global/Mapper/MIssionHistory+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/MIssionHistory+UIMapper.swift
@@ -39,8 +39,6 @@ extension Date {
     
     func toDisplayFormat(_ format: DisplayFormat = .full) -> String {
         let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         formatter.dateFormat = format.rawValue
         return formatter.string(from: self)
     }

--- a/ILSANG/Sources/Views/Ranking/RankingDetailView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingDetailView.swift
@@ -61,8 +61,9 @@ struct RankingDetailView: View {
             .padding(.top, 8)
         }
         .overlay(alignment: .bottom) {
-            if let currentSeason = seasonManager.currentSeason {
-                SeasonTimerView(season: currentSeason.seasonNumber, targetDateString: currentSeason.endDate.formatDateOnly())
+            if let currentSeason = seasonManager.currentSeason,
+            let targetDate = currentSeason.endDate.toISO8601Date() {
+                SeasonTimerView(season: currentSeason.seasonNumber, targetDate: targetDate)
                     .padding(.horizontal, 20)
                     .padding(.bottom, 20)
             }

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -55,8 +55,9 @@ struct RankingView: View {
             }
         }
         .overlay(alignment: .bottom) {
-            if let currentSeason = seasonManager.currentSeason {
-                SeasonTimerView(season: currentSeason.seasonNumber, targetDateString: currentSeason.endDate.formatDateOnly())
+            if let currentSeason = seasonManager.currentSeason,
+            let targetDate = currentSeason.endDate.toISO8601Date() {
+                SeasonTimerView(season: currentSeason.seasonNumber, targetDate: targetDate)
                     .padding(.horizontal, 20)
                     .padding(.bottom, 20)
             }
@@ -312,7 +313,7 @@ extension RankingView {
                         areaPoint: rank.point,
                         areaImageIds: rank.imageIds,
                         areaCode: rank.areaCode,
-                        areaType: .commercial,
+                        areaType: .metro,
                         rankRepository: vm.rankRepository,
                         areaNameService: vm.areaNameService
                     )

--- a/ILSANG/Sources/Views/Ranking/SeasonTimerView.swift
+++ b/ILSANG/Sources/Views/Ranking/SeasonTimerView.swift
@@ -15,15 +15,6 @@ struct SeasonTimerView: View {
     @State private var now: Date = Date()
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     
-    init(season: Int, targetDateString: String) {
-        self.season = season
-        
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
-        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        self.targetDate = formatter.date(from: targetDateString) ?? Date()
-    }
-    
     var body: some View {
         VStack(spacing: 6) {
             Text("시즌\(season) 종료까지")
@@ -55,5 +46,5 @@ struct SeasonTimerView: View {
 }
 
 #Preview {
-    SeasonTimerView(season: 2, targetDateString: "2025-09-01")
+    SeasonTimerView(season: 2, targetDate: .now)
 }


### PR DESCRIPTION
#### close #410

### ✏️ 개요
String Extension의 toISO8601Date 메서드를 KST 반영해서 Date로 초기화하도록 개선합니다.
시즌 마감 타이머에 종료 시간을 포함해서 계산해도록 수정합니다.

### 💻 작업 사항
랭킹 타이머 화면, 인증 화면 반영