### PR TITLE
[Feat/#424] 홈, 퀘스트, 랭킹 화면: 디테일 수정

### DIFF
--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -29,7 +29,7 @@ final class HomeViewModel {
     var userRankList: [UserRankViewModelItem] = [] // 10개
     var largestRewardQuestList: [QuestViewModelItem] = [] // 3*5개
     var recommendQuestList: [QuestViewModelItem] = [] //QuestViewModelItem.mockQuestList // 10개
-    var popularQuestList: [QuestViewModelItem] = [QuestViewModelItem.mockData] // 4n개
+    var popularQuestList: [QuestViewModelItem] = [] // 4n개
     
     var currentBanner: Int = 0
     
@@ -327,8 +327,13 @@ final class HomeViewModel {
             }
             
             for await (index, image) in group {
-                if let image = image {
-                    quests[index].image = image
+                if let image {
+                    if getWriterImage {
+                        quests[index].image = image
+                    }
+                    if getMainImage {
+                        quests[index].mainImage = image
+                    }
                 }
             }
         }
@@ -371,6 +376,9 @@ final class HomeViewModel {
             let questDetail = try await questRepository.getQuestDetail(questId: quest.id)
                 .get()
                 .toQuestItem()
+            if let imageId = questDetail.imageId {
+                questDetail.image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+            }
             self.selectedQuest = questDetail
         }
         

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -234,7 +234,7 @@ struct PopularQuestItemView: View {
     var body: some View {
         Button(action: { action() }) {
             VStack(alignment: .leading, spacing: 0) {
-                Image(uiImage: quest.image ?? .logo)
+                Image(uiImage: quest.mainImage ?? .logo)
                     .resizable()
                     .scaledToFill()
                     .frame(width: imageSize.width, height: imageSize.height)

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -369,7 +369,13 @@ class QuestViewModel: ObservableObject {
             let questDetail = try await questRepository.getQuestDetail(questId: quest.id)
                 .get()
                 .toQuestItem()
-            self.selectedQuest = questDetail
+            
+            if let imageId = questDetail.imageId {
+                questDetail.image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+            }
+            await MainActor.run {
+                self.selectedQuest = questDetail
+            }
         }
         
         DispatchQueue.main.asyncAfter(deadline: .now()+0.3) {

--- a/ILSANG/Sources/Views/Ranking/RankingDetailView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingDetailView.swift
@@ -92,14 +92,24 @@ struct RankingDetailView: View {
     private var imageListView: some View {
         let height: CGFloat = 150
         return VStack(spacing: 0) {
-            TabView(selection: $vm.imageIdx) {
-                ForEach(Array(vm.imageList.enumerated()), id: \.offset) { idx, image in
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
+            Group {
+                if vm.imageList.isEmpty {
+                    Text("아직 사진이\n등록되지 않았어요")
+                        .styledFont(.heading3)
+                        .foregroundStyle(.gray200)
+                        .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity)
-                        .frame(height: height)
-                        .tag(idx)
+                } else {
+                    TabView(selection: $vm.imageIdx) {
+                        ForEach(Array(vm.imageList.enumerated()), id: \.offset) { idx, image in
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(maxWidth: .infinity)
+                                .frame(height: height)
+                                .tag(idx)
+                        }
+                    }
                 }
             }
             .frame(height: height)

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -29,7 +29,8 @@ struct RankingView: View {
                             switch vm.viewStatus {
                             case .loading:
                                 ProgressView()
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                    .frame(height: 300)
+                                    .frame(maxWidth: .infinity)
                             case .loaded:
                                 rankingListView
                             case .error:


### PR DESCRIPTION
#### close #424

### ✏️ 개요
홈, 퀘스트, 랭킹 화면의 디테일한 부분을 수정합니다.

### 💻 작업 사항
- 홈 화면: 인기퀘스트 목데이터 제거
- 홈 화면: 인기퀘스트 메인이미지로 연결
- 퀘스트 상세 화면: 이미지 조회
- 랭킹 화면: ProgressView 프레임 높이 수정
- 랭킹 상세 화면: 이미지 리스트 빈 화면 적용