### PR TITLE
[Feat/#428] 랭킹 상세 화면: PointGap 필드 연결

### DIFF
--- a/ILSANG/Sources/Domain/Entity/Rank/UserRank.swift
+++ b/ILSANG/Sources/Domain/Entity/Rank/UserRank.swift
@@ -13,4 +13,5 @@ struct UserRank {
     let point: Int
     let rank: Int
     let title: TitleResponse?
+    let pointGap: Int?
 }

--- a/ILSANG/Sources/Domain/Mapper/Rank/UserRankResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/Rank/UserRankResponse+Mapping.swift
@@ -14,7 +14,8 @@ extension UserRankResponse: DomainConvertible {
             nickname: nickname,
             point: point ?? 0,
             rank: rank ?? 0,
-            title: title
+            title: title,
+            pointGap: pointGap
         )
     }
     

--- a/ILSANG/Sources/Global/Mapper/Rank+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/Rank+UIMapper.swift
@@ -14,7 +14,8 @@ extension UserRank {
             nickname: nickname,
             point: point,
             rank: rank,
-            title: title
+            title: title,
+            pointGap: pointGap
         )
     }
 }

--- a/ILSANG/Sources/Network/Response/Rank/UserRankResponse.swift
+++ b/ILSANG/Sources/Network/Response/Rank/UserRankResponse.swift
@@ -13,7 +13,8 @@ struct UserRankResponse: Decodable {
     let point: Int?
     let rank: Int?
     let title: TitleResponse?
-    
+    let pointGap: Int?
+
     enum CodingKeys: String, CodingKey {
         case userId
         case profileImageId
@@ -21,5 +22,6 @@ struct UserRankResponse: Decodable {
         case point
         case rank
         case title
+        case pointGap
     }
 }

--- a/ILSANG/Sources/Views/Ranking/RankingItemView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingItemView.swift
@@ -111,7 +111,6 @@ fileprivate struct AreaRankItemView: View {
 
 fileprivate struct CurrentUserRankItemView: View {
     @ObservedObject var rank: UserRankViewModelItem
-    let remainPoint: Int? = nil // TODO: API 추가 요청
     
     var body: some View {
         VStack(spacing: 10) {
@@ -152,7 +151,7 @@ fileprivate struct CurrentUserRankItemView: View {
                 Spacer(minLength: 0)
             }
             
-            if let remainPoint {
+            if let remainPoint = rank.pointGap {
                 Text("앞으로 \(remainPoint)P 획득 시 다음 순위로 올라갈 수 있어요!")
                     .styledFont(.badge1)
                     .foregroundColor(.primaryPurple)

--- a/ILSANG/Sources/Views/Ranking/UserRankViewModelItem.swift
+++ b/ILSANG/Sources/Views/Ranking/UserRankViewModelItem.swift
@@ -15,8 +15,9 @@ class UserRankViewModelItem: ObservableObject {
     let point: Int
     let rank: Int
     let title: TitleResponse?
+    let pointGap: Int?
     
-    init(userId: String, profileImageId: String?, profileImage: UIImage?, nickname: String, point: Int, rank: Int, title: TitleResponse?) {
+    init(userId: String, profileImageId: String?, profileImage: UIImage?, nickname: String, point: Int, rank: Int, title: TitleResponse?, pointGap: Int?) {
         self.userId = userId
         self.profileImageId = profileImageId
         self.profileImage = profileImage
@@ -24,6 +25,7 @@ class UserRankViewModelItem: ObservableObject {
         self.point = point
         self.rank = rank
         self.title = title
+        self.pointGap = pointGap
     }
     
 //    func loadImage() {
@@ -39,7 +41,7 @@ class UserRankViewModelItem: ObservableObject {
 }
 
 extension UserRankViewModelItem {
-    static let mockData1 = UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "일상", point: 100000, rank: 1, title: .init(id: "", name: "칭호", grade: "LEGEND", type: "METRO"))
-    static let mockData100 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: nil, nickname: "김일상", point: 100, rank: 100, title: .init(id: "", name: "칭호", grade: "LEGEND", type: "METRO"))
-    static let mockData1000 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "김일상", point: 1000, rank: 1000, title: .init(id: "", name: "칭호", grade: "STANDARD", type: "METRO"))
+    static let mockData1 = UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "일상", point: 100000, rank: 1, title: .init(id: "", name: "칭호", grade: "LEGEND", type: "METRO"), pointGap: nil)
+    static let mockData100 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: nil, nickname: "김일상", point: 100, rank: 100, title: .init(id: "", name: "칭호", grade: "LEGEND", type: "METRO"), pointGap: 10)
+    static let mockData1000 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "김일상", point: 1000, rank: 1000, title: .init(id: "", name: "칭호", grade: "STANDARD", type: "METRO"), pointGap: nil)
 }


### PR DESCRIPTION
#### close #428 

### ✏️ 개요
랭킹 상세화면에 다음 랭킹까지의 순위 포인트를 표시하기위해, API응답 및 매핑 부분을 수정합니다.

### 💻 작업 사항
- 랭킹 상세 화면: PointGap 필드 연결

### 📱결과 화면(optional)
<img width="393" alt="image" src="https://github.com/user-attachments/assets/43bcd8db-877f-4ced-8fd0-16246326839b" />
