### PR TITLE
[Feat/#363] 퀘스트, 유저 라우터 추가

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -118,6 +118,12 @@
 		606C3ED72E61ACCF0050C4D6 /* PointSummaryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3ED62E61ACCF0050C4D6 /* PointSummaryItem.swift */; };
 		606C3ED92E61ADD50050C4D6 /* Point+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3ED82E61ADD50050C4D6 /* Point+UIMapper.swift */; };
 		606C3EDD2E65D9640050C4D6 /* AppDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3EDC2E65D9640050C4D6 /* AppDependencies.swift */; };
+		606C3EE12E662E3E0050C4D6 /* IllsangZoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3EE02E662E3E0050C4D6 /* IllsangZoneManager.swift */; };
+		606C3EE32E674AF50050C4D6 /* IllsangZoneAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3EE22E674AF50050C4D6 /* IllsangZoneAlertView.swift */; };
+		606C3EE52E674B360050C4D6 /* UserRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3EE42E674B360050C4D6 /* UserRouter.swift */; };
+		606C3EE72E674B470050C4D6 /* QuestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3EE62E674B460050C4D6 /* QuestRouter.swift */; };
+		606C3EE92E674B530050C4D6 /* UserNavigationSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3EE82E674B530050C4D6 /* UserNavigationSetup.swift */; };
+		606C3EED2E674B7B0050C4D6 /* QuestNavigationSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C3EEC2E674B7B0050C4D6 /* QuestNavigationSetup.swift */; };
 		606C87AF2C0B9B8C002D5C3E /* ApprovalItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C87AE2C0B9B8C002D5C3E /* ApprovalItemView.swift */; };
 		606C87B12C0CC89B002D5C3E /* 2406_TERMS_OF_USE.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 606C87B02C0CC89B002D5C3E /* 2406_TERMS_OF_USE.pdf */; };
 		606F18152DA3E1F800ABEA84 /* FavoriteNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606F18142DA3E1F800ABEA84 /* FavoriteNetwork.swift */; };
@@ -418,6 +424,12 @@
 		606C3ED62E61ACCF0050C4D6 /* PointSummaryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointSummaryItem.swift; sourceTree = "<group>"; };
 		606C3ED82E61ADD50050C4D6 /* Point+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Point+UIMapper.swift"; sourceTree = "<group>"; };
 		606C3EDC2E65D9640050C4D6 /* AppDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDependencies.swift; sourceTree = "<group>"; };
+		606C3EE02E662E3E0050C4D6 /* IllsangZoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IllsangZoneManager.swift; sourceTree = "<group>"; };
+		606C3EE22E674AF50050C4D6 /* IllsangZoneAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IllsangZoneAlertView.swift; sourceTree = "<group>"; };
+		606C3EE42E674B360050C4D6 /* UserRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRouter.swift; sourceTree = "<group>"; };
+		606C3EE62E674B460050C4D6 /* QuestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestRouter.swift; sourceTree = "<group>"; };
+		606C3EE82E674B530050C4D6 /* UserNavigationSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNavigationSetup.swift; sourceTree = "<group>"; };
+		606C3EEC2E674B7B0050C4D6 /* QuestNavigationSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestNavigationSetup.swift; sourceTree = "<group>"; };
 		606C87AE2C0B9B8C002D5C3E /* ApprovalItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalItemView.swift; sourceTree = "<group>"; };
 		606C87B02C0CC89B002D5C3E /* 2406_TERMS_OF_USE.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = 2406_TERMS_OF_USE.pdf; sourceTree = "<group>"; };
 		606F18142DA3E1F800ABEA84 /* FavoriteNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteNetwork.swift; sourceTree = "<group>"; };
@@ -674,6 +686,7 @@
 				600D83A32C7B1FA4005C93E2 /* PaginationManager.swift */,
 				6053345B2D31182500599159 /* XpLevelCalculator.swift */,
 				609197582E5C950B00F1D81B /* SeasonManager.swift */,
+				606C3EE02E662E3E0050C4D6 /* IllsangZoneManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -921,11 +934,31 @@
 			path = User;
 			sourceTree = "<group>";
 		};
+		606C3EEE2E674B940050C4D6 /* Quest */ = {
+			isa = PBXGroup;
+			children = (
+				606C3EE62E674B460050C4D6 /* QuestRouter.swift */,
+				606C3EEC2E674B7B0050C4D6 /* QuestNavigationSetup.swift */,
+			);
+			path = Quest;
+			sourceTree = "<group>";
+		};
+		606C3EEF2E674BA10050C4D6 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				606C3EE42E674B360050C4D6 /* UserRouter.swift */,
+				606C3EE82E674B530050C4D6 /* UserNavigationSetup.swift */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
 		607FCBD22BFA645100BB2D04 /* Router */ = {
 			isa = PBXGroup;
 			children = (
 				607FCBD32BFA648000BB2D04 /* Tab.swift */,
 				606C3EDC2E65D9640050C4D6 /* AppDependencies.swift */,
+				606C3EEE2E674B940050C4D6 /* Quest */,
+				606C3EEF2E674BA10050C4D6 /* User */,
 				607FCBD52BFA660C00BB2D04 /* MainTabView.swift */,
 			);
 			path = Router;
@@ -1374,6 +1407,7 @@
 				604687A92D1FDA090056E394 /* CarouselAutoSlideView.swift */,
 				60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */,
 				60054F9F2D931AA300E7C5A6 /* PDFKitView.swift */,
+				606C3EE22E674AF50050C4D6 /* IllsangZoneAlertView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1620,6 +1654,7 @@
 				A142E0312C2D9F37004395F8 /* SettingAlertView.swift in Sources */,
 				601BCF392D7EE63100138387 /* CustomImagePicker.swift in Sources */,
 				606C3EB62E60A57C0050C4D6 /* UserMissionHistoryViewModel.swift in Sources */,
+				606C3EE92E674B530050C4D6 /* UserNavigationSetup.swift in Sources */,
 				603CF4F32D79A8CE00A2D19E /* SubmitInprogressView.swift in Sources */,
 				609197592E5C957700F1D81B /* SeasonManager.swift in Sources */,
 				6091976F2E5F8EC500F1D81B /* UserMissionHistoryResponse.swift in Sources */,
@@ -1707,6 +1742,7 @@
 				609197632E5DEC0F00F1D81B /* Banner+UIMapper.swift in Sources */,
 				6091974F2E5C292F00F1D81B /* AreaRankViewModelItem.swift in Sources */,
 				60D897202E5372BE006A8480 /* MissionHistoryResponse+Mapping.swift in Sources */,
+				606C3EE52E674B360050C4D6 /* UserRouter.swift in Sources */,
 				607FCBE42BFD124900BB2D04 /* QuestItemView.swift in Sources */,
 				605E81442D9FE56000ECDB15 /* QuestDetailTitleView.swift in Sources */,
 				60FF5EC32E4937A6007A5B40 /* MyRegionAreaSelectionView.swift in Sources */,
@@ -1720,6 +1756,7 @@
 				A18EB9B02C26B61C00405D56 /* WithdrawNetwork.swift in Sources */,
 				603CF4EF2D79A83600A2D19E /* SubmitStatus.swift in Sources */,
 				609197262E59EC5F00F1D81B /* MissionResponse+Mapping.swift in Sources */,
+				606C3EE12E662E3E0050C4D6 /* IllsangZoneManager.swift in Sources */,
 				60FF5ECB2E4BB4A6007A5B40 /* SeasonNetwork.swift in Sources */,
 				609197752E5F8FF900F1D81B /* UserMissionHistory+UIMapper.swift in Sources */,
 				60246FA82D91E57E007C05B3 /* AnalyticsService.swift in Sources */,
@@ -1750,6 +1787,7 @@
 				609197772E5FA6ED00F1D81B /* IllsangZonePointView.swift in Sources */,
 				6091971C2E59EAB800F1D81B /* QuestDetailResponse+Mapping.swift in Sources */,
 				609197402E5C26D800F1D81B /* MetroAreaRankResponse.swift in Sources */,
+				606C3EED2E674B7B0050C4D6 /* QuestNavigationSetup.swift in Sources */,
 				608EBF9F2C39C17F00B862CC /* Dictionary++.swift in Sources */,
 				60FF5EC92E4BA59E007A5B40 /* SeasonPopupContainerView.swift in Sources */,
 				60D897512E577E96006A8480 /* TrailingStarView.swift in Sources */,
@@ -1784,6 +1822,7 @@
 				605E814A2D9FEB2300ECDB15 /* QuestDetailStatView.swift in Sources */,
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,
 				6091973E2E5C26C000F1D81B /* MetroAreaResponse+Mapping.swift in Sources */,
+				606C3EE32E674AF50050C4D6 /* IllsangZoneAlertView.swift in Sources */,
 				609197672E5E069600F1D81B /* Area.swift in Sources */,
 				60ADF9C22D59D47100556958 /* FontWithLineHeight.swift in Sources */,
 				606292D82C19E70A0098B6D2 /* Network.swift in Sources */,
@@ -1813,6 +1852,7 @@
 				60ADF8872D57B49B00556958 /* QuestEngageView.swift in Sources */,
 				609169E22E01500900A34D4F /* TokenManager.swift in Sources */,
 				605DA0CD2C070A0300CC9450 /* Camera.swift in Sources */,
+				606C3EE72E674B470050C4D6 /* QuestRouter.swift in Sources */,
 				600211EE2C1EEF91000CC02E /* EmojiNetwork.swift in Sources */,
 				600657E42DBD2DF50022D117 /* MyPageHonorManageView.swift in Sources */,
 				601189212C3E94A60070F2AD /* AuthService.swift in Sources */,
@@ -1985,7 +2025,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2196,7 +2236,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = com.ilsang240615.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2243,7 +2283,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/ILSANG/Sources/Global/View/IllsangZoneAlertView.swift
+++ b/ILSANG/Sources/Global/View/IllsangZoneAlertView.swift
@@ -1,0 +1,52 @@
+//
+//  IllsangZoneAlertView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/3/25.
+//
+
+
+import SwiftUI
+
+struct IllsangZoneAlertView: View {
+    let alertType: IllsangZoneAlertType
+    @Binding var isNeverShowSelected: Bool
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+    
+    var body: some View {
+        SettingAlertView(
+            alertType: alertType,
+            onCancel: alertType == .illsangZoneNotSelected ? onCancel : nil,
+            onConfirm: onConfirm
+        ) {
+            if alertType == .illsangZoneNotSelected {
+                Button {
+                    isNeverShowSelected.toggle()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(.checkThin)
+                            .renderingMode(.template)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 9, height: 5.5)
+                            .frame(16)
+                            .foregroundStyle(isNeverShowSelected ? .white : .clear)
+                            .background(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .strokeBorder(
+                                        isNeverShowSelected ? .clear : .gray200,
+                                        style: StrokeStyle(lineWidth: 1)
+                                    )
+                                    .fill(isNeverShowSelected ? .primaryPurple : .clear)
+                            )
+                            .frame(24)
+                        Text("다시 보지 않기")
+                            .styledFont(.tabRegular)
+                            .foregroundStyle(.gray500)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ILSANG/Sources/Global/View/SeasonPopupContainerView.swift
+++ b/ILSANG/Sources/Global/View/SeasonPopupContainerView.swift
@@ -8,15 +8,15 @@
 import SwiftUI
 
 struct SeasonPopupContainerView: View {
-    @EnvironmentObject private var manager: SeasonManager
+    @EnvironmentObject var dependencies: AppDependencies
     @State private var isPresented: Bool? = nil
     
     var onTapShowRank: () -> Void
     
     var body: some View {
-        let showPopup = isPresented ?? manager.shouldShowPopup
+        let showPopup = isPresented ?? dependencies.seasonManager.shouldShowPopup
         
-        if showPopup, let currentSeason = manager.currentSeason {
+        if showPopup, let currentSeason = dependencies.seasonManager.currentSeason {
             AnimatedPopup(isPresented: Binding(
                 get: { self.isPresented ?? true },
                 set: { newValue in
@@ -30,7 +30,7 @@ struct SeasonPopupContainerView: View {
                     onDismiss: { neverShow in
                         withAnimation {
                             if neverShow {
-                                manager.hidePopupForCurrentSeason()
+                                dependencies.seasonManager.hidePopupForCurrentSeason()
                             }
                             isPresented = false
                         }
@@ -38,7 +38,7 @@ struct SeasonPopupContainerView: View {
                     }) { neverShow in
                         withAnimation {
                             if neverShow {
-                                manager.hidePopupForCurrentSeason()
+                                dependencies.seasonManager.hidePopupForCurrentSeason()
                             }
                             isPresented = false
                         }

--- a/ILSANG/Sources/Manager/IllsangZoneManager.swift
+++ b/ILSANG/Sources/Manager/IllsangZoneManager.swift
@@ -1,0 +1,81 @@
+//
+//  IllsangZoneManager.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/2/25.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+class IllsangZoneManager: ObservableObject {
+    @Published var currentZoneCode: String?
+    @Published var currentZoneName: String?
+    @Published var shouldShowWarning: Bool = false
+    
+    @Published var currentSeason: Season?
+    private let dontShowKey = "DontShowIllsangZoneWarning"
+    private let seasonKey = "IllsangZoneSeason"
+    
+    private let areaNameService: AreaNameProvider
+    private var cancellables = Set<AnyCancellable>() // 구독 저장
+
+    init(areaNameService: AreaNameProvider, seasonManager: SeasonManager) {
+        self.areaNameService = areaNameService
+        
+        // 시즌 변경 시 currentSeason 업데이트
+        seasonManager.$currentSeason
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newSeason in
+                self?.currentSeason = newSeason
+                self?.updateWarningStatus()
+            }
+            .store(in: &cancellables)
+        
+        loadCurrentZone()
+//        updateWarningStatus()
+    }
+    
+    func loadCurrentZone() {
+        if let zoneCode = UserService.shared.currentUser?.commercialAreaCode {
+            self.currentZoneCode = zoneCode
+            Task {
+                self.currentZoneName = await areaNameService.getAreaName(for: zoneCode)
+            }
+        }
+    }
+    
+    func setZone(_ area: CommercialArea) {
+        self.currentZoneCode = area.code
+        self.currentZoneName = area.areaName
+        // TODO: 서버에 저장 로직
+    }
+    
+    func canChangeZone() -> Bool {
+        return currentZoneCode == nil // 시즌 중에는 변경 불가
+    }
+    
+    func isZoneSelected() -> Bool {
+        return currentZoneCode != nil
+    }
+    
+    func updateWarningStatus() {
+        let savedSeason = UserDefaults.standard.integer(forKey: seasonKey)
+        let dontShow = UserDefaults.standard.bool(forKey: dontShowKey)
+        
+        if let seasonNumber = currentSeason?.id {
+            shouldShowWarning = (savedSeason != seasonNumber) || !dontShow
+        } else {
+            shouldShowWarning = !dontShow
+        }
+    }
+    
+    func saveDontShowPreference() {
+        UserDefaults.standard.set(true, forKey: dontShowKey)
+        if let seasonNumber = currentSeason?.id {
+            UserDefaults.standard.set(seasonNumber, forKey: seasonKey)
+        }
+        shouldShowWarning = false
+    }
+}

--- a/ILSANG/Sources/Manager/PaginationManager.swift
+++ b/ILSANG/Sources/Manager/PaginationManager.swift
@@ -12,17 +12,16 @@ final class PaginationManager<T> {
     private let threshold: Int
     
     /// 페이지 번호를 인자로 받아 해당 페이지의 데이터를 비동기적으로 로드하는 메서드. 데이터 배열과 전체 항목 수를 반환해야 합니다.
-    private let loadPageData: (Int) async -> (data: [T], totalCount: Int)
-    
+    var loadPageData: ((Int) async -> (data: [T], totalCount: Int))?
+
     private var currentPage: Int = 0
     private var totalPage: Int = 0
     private var totalCount: Int = 0
     private var isLoading = false
     
-    init(size: Int, threshold: Int, loadPage: @escaping (Int) async -> (data: [T], totalCount: Int)) {
+    init(size: Int, threshold: Int) {
         self.size = size
         self.threshold = threshold
-        self.loadPageData = loadPage
     }
     
     /// 인덱스 없이 데이터를 로드할 수 있는지 확인하는 메서드
@@ -54,7 +53,7 @@ final class PaginationManager<T> {
         } else {
             incrementPage()
         }
-        
+        guard let loadPageData else { return }
         let (_, totalCount) = await loadPageData(currentPage)
         updatePaginationState(totalCount: totalCount)
     }

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -103,17 +103,25 @@ final class Network {
         }
 
         let response = await request
+            .responseString { response in
+                   switch response.result {
+                   case .success(let raw): 
+                        print("✅ [Raw Response String]:\n\(raw)")
+                   case .failure(let error):
+                       print("❌ [Raw Response String Error]: \(error)")
+                   }
+               }
             .serializingResponse(using: DecodableResponseSerializer<T>(emptyResponseCodes: [200]))
             .response
         let statusCode = response.response?.statusCode ?? -1
         let responseData = try? response.result.get()
         let result = handleStatusCode(statusCode, data: responseData, errorData: request.data)
-        dump(response.result)
         switch result {
         case .success(let res):
             Log("네트워크 요청 성공: \(fullPath), \(method.rawValue)")
             return .success(res)
         case .failure(let error):
+            print(response.response?.statusCode, response.result)
             Log("네트워크 요청 실패: \(fullPath), \(error.localizedDescription)")
             return .failure(error)
         }

--- a/ILSANG/Sources/Views/Approval/ApprovalDetailView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalDetailView.swift
@@ -24,7 +24,6 @@ struct ApprovalDetailView: View {
                 vm: ApprovalViewModel(
                     approvalSource: .detail(missionId: missionId),
                     emojiNetwork: dependencies.emojiNetwork,
-                    userRepository: dependencies.userRepository,
                     missionHistoryRepository: dependencies.missionHistoryRepository,
                     areaNameService: dependencies.areaNameService
                 )

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -9,9 +9,16 @@ import SwiftUI
 
 struct ApprovalView: View {
     @State var vm: ApprovalViewModel
+    @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
-    @EnvironmentObject var seasonManager: SeasonManager
-
+    
+    init(
+        vm: ApprovalViewModel,
+    ) {
+        _vm = State(wrappedValue: vm)
+        _userRouter = StateObject(wrappedValue: UserRouter())
+    }
+    
     var body: some View {
         VStack(spacing: 0) {
             switch vm.viewStatus {
@@ -29,15 +36,7 @@ struct ApprovalView: View {
             await vm.loadDataIfNeeded()
         }
         .overlay { reportAlertView }
-        .navigationDestination(item: $vm.selectedUserId) { userId in
-            OtherUserProfileView(
-                userId: userId,
-                userRepository: dependencies.userRepository,
-                missionHistoryRepository: dependencies.missionHistoryRepository,
-                areaNameService: dependencies.areaNameService,
-                seasonManager: seasonManager
-            )
-        }
+        .withUserNavigation(userRouter: userRouter)
     }
     
     /// 퀘스트 타이틀  + 퀘스트 인증 이미지
@@ -62,7 +61,7 @@ struct ApprovalView: View {
                         onLike: { vm.onLike(for: idx) },
                         onHate: { vm.onHate(for: idx) },
                         onOtherUserTapped: {
-                            vm.selectedUserId = item.userId
+                            userRouter.navigateToUserProfile(userId: item.userId)
                         }
                     )
                     .overlay(alignment: .topTrailing) {
@@ -113,7 +112,7 @@ struct ApprovalView: View {
     private var reportAlertView: some View {
         if vm.showReportAlert {
             SettingAlertView(
-                alertType: .Report,
+                alertType: AlertType.Report,
                 onCancel: { vm.dismissReportAlert() },
                 onConfirm: { Task { await vm.confirmReport() } }
             )
@@ -170,7 +169,6 @@ struct ApprovalView: View {
             ApprovalViewModel(
                 approvalSource: .tab,
                 emojiNetwork: EmojiNetwork(),
-                userRepository: UserRepository(network: UserNetwork()),
                 missionHistoryRepository: MissionHistoryRepository(network: MissionHistoryNetwork(),),
                 areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork()))
             )

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -32,7 +32,6 @@ final class ApprovalViewModel {
     
     var viewStatus: ViewStatus = .loading
     var itemList: [ApprovalMissionHistoryItem] = []
-    var selectedUserId: String?
     
     var showReportAlert = false
     var selectedChallenge: ApprovalMissionHistoryItem?
@@ -41,31 +40,28 @@ final class ApprovalViewModel {
     let approvalSource: ApprovalSource
 
     private let emojiNetwork: EmojiNetwork
-    let userRepository: UserRepositoryInterface
-    let missionHistoryRepository: MissionHistoryRepository
-    let areaNameService: AreaNameProvider
+    private let missionHistoryRepository: MissionHistoryRepository
+    private let areaNameService: AreaNameProvider
 
     init(
         approvalSource: ApprovalSource,
         emojiNetwork: EmojiNetwork,
-        userRepository: UserRepositoryInterface,
         missionHistoryRepository: MissionHistoryRepository,
         areaNameService: AreaNameProvider
     ) {
         self.approvalSource = approvalSource
         self.emojiNetwork = emojiNetwork
-        self.userRepository = userRepository
         self.missionHistoryRepository = missionHistoryRepository
         self.areaNameService = areaNameService
         
         self.paginationManager = PaginationManager<ApprovalMissionHistoryItem>(
             size: 10,
-            threshold: 3,
-            loadPage: { [weak self] page in
-                guard let self = self else { return ([], 0) }
-                return await self.getChallengesWithImage(page: page)
-            }
+            threshold: 3
         )
+        paginationManager?.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await self.getChallengesWithImage(page: page)
+        }
     }
     
     @MainActor

--- a/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
@@ -95,7 +95,7 @@ class IllsangZoneSelectionViewModel: ObservableObject {
     @Published var selectedMetroIdx: Int = 0
     @Published var selectedArea: CommercialArea?
     @Published var showAlert: Bool = false
-    @Published var alertType: AlertType = .illsangZoneSetWarning
+    @Published var alertType: IllsangZoneAlertType = .illsangZoneSetWarning
     
     private let userRepository: UserRepositoryInterface
     private let areaRepository: AreaRepositoryInterface

--- a/ILSANG/Sources/Views/Home/BannerDetailView.swift
+++ b/ILSANG/Sources/Views/Home/BannerDetailView.swift
@@ -82,7 +82,7 @@ struct BannerDetailView: View {
                     vm: QuestDetailViewModel(
                         quest: quest,
                         questRepository: dependencies.questRepository,
-                        onUpdate: { quest in
+                        onFavorite: { quest in
                             viewModel.toggleQuestFavorite(quest: quest)
                         })
                 , showQuestExImageAction: {
@@ -210,7 +210,7 @@ struct BannerDetailView: View {
     }
     
     @ViewBuilder
-    private func alertView(_ alertType: AlertType) -> some View {
+    private func alertView(_ alertType: IllsangZoneAlertType) -> some View {
         if alertType == .illsangZoneNotSelected {
             SettingAlertView(
                 alertType: alertType,
@@ -341,8 +341,6 @@ struct QuestSortHelper {
     BannerDetailView(
         viewModel: BannerDetailViewModel(
             banner: .init(id: 0, title: "title", navigationTitle: "일상", imageId: "", description: "", image: .img0),
-            shouldShowIllsangZoneWarning: false,
-            currentSeason: 1,
             userRepository: UserRepository(network: UserNetwork()),
             questRepository: QuestRepository(network: QuestNetwork()),
             areaRepository: AreaRepository(network: AreaNetwork()),

--- a/ILSANG/Sources/Views/Home/BannerDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Home/BannerDetailViewModel.swift
@@ -43,14 +43,14 @@ class BannerDetailViewModel {
     var eventFilterState: StaticFilterPickerState<BannerEventQuestFilterType>
     
     // 일상존 관련
-    var currentSeason: Int
-    private var shouldShowIllsangZoneWarning: Bool
+//    var currentSeason: Int
+//    private var shouldShowIllsangZoneWarning: Bool
     var showSelectIllsangZoneView: Bool = false
     
     
     var isNeverShowAlertSelected: Bool = false // 일상존미선택 알럿 - 토글버튼
     var isQuestSheetPending: Bool = false // 퀘스트 시트를 다시 열어야 하는지 여부
-    var alertType: AlertType? = nil
+    var alertType: IllsangZoneAlertType? = nil
     private let dontShowKey = "DontShowIllsangZoneWarning"
     private let seasonKey = "IllsangZoneSeason"
     
@@ -76,8 +76,7 @@ class BannerDetailViewModel {
     
     init(
         banner: BannerViewModelItem,
-        shouldShowIllsangZoneWarning: Bool,
-        currentSeason: Int,
+//        shouldShowIllsangZoneWarning: Bool,
         userRepository: UserRepositoryInterface,
         questRepository: QuestRepositoryInterface,
         areaRepository: AreaRepositoryInterface,
@@ -91,8 +90,10 @@ class BannerDetailViewModel {
         
         eventFilterState = StaticFilterPickerState(initialValue: .popular)
         
-        self.currentSeason = currentSeason
-        self.shouldShowIllsangZoneWarning = shouldShowIllsangZoneWarning
+//        self.currentSeason = currentSeason
+// TODO: 내부에서 계산 (shouldShowIllsangZoneWarning)
+//        self.shouldShowIllsangZoneWarning = shouldShowIllsangZoneWarning
+        
         Task { await fetchQuestByBannerId() }
     }
     
@@ -112,14 +113,14 @@ class BannerDetailViewModel {
     
     func selectQuest(_ quest: QuestViewModelItem) {
         selectedQuest = quest
-        if shouldShowIllsangZoneWarning {
-            isQuestSheetPending = true // 일상존 선택 후 다시 열기 위해 기록
-            alertType = .illsangZoneNotSelected
-        } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                self.showQuestSheet.toggle()
-            }
-        }
+//        if shouldShowIllsangZoneWarning {
+//            isQuestSheetPending = true // 일상존 선택 후 다시 열기 위해 기록
+//            alertType = .illsangZoneNotSelected
+//        } else {
+//            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+//                self.showQuestSheet.toggle()
+//            }
+//        }
     }
     
     func onQuestApprovalTapped() {
@@ -153,8 +154,8 @@ class BannerDetailViewModel {
     func saveDontShowPreferenceIfSelected() {
         if isNeverShowAlertSelected {
             UserDefaults.standard.set(true, forKey: dontShowKey)
-            UserDefaults.standard.set(currentSeason, forKey: seasonKey)
-            shouldShowIllsangZoneWarning = false
+//            UserDefaults.standard.set(currentSeason, forKey: seasonKey)
+//            shouldShowIllsangZoneWarning = false
         }
     }
     

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 // TODO: 에러처리 재정의 필요
 struct HomeView: View {
     @State var vm: HomeViewModel
+    @StateObject var questRouter: QuestRouter
+    @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
-    @EnvironmentObject var honorAcquisitionManager: HonorAcquisitionManager
-    @EnvironmentObject var seasonManager: SeasonManager
     @EnvironmentObject var sharedState: SharedState
     @Environment(\.redactionReasons) var redactionReasons
     
@@ -26,6 +26,20 @@ struct HomeView: View {
         static let tabViewHeight: CGFloat = 450
         static let paginationSpacing: CGFloat = 4
         static let circleSize: CGFloat = 10
+    }
+    
+    init(
+        vm: HomeViewModel,
+        questRepository: QuestRepositoryInterface,
+        illsangZoneManager: IllsangZoneManager
+    ) {
+        _vm = State(wrappedValue: vm)
+        _questRouter = StateObject(
+            wrappedValue: QuestRouter(
+                illsangZoneManager: illsangZoneManager, questRepository: questRepository
+            )
+        )
+        _userRouter = StateObject(wrappedValue: UserRouter())
     }
     
     var body: some View {
@@ -45,55 +59,30 @@ struct HomeView: View {
                     await vm.loadInitialData()
                 }
                 .disabled(vm.viewStatus == .loading)
+                .withQuestNavigation(questRouter: questRouter)
+                .withUserNavigation(userRouter: userRouter)
             case .error:
                 networkErrorView
             }
         }
         .task {
-            await vm.loadInitialData()
+            await vm.loadDataIfNeeded()
         }
         .background(Color.background)
         .overlay(
             Group {
-                if let _ = honorAcquisitionManager.currentHonor {
+                if let _ = dependencies.honorAcquisitionManager.currentHonor {
                     HonorPopupContainerView()
                 } else if let alert = vm.alertType {
                      alertView(alert)
                 }
             }
         )
-        .sheet(isPresented: $vm.showQuestSheet) {
-            let tall = vm.selectedQuest.questType == .repeat || vm.selectedQuest.missionType == .photo
-            QuestDetailView(
-                vm: QuestDetailViewModel(
-                    quest: vm.selectedQuest,
-                    questRepository: dependencies.questRepository,
-                    onUpdate: { quest in
-                        vm.toggleFavoriteStatus(quest: quest)
-                    }
-                ), showQuestExImageAction: {
-                    vm.onChallengeExImageTapped()
-                }, questApproveAction: {
-                    vm.onQuestApprovalTapped()
-                }
-            )
-            .presentationCornerRadius(24)
-            .presentationDragIndicator(.hidden)
-            .presentationDetents([tall ? .height(UISheetPresentationController.Detent.questDetailDetentHeightTall) : .height(UISheetPresentationController.Detent.questDetailDetentHeightShort)])
-            .onAppear {
-                UIApplication.shared.updateSheetDetents(to: [tall ? .questDetailDetentTall : .questDetailDetentShort], whenCurrentDetentsAre: [.large()])
-            }
-        }
-        .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
-            SubmitRouterView(selectedQuest: vm.selectedQuest, submitService: dependencies.imageChallengeSubmitService, challengeNetwork: dependencies.challengeNetwork)
-                .interactiveDismissDisabled()
-        }
+       
         .navigationDestination(item: $vm.selectedBanner) { banner in
             BannerDetailView(
                 viewModel: BannerDetailViewModel(
                     banner: banner,
-                    shouldShowIllsangZoneWarning: vm.shouldShowIllsangZoneWarning,
-                    currentSeason: vm.currentSeason,
                     userRepository: dependencies.userRepository,
                     questRepository: dependencies.questRepository,
                     areaRepository: dependencies.areaRepository,
@@ -105,27 +94,6 @@ struct HomeView: View {
             MyRegionAreaSelectionView(areaRepository: dependencies.areaRepository) { area in
                 vm.handleMyRegionSelection(area)
             }
-        }
-        .navigationDestination(isPresented: $vm.showSelectIllsangZoneView) {
-            IllsangZoneSelectionView(userRepository: dependencies.userRepository, areaRepository: dependencies.areaRepository) { area in
-                vm.handleIllsangZoneSelection(area)
-            }
-        }
-        .navigationDestination(isPresented: $vm.showQuestEngageView) {
-            QuestEngageView(
-                vm: QuestEngageViewModel(
-                    quest: vm.selectedQuest, challengeNetwork: dependencies.challengeNetwork
-                ),
-                submitVM: SubmitRouterViewModel(
-                    selectedImage: nil,
-                    selectedQuest: vm.selectedQuest,
-                    submitService: dependencies.imageChallengeSubmitService,
-                    challengeNetwork: dependencies.challengeNetwork
-                )
-            )
-        }
-        .navigationDestination(isPresented: $vm.showChallengeImageView) {
-            ApprovalDetailView(missionId: vm.selectedQuest.missionId)
         }
     }
     
@@ -183,17 +151,12 @@ struct HomeView: View {
                 .styledFont(.caption2)
                 .foregroundStyle(.gray400)
             Button {
-                if vm.illsangZoneName == nil {
-                    vm.isQuestSheetPending = false
-                    vm.showSelectIllsangZoneView = true
-                } else {
-                    vm.alertType = .illsangZoneChangeNotAllowed
-                }
+                questRouter.handleIllsangZoneButtonTap()
             } label: {
                 HStack(spacing: 0) {
-                    Text(vm.illsangZoneName ?? "선택하기")
+                    Text(dependencies.illsangZoneManager.currentZoneName ?? "선택하기")
                         .styledFont(.caption1)
-                    if vm.illsangZoneName == nil {
+                    if dependencies.illsangZoneManager.currentZoneName == nil {
                         Image(.arrowUnder)
                             .resizable()
                             .scaledToFit()
@@ -278,7 +241,9 @@ struct HomeView: View {
                     imageSize: CGSize(width: (UIScreen.main.bounds.width - 40 - 2) / 2, height: 137)
                 ) {
                     AnalyticsService.logEvent(.homePopularQuestClick(questId: quest.id))
-                    vm.onQuestTapped(quest: quest)
+                    questRouter.presentQuestDetail(quest: quest) { quest in
+                        vm.toggleFavoriteStatus(quest: quest)
+                    }
                 }
             }
         }
@@ -296,7 +261,9 @@ struct HomeView: View {
                                 imageSize: CGSize(width: (UIScreen.main.bounds.width - 40 - 2) / 2, height: 137)
                             ) {
                                 AnalyticsService.logEvent(.homePopularQuestClick(questId: quest.id))
-                                vm.onQuestTapped(quest: quest)
+                                questRouter.presentQuestDetail(quest: quest) { quest in
+                                    vm.toggleFavoriteStatus(quest: quest)
+                                }
                             }
                         }
                     }
@@ -334,7 +301,9 @@ struct HomeView: View {
                         ForEach(vm.recommendQuestList, id: \.id) { quest in
                             RecommendQuestItemView(quest: quest) {
                                 AnalyticsService.logEvent(.homeRecommendQuestClick(questId: quest.id))
-                                vm.onQuestTapped(quest: quest)
+                                questRouter.presentQuestDetail(quest: quest) { quest in
+                                    vm.toggleFavoriteStatus(quest: quest)
+                                }
                             }
                         }
                     }
@@ -358,7 +327,9 @@ struct HomeView: View {
                     ForEach(vm.largestRewardQuestList.prefix(3), id: \.id) { quest in
                         LargeRewardQuestItemView(quest: quest) {
                             AnalyticsService.logEvent(.homeBigRewardQuestClick(questId: quest.id))
-                            vm.onQuestTapped(quest: quest)
+                            questRouter.presentQuestDetail(quest: quest) { quest in
+                                vm.toggleFavoriteStatus(quest: quest)
+                            }
                         }
                     }
                 }
@@ -380,8 +351,7 @@ struct HomeView: View {
                         ForEach(vm.userRankList, id: \.userId) { rank in
                             Button {
                                 AnalyticsService.logEvent(.homeRankingClick(userId: rank.userId))
-                                vm.selectedUserId = rank.userId
-                                vm.showOtherUserProfileView = true
+                                userRouter.navigateToUserProfile(userId: rank.userId)
                             } label: {
                                 RankingItemView(style: .totalRank(rank))
                             }
@@ -390,66 +360,12 @@ struct HomeView: View {
                     .padding(.horizontal, LayoutConstants.horizontalPadding)
                 }
                 .scrollIndicators(.never)
-                .navigationDestination(isPresented: $vm.showOtherUserProfileView) {
-                    if let userId = vm.selectedUserId {
-                        OtherUserProfileView(
-                            userId: userId,
-                            userRepository: dependencies.userRepository,
-                            missionHistoryRepository: dependencies.missionHistoryRepository,
-                            areaNameService: dependencies.areaNameService,
-                            seasonManager: seasonManager
-                        )
-                    }
-                }
         )
     }
     
     @ViewBuilder
     private func alertView(_ alertType: AlertType) -> some View {
-        if alertType == .illsangZoneNotSelected {
-            SettingAlertView(
-                alertType: alertType,
-                onCancel: {
-                    vm.alertType = nil
-                    vm.saveDontShowPreferenceIfSelected()
-                    vm.showQuestSheet = true
-                }, onConfirm: {
-                    vm.alertType = nil
-                    vm.saveDontShowPreferenceIfSelected()
-                    vm.showSelectIllsangZoneView = true
-                }) {
-                    Button {
-                        vm.isNeverShowAlertSelected.toggle()
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(.checkThin)
-                                .renderingMode(.template)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 9, height: 5.5)
-                                .frame(16)
-                                .foregroundStyle(vm.isNeverShowAlertSelected ? .white : .clear)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 3)
-                                        .strokeBorder(
-                                            vm.isNeverShowAlertSelected ? .clear : .gray200,
-                                            style: StrokeStyle(lineWidth: 1)
-                                        )
-                                        .fill(vm.isNeverShowAlertSelected ? .primaryPurple : .clear)
-                                )
-                                .frame(24)
-                            Text("다시 보지 않기")
-                                .styledFont(.tabRegular)
-                                .foregroundStyle(.gray500)
-                        }
-                    }
-                }
-        } else if alertType == .illsangZoneSetSuccess {
-            SettingAlertView(
-                alertType: alertType,
-                onConfirm: { vm.finalizeIllsangZoneSelection() }
-            )
-        } else if [AlertType.illsangZoneChangeNotAllowed, AlertType.myRegionChangeSuccess].contains(alertType) {
+        if alertType ==  AlertType.myRegionChangeSuccess {
             SettingAlertView(
                 alertType: alertType,
                 onConfirm: { vm.alertType = nil }
@@ -476,10 +392,16 @@ struct HomeView: View {
         questRepository: QuestRepository(network: QuestNetwork()),
         rankRepository: RankRepository(network: RankNetwork()),
         bannerRepository: BannerRepository(network: BannerNetwork()),
-        areaRepository: AreaRepository(network: AreaNetwork()),
         favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: SharedState()
     )
-    HomeView(vm: viewModel)
+    HomeView(
+        vm: viewModel,
+        questRepository: QuestRepository(network: QuestNetwork()),
+        illsangZoneManager: IllsangZoneManager(
+            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
+            seasonManager: SeasonManager(seasonNetwork: SeasonNetwork())
+        )
+    )
 }
 
 extension Array {

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -33,55 +33,23 @@ final class HomeViewModel {
     
     var currentBanner: Int = 0
     
-    var showQuestSheet: Bool = false
-    var selectedQuest: QuestViewModelItem = .mockData
     var selectedPopularTabIndex: Int = 0
     let popularChunkSize: Int = 4
     var paginatedPopularQuests: [[QuestViewModelItem]] {
         popularQuestList.chunks(of: popularChunkSize)
     }
-    var showChallengeImageView: Bool = false
-    var showSubmitRouterView: Bool = false {
-        didSet {
-            // TODO: 해당 데이터가 포함되어있으면 제거 or 리로드하도록 수정
-            if showSubmitRouterView == false {
-                Task {
-                    await loadInitialData()
-                }
-            }
-        }
-    }
-    var showQuestEngageView: Bool = false {
-        didSet {
-            // TODO: 해당 데이터가 포함되어있으면 제거 or 리로드하도록 수정
-            if showSubmitRouterView == false {
-                Task {
-                    await loadInitialData()
-                }
-            }
-        }
-    }
+    
     var showSelectMyRegionView: Bool = false
-    var showSelectIllsangZoneView: Bool = false
     var selectedBanner: BannerViewModelItem? = nil
     
-    var illsangZoneCode: String? = nil
-    var illsangZoneName: String? = nil
     var alertType: AlertType? = nil
     
-    var isNeverShowAlertSelected: Bool = false // 일상존미선택 알럿 - 토글버튼
-    var isQuestSheetPending: Bool = false // 퀘스트 시트를 다시 열어야 하는지 여부
+//    var shouldShowIllsangZoneWarning: Bool = false
+//    
+//    private let dontShowKey = "DontShowIllsangZoneWarning"
+//    private let seasonKey = "IllsangZoneSeason"
     
-    var shouldShowIllsangZoneWarning: Bool = false
-    
-    private let dontShowKey = "DontShowIllsangZoneWarning"
-    private let seasonKey = "IllsangZoneSeason"
-    
-    let currentSeason: Int = 1 // TODO: 서버에서 가져오도록 수정
-    
-    // 다른 유저 프로필 확인
-    var showOtherUserProfileView = false
-    var selectedUserId: String? = nil
+//    let currentSeason: Int = 1 // TODO: 서버에서 가져오도록 수정
     
     var errorCnt = 0
     var showMainBanners: Bool = true
@@ -90,13 +58,12 @@ final class HomeViewModel {
     var showPopularRewardQuest: Bool = true
     var showRankList = true
     
-    let userRepository: UserRepositoryInterface
-    let areaNameService: AreaNameProvider
-    let questRepository: QuestRepositoryInterface
+    private let userRepository: UserRepositoryInterface
+    private let areaNameService: AreaNameProvider
+    private let questRepository: QuestRepositoryInterface
     private let rankRepository: RankRepositoryInterface
     private let bannerRepository: BannerRepositoryInterface
-    let areaRepository: AreaRepositoryInterface
-    let favoriteService: FavoriteService
+    private let favoriteService: FavoriteService
     private let sharedState: SharedState
     
     private var cancellables = Set<AnyCancellable>()
@@ -107,26 +74,61 @@ final class HomeViewModel {
         questRepository: QuestRepositoryInterface,
         rankRepository: RankRepositoryInterface,
         bannerRepository: BannerRepositoryInterface,
-        areaRepository: AreaRepositoryInterface,
         favoriteService: FavoriteService,
         sharedState: SharedState
-    ) {
+    )  {
         self.userRepository = userRepository
         self.areaNameService = areaNameService
         self.questRepository = questRepository
         self.rankRepository = rankRepository
         self.bannerRepository = bannerRepository
-        self.areaRepository = areaRepository
         self.favoriteService = favoriteService
         self.sharedState = sharedState
         
+        Task { await setupBindings() }
+    }
+    
+    @MainActor
+    private func setupBindings() {
         sharedState.$selectedCommercialArea
             .removeDuplicates()
             .dropFirst()
             .sink { [weak self] _ in
-                Task { await self?.loadInitialData() } // TODO: 배너 제외 데이터 재로드
+                Task { await self?.loadInitialData() }
             }
             .store(in: &cancellables)
+        
+        // 퀘스트 라우터 완료 시 데이터 새로고침
+//        questRouter.$showSubmitRouter
+//            .removeDuplicates()
+//            .dropFirst()
+//            .sink { [weak self] isPresented in
+//                if !isPresented {
+//                    Task { await self?.loadInitialData() }
+//                }
+//            }
+//            .store(in: &cancellables)
+//        
+//        questRouter.$showQuestEngage
+//            .removeDuplicates()
+//            .dropFirst()
+//            .sink { [weak self] isPresented in
+//                if !isPresented {
+//                    Task { await self?.loadInitialData() }
+//                }
+//            }
+//            .store(in: &cancellables)
+    }
+    
+    @MainActor
+    func loadDataIfNeeded() async {
+        if mainBanners.isEmpty ||
+            popularQuestList.isEmpty ||
+            recommendQuestList.isEmpty ||
+            largestRewardQuestList.isEmpty ||
+            userRankList.isEmpty {
+            await loadInitialData()
+        }
     }
     
     @MainActor
@@ -138,7 +140,6 @@ final class HomeViewModel {
         self.showRecommendRewardQuest = true
         self.showLargestRewardQuest = true
         self.showRankList = true
-        updateIllsangZoneWarningStatus()
         
         await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
@@ -196,11 +197,6 @@ final class HomeViewModel {
 
         if let userProfileImageId = UserService.shared.currentUser?.profileImageId {
             self.userProfileImage = await ImageCacheService.shared.loadImageAsync(imageId: userProfileImageId)
-        }
-        
-        if let illsangZoneCode = UserService.shared.currentUser?.commercialAreaCode {
-            self.illsangZoneCode = illsangZoneCode
-            self.illsangZoneName = await areaNameService.getAreaName(for: illsangZoneCode)
         }
 
         changeViewStatus(.loaded)
@@ -370,82 +366,10 @@ final class HomeViewModel {
         self.viewStatus = viewStatus
     }
     
-    func onQuestTapped(quest: QuestViewModelItem) {
-        selectedQuest = quest
-        Task {
-            let questDetail = try await questRepository.getQuestDetail(questId: quest.id)
-                .get()
-                .toQuestItem()
-            if let imageId = questDetail.imageId {
-                questDetail.image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
-            }
-            self.selectedQuest = questDetail
-        }
-        
-        if illsangZoneCode == nil && shouldShowIllsangZoneWarning {
-            isQuestSheetPending = true // 일상존 선택 후 다시 열기 위해 기록
-            alertType = .illsangZoneNotSelected
-        } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                self.showQuestSheet.toggle()
-            }
-        }
-    }
-    
-    func onQuestApprovalTapped() {
-        showQuestSheet = false
-        if selectedQuest.missionType == .photo {
-            showSubmitRouterView = true
-        } else {
-            showQuestEngageView = true
-        }
-    }
-    
-    func onChallengeExImageTapped() {
-        showQuestSheet = false
-        showChallengeImageView = true
-    }
-    
-    // 일상존 선택 완료 시
-    func handleIllsangZoneSelection(_ area: CommercialArea) {
-        self.illsangZoneCode = area.code
-        self.illsangZoneName = area.areaName
-        self.alertType = .illsangZoneSetSuccess
-    }
-    
-    // TODO: 함수명 변경
-    func finalizeIllsangZoneSelection() {
-        alertType = nil
-        if isQuestSheetPending {
-            isQuestSheetPending = false
-            showQuestSheet = true
-        }
-    }
-    
     // 내 지역 선택 완료 시
     func handleMyRegionSelection(_ area: CommercialArea) {
         sharedState.selectedCommercialArea = area
         self.alertType = .myRegionChangeSuccess
-    }
-    
-    /// "다시 보지 않기" 체크 여부 확인
-    private func updateIllsangZoneWarningStatus() {
-        let savedSeason = UserDefaults.standard.integer(forKey: seasonKey)
-        let dontShow = UserDefaults.standard.bool(forKey: dontShowKey)
-        
-        // 시즌이 바뀌었거나 "다시 보지 않기" 안 한 경우엔 보여주기
-        if savedSeason != currentSeason || !dontShow {
-            shouldShowIllsangZoneWarning = true
-        }
-    }
-    
-    /// "다시 보지 않기" 선택 시 저장
-    func saveDontShowPreferenceIfSelected() {
-        if isNeverShowAlertSelected {
-            UserDefaults.standard.set(true, forKey: dontShowKey)
-            UserDefaults.standard.set(currentSeason, forKey: seasonKey)
-            shouldShowIllsangZoneWarning = false
-        }
     }
     
     /// 즐겨찾기 상태를 UI에 즉시 반영하고,  서버 반영은 디바운싱 처리

--- a/ILSANG/Sources/Views/MyPage/IllsangZonePointView.swift
+++ b/ILSANG/Sources/Views/MyPage/IllsangZonePointView.swift
@@ -62,6 +62,7 @@ struct IllsangZonePointView: View {
                 VStack(alignment: .leading, spacing: 32) {
                     let percents = totalOwnerContributions.pointRatios()
                     
+                    // TODO: 지역 3개만 보이도록 수정
                     ForEach(Array(totalOwnerContributions.enumerated()), id: \.offset) { idx, contribution in
                         VStack(alignment: .leading, spacing: 10) {
                             HStack(spacing: 4) {

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct MyPageView: View {
     @ObservedObject var vm: MyPageViewModel
     @EnvironmentObject var dependencies: AppDependencies
-    @EnvironmentObject var seasonManager: SeasonManager
     @EnvironmentObject var sharedState: SharedState
     
     var body: some View {
@@ -108,7 +107,7 @@ struct MyPageView: View {
                     style: .my,
                     content:
                         UserPointView(
-                            seasonNumbers: seasonManager.seasons.map { $0.seasonNumber },
+                            seasonNumbers: dependencies.seasonManager.seasons.map { $0.seasonNumber },
                             points: vm.points,
                             completedQuestCount: vm.completedQuestCount,
                             selectedSeason: $vm.selectedSeasonNumber,

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
@@ -55,7 +55,7 @@ struct UserMissionHistoryDetailView: View {
         .overlay {
             if vm.challengeDelete {
                 SettingAlertView(
-                    alertType: .ChallengeDelete,
+                    alertType: AlertType.ChallengeDelete,
                     onCancel: { vm.challengeDelete = false },
                     onConfirm: {
                         Task {

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryViewModel.swift
@@ -21,14 +21,15 @@ final class UserMissionHistoryViewModel: ObservableObject {
     
     init(missionHistoryRepository: MissionHistoryRepository, challengeDelete: Bool = false) {
         self.missionHistoryRepository = missionHistoryRepository
-    }
-    lazy var challengePaginationManager = PaginationManager<UserMissionHistoryViewModelItem>(
-        size: 10,
-        threshold: 7,
-        loadPage: { [weak self] page in
+        challengePaginationManager.loadPageData = { [weak self] page in
             guard let self = self else { return ([], 0) }
             return await loadChallengeListWithImage(page: page, size: 10)
         }
+    }
+    
+    var challengePaginationManager = PaginationManager<UserMissionHistoryViewModelItem>(
+        size: 10,
+        threshold: 7
     )
     
     @discardableResult @MainActor

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct OtherUserProfileView: View {
     @StateObject var vm: OtherUserProfileViewModel
     @EnvironmentObject var dependencies: AppDependencies
-    @EnvironmentObject var seasonManager: SeasonManager
     @Environment(\.dismiss) var dismiss
     
     init(
@@ -128,7 +127,7 @@ struct OtherUserProfileView: View {
             style: .my,
             content:
                 UserPointView(
-                    seasonNumbers: seasonManager.seasons.map { $0.seasonNumber },
+                    seasonNumbers: dependencies.seasonManager.seasons.map { $0.seasonNumber },
                     points: vm.points,
                     completedQuestCount: vm.completedQuestCount,
                     selectedSeason: $vm.selectedSeasonNumber,

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
@@ -28,14 +28,9 @@ final class OtherUserProfileViewModel: ObservableObject {
     
     @Published var seasonFilterState: DynamicFilterPickerState<SeasonFilterType>
 
-    lazy var challengePaginationManager = PaginationManager<UserMissionHistoryViewModelItem>(
+    var challengePaginationManager = PaginationManager<UserMissionHistoryViewModelItem>(
         size: 10,
-        threshold: 7,
-        loadPage: { [weak self] page in
-            guard let self = self else { return ([], 0) }
-            return await loadChallengeListWithImage(page: page, size: 10)
-        }
-    )
+        threshold: 7)
     
     private let userRepository: UserRepositoryInterface
     private let missionHistoryRepository: MissionHistoryRepository
@@ -84,6 +79,11 @@ final class OtherUserProfileViewModel: ObservableObject {
 //                self.updateSeasonsFromServer(seasons.map { $0.seasonNumber })
 //            }
 //            .store(in: &cancellables)
+        
+        challengePaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await loadChallengeListWithImage(page: page, size: 10)
+        }
     }
 
     

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailView.swift
@@ -110,7 +110,7 @@ struct QuestDetailView: View {
         vm: QuestDetailViewModel(
             quest: .mockData,
             questRepository:  QuestRepository(network: QuestNetwork()),
-            onUpdate:  { _ in }
+            onFavorite:  { _ in }
         ),
         showQuestExImageAction: { },
         questApproveAction: { }
@@ -124,7 +124,7 @@ struct QuestDetailView: View {
         vm: QuestDetailViewModel(
             quest: .mockRepeatData,
             questRepository:  QuestRepository(network: QuestNetwork()),
-            onUpdate:  { _ in }
+            onFavorite:  { _ in }
         ),
         showQuestExImageAction: { },
         questApproveAction: { }

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
@@ -11,16 +11,16 @@ import SwiftUI
 class QuestDetailViewModel {
     var quest: QuestViewModelItem
     var isLoading: Bool = false
-    private let onUpdate: (QuestViewModelItem) -> Void
+    private let onFavorite: (QuestViewModelItem) -> Void
 
     var approvalDescription: String = "퀘스트를 수행하고\n인증 후, 포인트를 적립받으세요"
     
     private let questRepository: QuestRepositoryInterface
     
-    init(quest: QuestViewModelItem, questRepository: QuestRepositoryInterface, onUpdate: @escaping (QuestViewModelItem) -> Void) {
+    init(quest: QuestViewModelItem, questRepository: QuestRepositoryInterface, onFavorite: @escaping (QuestViewModelItem) -> Void) {
         self.quest = quest
         self.questRepository = questRepository
-        self.onUpdate = onUpdate
+        self.onFavorite = onFavorite
     }
     
     func updateChallengeImages() async {
@@ -30,6 +30,6 @@ class QuestDetailViewModel {
     }
     
     func toggleFavorite() {
-        onUpdate(quest)
+        onFavorite(quest)
     }
 }

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -9,10 +9,26 @@ import SwiftUI
 import Combine
 
 struct QuestView: View {
-    @ObservedObject var vm: QuestViewModel
+    @State var vm: QuestViewModel
+    @StateObject var questRouter: QuestRouter
+    @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
     @EnvironmentObject var sharedState: SharedState
 
+    init(
+        vm: QuestViewModel,
+        questRepository: QuestRepositoryInterface,
+        illsangZoneManager: IllsangZoneManager
+    ) {
+        _vm = State(wrappedValue: vm)
+        _questRouter = StateObject(
+            wrappedValue: QuestRouter(
+                illsangZoneManager: illsangZoneManager, questRepository: questRepository
+            )
+        )
+        _userRouter = StateObject(wrappedValue: UserRouter())
+    }
+    
     var body: some View {
         VStack(spacing: 0) {
             headerView
@@ -31,14 +47,8 @@ struct QuestView: View {
         .task {
             await vm.loadDataIfNeeded()
         }
-        .onReceive(
-            vm.$selectedHeader
-                .combineLatest(vm.questFilterState.$selectedValue)
-                .combineLatest(vm.repeatFilterState.$selectedValue)
-                .combineLatest(vm.eventFilterState.$selectedValue)
-        ) { _ in
-            vm.closeFilterPicker()
-        }
+        .withQuestNavigation(questRouter: questRouter)
+        .withUserNavigation(userRouter: userRouter)
         .overlay(
             Group {
                 if let alert = vm.alertType {
@@ -46,51 +56,10 @@ struct QuestView: View {
                 }
             }
         )
-        .sheet(isPresented: $vm.showQuestSheet) {
-            let tall = vm.selectedQuest.questType == .repeat || vm.selectedQuest.missionType == .photo
-            
-            QuestDetailView(
-                vm: QuestDetailViewModel(
-                    quest: vm.selectedQuest,
-                    questRepository: dependencies.questRepository,
-                    onUpdate: { quest in
-                        vm.toggleFavoriteStatus(quest: quest)
-                    }
-                ), showQuestExImageAction: {
-                    vm.onChallengeExImageTapped()
-                }, questApproveAction: {
-                    vm.onQuestApprovalTapped()
-                }
-            )
-            .presentationCornerRadius(24)
-            .presentationDragIndicator(.hidden)
-            .presentationDetents([tall ? .height(UISheetPresentationController.Detent.questDetailDetentHeightTall) : .height(UISheetPresentationController.Detent.questDetailDetentHeightShort)])
-            .onAppear {
-                UIApplication.shared.updateSheetDetents(to: [tall ? .questDetailDetentTall : .questDetailDetentShort], whenCurrentDetentsAre: [.large()])
-            }
-        }
-        .fullScreenCover(isPresented: $vm.showSubmitRouterView) {
-            SubmitRouterView(selectedQuest: vm.selectedQuest, submitService: dependencies.imageChallengeSubmitService, challengeNetwork: dependencies.challengeNetwork)
-                .interactiveDismissDisabled()
-        }
         .navigationDestination(isPresented: $vm.showSelectMyRegionView) {
             MyRegionAreaSelectionView(areaRepository: dependencies.areaRepository) { area in
                 vm.handleMyRegionSelection(area)
             }
-        }
-        .navigationDestination(isPresented: $vm.showQuestEngageView) {
-            QuestEngageView(
-                vm: QuestEngageViewModel(quest: vm.selectedQuest, challengeNetwork: dependencies.challengeNetwork),
-                submitVM: SubmitRouterViewModel(
-                    selectedImage: nil,
-                    selectedQuest: vm.selectedQuest,
-                    submitService: dependencies.imageChallengeSubmitService,
-                    challengeNetwork: dependencies.challengeNetwork
-                )
-            )
-        }
-        .navigationDestination(isPresented: $vm.showChallengeImageView) {
-            ApprovalDetailView(missionId: vm.selectedQuest.missionId)
         }
     }
 }
@@ -131,12 +100,25 @@ extension QuestView {
                     questListEmptyView
                 }
             }
-            .onReceive(
-                vm.$selectedHeader
-                    .combineLatest(vm.questFilterState.$selectedValue)
-                    .combineLatest(vm.repeatFilterState.$selectedValue)
-                    .combineLatest(vm.eventFilterState.$selectedValue)
-            ) { _ in
+            .onChange(of: vm.selectedHeader) { _, _ in
+                vm.closeFilterPicker()
+                withAnimation {
+                    proxy.scrollTo("top", anchor: .top)
+                }
+            }
+            .onChange(of: vm.questFilterState.selectedValue) {  _, _ in
+                vm.closeFilterPicker()
+                withAnimation {
+                    proxy.scrollTo("top", anchor: .top)
+                }
+            }
+            .onChange(of: vm.repeatFilterState.selectedValue) { _, _ in
+                vm.closeFilterPicker()
+                withAnimation {
+                    proxy.scrollTo("top", anchor: .top)
+                }
+            }
+            .onChange(of: vm.eventFilterState.selectedValue) { _, _ in
                 vm.closeFilterPicker()
                 withAnimation {
                     proxy.scrollTo("top", anchor: .top)
@@ -152,7 +134,12 @@ extension QuestView {
                 ForEach(vm.currentQuests, id: \.id) { quest in
                     DefaultQuestItemView(
                         quest: quest,
-                        action: { vm.onQuestTapped(quest: quest) },
+                        action: {
+                            AnalyticsService.logEvent(.questItemClick(questId: quest.id, questType: quest.questType?.rawValue.uppercased() ?? ""))
+                            questRouter.presentQuestDetail(quest: quest) { quest in
+                                vm.toggleFavoriteStatus(quest: quest)
+                            }
+                        },
                         favoriteAction: { vm.toggleFavoriteStatus(quest: quest) }
                     )
                 }
@@ -160,7 +147,12 @@ extension QuestView {
                 ForEach(vm.currentQuests, id: \.id) { quest in
                     RepeatQuestItemView(
                         quest: quest,
-                        action: { vm.onQuestTapped(quest: quest) },
+                        action: {
+                            AnalyticsService.logEvent(.questItemClick(questId: quest.id, questType: quest.questType?.rawValue.uppercased() ?? ""))
+                            questRouter.presentQuestDetail(quest: quest) { quest in
+                                vm.toggleFavoriteStatus(quest: quest)
+                            }
+                        },
                         favoriteAction: { vm.toggleFavoriteStatus(quest: quest) }
                     )
                 }
@@ -168,7 +160,12 @@ extension QuestView {
                 ForEach(vm.currentQuests, id: \.id) { quest in
                     EventQuestItemView(
                         quest: quest,
-                        action: { vm.onQuestTapped(quest: quest) },
+                        action: {
+                            AnalyticsService.logEvent(.questItemClick(questId: quest.id, questType: quest.questType?.rawValue.uppercased() ?? ""))
+                            questRouter.presentQuestDetail(quest: quest) { quest in
+                                vm.toggleFavoriteStatus(quest: quest)
+                            }
+                        },
                         favoriteAction: { vm.toggleFavoriteStatus(quest: quest) }
                     )
                 }
@@ -209,7 +206,6 @@ extension QuestView {
                 .frame(maxWidth: .infinity, alignment: .trailing)
             }
             .padding(.horizontal, 20)
-//            .padding(.top, 16)
             .padding(.top, 2)
             .padding(.bottom, 12)
         }
@@ -264,8 +260,18 @@ extension QuestView {
 }
 
 #Preview {
-    QuestView(vm: QuestViewModel(
-        questRepository: MockQuestRepository(), areaRepository: AreaRepository(network: AreaNetwork()),
-        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: SharedState()
-    ))
+    QuestView(
+        vm: QuestViewModel(
+            questRepository: QuestRepository(network: QuestNetwork()),
+            favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
+            sharedState: SharedState()
+        ),
+        questRepository: QuestRepository(network: QuestNetwork()),
+        illsangZoneManager: IllsangZoneManager(
+            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
+            seasonManager: SeasonManager(
+                seasonNetwork: SeasonNetwork()
+            )
+        )
+    )
 }

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -8,7 +8,8 @@
 import UIKit
 import Combine
 
-class QuestViewModel: ObservableObject {
+@Observable
+class QuestViewModel {
     // TODO: API 요청 실패 시 에러상태로 변경하기
     enum ViewStatus {
         case error
@@ -16,46 +17,24 @@ class QuestViewModel: ObservableObject {
         case loaded
     }
     
-    @Published var viewStatus: ViewStatus = .loading
+     var viewStatus: ViewStatus = .loading
     
     // TODO: 바뀔 때 api 요청하도록 수정 (refresh, init 고려)
-    @Published var selectedHeader: QuestStatus = .default
+     var selectedHeader: QuestStatus = .default
     
-    @Published var showSelectMyRegionView: Bool = false
-    @Published var alertType: AlertType? = nil
+     var showSelectMyRegionView: Bool = false
+     var alertType: AlertType? = nil
     
     // 필터
-    @Published var questFilterState: StaticFilterPickerState<QuestFilterType>
-    @Published var repeatFilterState: StaticFilterPickerState<RepeatType>
-    @Published var eventFilterState: StaticFilterPickerState<EventQuestFilterType>
-    
-    // 선택된 퀘스트
-    @Published var selectedQuest: QuestViewModelItem = .mockData
-    @Published var showQuestSheet: Bool = false
-    @Published var showChallengeImageView: Bool = false
-    @Published var showSubmitRouterView: Bool = false {
-        didSet {
-            // TODO: 도전내역 등록 완료시 리스트에서 퀘스트만 삭제/추가하도록 개선(퀘스트 조회 API 호출x)
-            if showSubmitRouterView == false {
-                Task { await loadInitialData() }
-            }
-        }
-    }
-    @Published var showQuestEngageView: Bool = false {
-        didSet {
-            // TODO: 도전내역 등록 완료시 리스트에서 퀘스트만 삭제/추가하도록 개선(퀘스트 조회 API 호출x)
-            if showQuestEngageView == false {
-                Task { await loadInitialData() }
-            }
-        }
-    }
-    
-    @Published var defaultQuestListByFilter: [QuestFilterType: [QuestViewModelItem]] = [:]
-    @Published var repeatQuestListByFilter: [RepeatType: [QuestFilterType: [QuestViewModelItem]]] = [:]
-    @Published var eventQuestListByFilter: [EventQuestFilterType: [QuestViewModelItem]] = [:]
-    @Published var completedQuestList: [QuestViewModelItem] = []
+     var questFilterState: StaticFilterPickerState<QuestFilterType>
+     var repeatFilterState: StaticFilterPickerState<RepeatType>
+     var eventFilterState: StaticFilterPickerState<EventQuestFilterType>
+       
+     var defaultQuestListByFilter: [QuestFilterType: [QuestViewModelItem]] = [:]
+     var repeatQuestListByFilter: [RepeatType: [QuestFilterType: [QuestViewModelItem]]] = [:]
+     var eventQuestListByFilter: [EventQuestFilterType: [QuestViewModelItem]] = [:]
+     var completedQuestList: [QuestViewModelItem] = []
 
-    
     var currentQuests: [QuestViewModelItem] {
         switch selectedHeader {
         case .default:
@@ -73,68 +52,56 @@ class QuestViewModel: ObservableObject {
         currentQuests.isEmpty
     }
     
-    // TODO: 퀘스트 갯수 확인 필요
-    // TODO: 현재 0페이지만 불러오며, 임시로 60개 로딩. 스탯 분류&필터링과 관련해서 기획 & API 수정에 따라 페이지네이션 로직 수정 필요
-    lazy var defaultPaginationManager = PaginationManager<QuestViewModelItem>(
-        size: 20,
-        threshold: 18,
-        loadPage: { [weak self] page in
-            guard let self = self else { return ([], 0) }
-            return await loadQuestListWithImage(page: page, size: 20, status: .default)
-        }
-    )
-    
-    // TODO: 현재 0페이지만 불러오며, 임시로 40개 로딩. 스탯 분류&필터링과 관련해서 기획 & API 수정에 따라 페이지네이션 로직 수정 필요
-    lazy var repeatPaginationManager = PaginationManager<QuestViewModelItem>(
-        size: 20,
-        threshold: 18,
-        loadPage: { [weak self] page in
-            guard let self = self else { return ([], 0) }
-            return await loadQuestListWithImage(page: page, size: 20, status: .repeat)
-        }
-    )
-    
-    // TODO: 스탯 분류&필터링과 관련해서 기획 & API 수정에 따라 페이지네이션 로직 수정 필요
-    lazy var eventPaginationManager = PaginationManager<QuestViewModelItem>(
-        size: 20,
-        threshold: 18,
-        loadPage: { [weak self] page in
-            guard let self = self else { return ([], 0) }
-            return await loadQuestListWithImage(page: page, size: 20, status: .event)
-        }
-    )
-    
-    lazy var completedPaginationManager = PaginationManager<QuestViewModelItem>(
-        size: 10,
-        threshold: 8,
-        loadPage: { [weak self] page in
-            guard let self = self else { return ([], 0) }
-            return await loadQuestListWithImage(page: page, size: 10, status: .completed)
-        }
-    )
+    // TODO: 페이지네이션 로직 수정 필요
+    let defaultPaginationManager: PaginationManager<QuestViewModelItem>
+    let repeatPaginationManager: PaginationManager<QuestViewModelItem>
+    let eventPaginationManager: PaginationManager<QuestViewModelItem>
+    let completedPaginationManager: PaginationManager<QuestViewModelItem>
     
     // MARK: throttle 관련
     let throttleInterval: TimeInterval = 2.0
     var lastRefreshTime: Date? = nil
     
     private let questRepository: QuestRepositoryInterface
-    let areaRepository: AreaRepositoryInterface
     private let favoriteService: FavoriteService
-    let sharedState: SharedState
+    private let sharedState: SharedState
+        
     private var cancellables = Set<AnyCancellable>()
     
-    init(questRepository: QuestRepositoryInterface, areaRepository: AreaRepositoryInterface, favoriteService: FavoriteService, sharedState: SharedState) {
+    init(
+        questRepository: QuestRepositoryInterface,
+        favoriteService: FavoriteService,
+        sharedState: SharedState
+    ) {
         self.questRepository = questRepository
-        self.areaRepository = areaRepository
         self.favoriteService = favoriteService
+        self.sharedState = sharedState
         
-        // 필터 설정
         questFilterState = StaticFilterPickerState<QuestFilterType>(initialValue: .popular)
         eventFilterState = StaticFilterPickerState<EventQuestFilterType>(initialValue: .popular)
         repeatFilterState = StaticFilterPickerState<RepeatType>(initialValue: .daily)
         
-        self.sharedState = sharedState
-
+        self.defaultPaginationManager = PaginationManager(size: 20, threshold: 18)
+        self.repeatPaginationManager = PaginationManager(size: 20, threshold: 18)
+        self.eventPaginationManager = PaginationManager(size: 20, threshold: 18)
+        self.completedPaginationManager = PaginationManager(size: 20, threshold: 18)
+        self.defaultPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await self.loadQuestListWithImage(page: page, size: 20, status: .default)
+        }
+        self.repeatPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await self.loadQuestListWithImage(page: page, size: 20, status: .repeat)
+        }
+        self.eventPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await self.loadQuestListWithImage(page: page, size: 20, status: .event)
+        }
+        self.completedPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await self.loadQuestListWithImage(page: page, size: 10, status: .completed)
+        }
+        
         questFilterState.onSelectionChange = { [weak self] _ in
             guard let self = self else { return }
             switch selectedHeader {
@@ -154,6 +121,11 @@ class QuestViewModel: ObservableObject {
             Task { await self.repeatPaginationManager.loadData(isRefreshing: true) }
         }
         
+        Task { await setupBindings() }
+    }
+    
+    @MainActor
+    private func setupBindings() {
         sharedState.$selectedCommercialArea
             .removeDuplicates()
             .dropFirst()
@@ -161,6 +133,26 @@ class QuestViewModel: ObservableObject {
                 Task { await self?.loadInitialData() }
             }
             .store(in: &cancellables)
+        
+//        questRouter.$showSubmitRouter
+//            .removeDuplicates()
+//            .dropFirst()
+//            .sink { [weak self] isPresented in
+//                if !isPresented {
+//                    Task { await self?.loadInitialData() }
+//                }
+//            }
+//            .store(in: &cancellables)
+//        
+//        questRouter.$showQuestEngage
+//            .removeDuplicates()
+//            .dropFirst()
+//            .sink { [weak self] isPresented in
+//                if !isPresented {
+//                    Task { await self?.loadInitialData() }
+//                }
+//            }
+//            .store(in: &cancellables)
     }
     
     func loadDataIfNeeded() async {
@@ -362,50 +354,14 @@ class QuestViewModel: ObservableObject {
         }
     }
     
-    func onQuestTapped(quest: QuestViewModelItem) {
-        AnalyticsService.logEvent(.questItemClick(questId: quest.id, questType: quest.questType?.rawValue.uppercased() ?? ""))
-        selectedQuest = quest
-        Task {
-            let questDetail = try await questRepository.getQuestDetail(questId: quest.id)
-                .get()
-                .toQuestItem()
-            
-            if let imageId = questDetail.imageId {
-                questDetail.image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
-            }
-            await MainActor.run {
-                self.selectedQuest = questDetail
-            }
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now()+0.3) {
-            self.showQuestSheet = true
-        }
-    }
-    
     func handleMyRegionSelection(_ area: CommercialArea) {
         sharedState.selectedCommercialArea = area
         self.alertType = .myRegionChangeSuccess
     }
     
-    
     /// 즐겨찾기 상태를 UI에 즉시 반영하고,  서버 반영은 디바운싱 처리
     func toggleFavoriteStatus(quest: QuestViewModelItem) {
         favoriteService.toggle(quest: quest)
-    }
-    
-    func onQuestApprovalTapped() {
-        showQuestSheet = false
-        if selectedQuest.missionType == .photo {
-            showSubmitRouterView = true
-        } else {
-            showQuestEngageView = true
-        }
-    }
-    
-    func onChallengeExImageTapped() {
-        showQuestSheet = false
-        showChallengeImageView = true
     }
     
     func closeFilterPicker() {

--- a/ILSANG/Sources/Views/Ranking/RankingDetailView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingDetailView.swift
@@ -9,12 +9,13 @@ import SwiftUI
 
 struct RankingDetailView: View {
     @StateObject var vm: RankingDetailViewModel
+    @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
-    @EnvironmentObject private var seasonManager: SeasonManager
     @Environment(\.dismiss) var dismiss
     
     init(vm: RankingDetailViewModel) {
         _vm = StateObject(wrappedValue: vm)
+        _userRouter = StateObject(wrappedValue: UserRouter())
     }
     
     var body: some View {
@@ -37,14 +38,15 @@ struct RankingDetailView: View {
                         RankingItemView(style: .currentUserRank(user))
                     }
                     ForEach(vm.areaUserRank.ranks, id: \.userId) { rank in
-                        NavigationLink {
-                            OtherUserProfileView(
-                                userId: rank.userId,
-                                userRepository: dependencies.userRepository,
-                                missionHistoryRepository: dependencies.missionHistoryRepository,
-                                areaNameService: dependencies.areaNameService,
-                                seasonManager: seasonManager
-                            )
+                        Button {
+                            userRouter.navigateToUserProfile(userId: rank.userId)
+//                            OtherUserProfileView(
+//                                userId: rank.userId,
+//                                userRepository: dependencies.userRepository,
+//                                missionHistoryRepository: dependencies.missionHistoryRepository,
+//                                areaNameService: dependencies.areaNameService,
+//                                seasonManager: seasonManager
+//                            )
                         } label: {
                             RankingItemView(style: .userRank(rank))
                         }
@@ -54,8 +56,9 @@ struct RankingDetailView: View {
             }
             .padding(.top, 8)
         }
+        .withUserNavigation(userRouter: userRouter)
         .overlay(alignment: .bottom) {
-            if let currentSeason = seasonManager.currentSeason,
+            if let currentSeason = dependencies.seasonManager.currentSeason,
             let targetDate = currentSeason.endDate.toISO8601Date() {
                 SeasonTimerView(season: currentSeason.seasonNumber, targetDate: targetDate)
                     .padding(.horizontal, 20)

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -8,20 +8,27 @@
 import SwiftUI
 
 struct RankingView: View {
-    @ObservedObject var vm: RankingViewModel
+    @StateObject var vm: RankingViewModel
+    @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
-    @EnvironmentObject private var seasonManager: SeasonManager
     @EnvironmentObject var sharedState: SharedState
     
     @State private var isRefreshing = false
    
+    init(
+        vm: RankingViewModel,
+    ) {
+        _vm = StateObject(wrappedValue: vm)
+        _userRouter = StateObject(wrappedValue: UserRouter())
+    }
+    
     var body: some View {
         VStack(spacing: 0) {
             Spacer().frame(height: 94) // 고정 영역
             
             ScrollView {
                 VStack(spacing: 0) {
-                    if let currentSeason = seasonManager.currentSeason {
+                    if let currentSeason = vm.seasonManager.currentSeason {
                         seasonBannerView(season: currentSeason)
                     }
                     
@@ -56,8 +63,9 @@ struct RankingView: View {
                     .frame(height: 200)
             }
         }
+        .withUserNavigation(userRouter: userRouter)
         .overlay(alignment: .bottom) {
-            if let currentSeason = seasonManager.currentSeason,
+            if let currentSeason = vm.seasonManager.currentSeason,
             let targetDate = currentSeason.endDate.toISO8601Date() {
                 SeasonTimerView(season: currentSeason.seasonNumber, targetDate: targetDate)
                     .padding(.horizontal, 20)
@@ -255,14 +263,15 @@ extension RankingView {
                 }
             case .contribution:
                 ForEach(vm.contributionRank, id: \.userId) { rank in
-                    NavigationLink {
-                        OtherUserProfileView(
-                            userId: rank.userId,
-                            userRepository: dependencies.userRepository,
-                            missionHistoryRepository: dependencies.missionHistoryRepository,
-                            areaNameService: dependencies.areaNameService,
-                            seasonManager: seasonManager
-                        )
+                    Button {
+                        userRouter.navigateToUserProfile(userId: rank.userId)
+//                        OtherUserProfileView(
+//                            userId: rank.userId,
+//                            userRepository: dependencies.userRepository,
+//                            missionHistoryRepository: dependencies.missionHistoryRepository,
+//                            areaNameService: dependencies.areaNameService,
+//                            seasonManager: seasonManager
+//                        )
                     } label: {
                         RankingItemView(style: .userRank(rank))
                     }
@@ -325,7 +334,7 @@ extension RankingView {
     RankingView(
         vm: RankingViewModel(
             rankRepository: RankRepository(network: RankNetwork()),
-            userRepository: UserRepository(network: UserNetwork()), areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
+            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
             seasonManager: SeasonManager(
                 seasonNetwork: SeasonNetwork()
             )

--- a/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
@@ -33,17 +33,15 @@ class RankingViewModel: ObservableObject {
     
     @Published var seasons: [Season] = []
     
-    let rankRepository: RankRepositoryInterface
-    let userRepository: UserRepositoryInterface
-    let areaNameService: AreaNameProvider
-    private let seasonManager: SeasonManager
+    private let rankRepository: RankRepositoryInterface
+    private let areaNameService: AreaNameProvider
+    let seasonManager: SeasonManager
     
     private var currentLoadTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
     
-    init(rankRepository: RankRepositoryInterface, userRepository: UserRepositoryInterface, areaNameService: AreaNameProvider, seasonManager: SeasonManager)  {
+    init(rankRepository: RankRepositoryInterface, areaNameService: AreaNameProvider, seasonManager: SeasonManager)  {
         self.rankRepository = rankRepository
-        self.userRepository = userRepository
         self.areaNameService = areaNameService
         self.seasonManager = seasonManager
         

--- a/ILSANG/Sources/Views/Router/AppDependencies.swift
+++ b/ILSANG/Sources/Views/Router/AppDependencies.swift
@@ -32,10 +32,12 @@ class AppDependencies: ObservableObject {
     let bannerRepository: BannerRepository
     
     // MARK: - Services
+    let illsangZoneManager: IllsangZoneManager
     let areaNameService: AreaNameProvider
-    // let seasonManager: SeasonManager
+    let seasonManager: SeasonManager
     let imageChallengeSubmitService: ImageChallengeSubmitService
     let favoriteService: FavoriteService
+    let honorAcquisitionManager: HonorAcquisitionManager
     
     init() {
         // Networks
@@ -62,11 +64,10 @@ class AppDependencies: ObservableObject {
         
         // Services
         self.areaNameService = AreaNameService(areaRepository: areaRepository)
-        // self.seasonManager = SeasonManager(seasonNetwork: seasonNetwork)
-        self.imageChallengeSubmitService = ImageChallengeSubmitService(
-            imageNetwork: imageNetwork,
-            challengeNetwork: challengeNetwork
-        )
+        self.seasonManager = SeasonManager(seasonNetwork: seasonNetwork)
+        self.illsangZoneManager = IllsangZoneManager(areaNameService: areaNameService, seasonManager: seasonManager)
+        self.imageChallengeSubmitService = ImageChallengeSubmitService(imageNetwork: imageNetwork, challengeNetwork: challengeNetwork)
         self.favoriteService = FavoriteService(favoriteNetwork: favoriteNetwork)
+        self.honorAcquisitionManager = HonorAcquisitionManager(honorNetwork: honorNetwork)
     }
 }

--- a/ILSANG/Sources/Views/Router/MainTabView.swift
+++ b/ILSANG/Sources/Views/Router/MainTabView.swift
@@ -10,22 +10,12 @@ import SwiftUI
 struct MainTabView: View {
     @StateObject var dependencies = AppDependencies()
     @StateObject var sharedState = SharedState()
-    @StateObject var honorAcquisitionManager = HonorAcquisitionManager(honorNetwork: defaultHonorNetwork)
-    @StateObject var seasonManager: SeasonManager // TODO: AppDependencies에 통합
-
+    
     @State var homeViewModel: HomeViewModel
-    @StateObject var questViewModel: QuestViewModel
-    var approvalViewModel: ApprovalViewModel
+    @State var questViewModel: QuestViewModel
+    @State var approvalViewModel: ApprovalViewModel
     @StateObject var rankViewModel: RankingViewModel
     @StateObject var myPageViewModel: MyPageViewModel
-    
-    static var defaultHonorNetwork: HonorNetworkProtocol {
-        return HonorNetwork() // MockHonorNetwork()
-    }
-    
-    static var defaultSeasonNetwork: SeasonNetworkProtocol {
-        return SeasonNetwork() // MockSeasonNetwork()
-    }
     
     init() {
         let dependencies = AppDependencies()
@@ -33,24 +23,19 @@ struct MainTabView: View {
         
         let sharedState = SharedState()
         _sharedState = StateObject(wrappedValue: sharedState)
-        
-        let seasonManager = SeasonManager(seasonNetwork: MainTabView.defaultSeasonNetwork)
-        _seasonManager = StateObject(wrappedValue: seasonManager)
-        
+
         self._homeViewModel = State(wrappedValue: HomeViewModel(
             userRepository: dependencies.userRepository,
             areaNameService: dependencies.areaNameService,
             questRepository: dependencies.questRepository,
             rankRepository: dependencies.rankRepository,
             bannerRepository: dependencies.bannerRepository,
-            areaRepository: dependencies.areaRepository,
             favoriteService: dependencies.favoriteService,
             sharedState: sharedState
         ))
         
-        self._questViewModel = StateObject(wrappedValue: QuestViewModel(
+        self._questViewModel = State(wrappedValue: QuestViewModel(
             questRepository: dependencies.questRepository,
-            areaRepository: dependencies.areaRepository,
             favoriteService: dependencies.favoriteService,
             sharedState: sharedState
         ))
@@ -58,7 +43,6 @@ struct MainTabView: View {
         self.approvalViewModel = ApprovalViewModel(
             approvalSource: .tab,
             emojiNetwork: dependencies.emojiNetwork,
-            userRepository: dependencies.userRepository,
             missionHistoryRepository: dependencies.missionHistoryRepository,
             areaNameService: dependencies.areaNameService
         )
@@ -67,9 +51,8 @@ struct MainTabView: View {
             wrappedValue:
                 RankingViewModel(
                     rankRepository: dependencies.rankRepository,
-                    userRepository: dependencies.userRepository,
                     areaNameService: dependencies.areaNameService,
-                    seasonManager: seasonManager
+                    seasonManager: dependencies.seasonManager
                 )
         )
         
@@ -78,7 +61,7 @@ struct MainTabView: View {
                 userRepository: dependencies.userRepository,
                 imageNetwork: dependencies.imageNetwork,
                 areaNameService: dependencies.areaNameService,
-                seasonManager: seasonManager
+                seasonManager: dependencies.seasonManager
             )
         )
     }
@@ -110,17 +93,16 @@ struct MainTabView: View {
         }
         .environmentObject(dependencies)
         .environmentObject(sharedState)
-        .environmentObject(honorAcquisitionManager)
-        .environmentObject(seasonManager)
+//        .environmentObject(dependencies.seasonManager)
     }
     
     @ViewBuilder
     func createTabView(for tab: Tab) -> some View {
         switch tab {
         case .home:
-            HomeView(vm: homeViewModel)
+            HomeView(vm: homeViewModel, questRepository: dependencies.questRepository, illsangZoneManager: dependencies.illsangZoneManager)
         case .quest:
-            QuestView(vm: questViewModel)
+            QuestView(vm: questViewModel, questRepository: dependencies.questRepository, illsangZoneManager: dependencies.illsangZoneManager)
         case .approval:
             ApprovalView(vm: approvalViewModel)
         case .ranking:

--- a/ILSANG/Sources/Views/Router/Quest/QuestNavigationSetup.swift
+++ b/ILSANG/Sources/Views/Router/Quest/QuestNavigationSetup.swift
@@ -1,0 +1,97 @@
+//
+//  QuestNavigationSetup.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/3/25.
+//
+
+
+import SwiftUI
+
+extension View {
+    func withQuestNavigation(questRouter: QuestRouter) -> some View {
+        self.modifier(QuestNavigationSetup(questRouter: questRouter))
+    }
+}
+
+struct QuestNavigationSetup: ViewModifier {
+    @ObservedObject var questRouter: QuestRouter
+    @EnvironmentObject var dependencies: AppDependencies
+    
+    func body(content: Content) -> some View {
+        content
+        // 퀘스트 상세 시트
+            .sheet(isPresented: $questRouter.showQuestSheet) {
+                let isTall = questRouter.selectedQuest.questType == .repeat || questRouter.selectedQuest.missionType == .photo
+                
+                QuestDetailView(
+                    vm: QuestDetailViewModel(
+                        quest: questRouter.selectedQuest,
+                        questRepository: dependencies.questRepository,
+                        onFavorite: { _ in questRouter.handleFavoriteToggle() }
+                    ),
+                    showQuestExImageAction: { questRouter.handleChallengeExImage() },
+                    questApproveAction: { questRouter.handleQuestApproval() }
+                )
+                .presentationCornerRadius(24)
+                .presentationDragIndicator(.hidden)
+                .presentationDetents([
+                    isTall ? .height(UISheetPresentationController.Detent.questDetailDetentHeightTall)
+                    : .height(UISheetPresentationController.Detent.questDetailDetentHeightShort)
+                ])
+            }
+        
+        // 도전내역 제출 라우터
+            .fullScreenCover(isPresented: $questRouter.showSubmitRouter) {
+                SubmitRouterView(
+                    selectedQuest: questRouter.selectedQuest,
+                    submitService: dependencies.imageChallengeSubmitService,
+                    challengeNetwork: dependencies.challengeNetwork
+                )
+                .interactiveDismissDisabled()
+            }
+        // 퀘스트 참여
+            .navigationDestination(isPresented: $questRouter.showQuestEngage) {
+                QuestEngageView(
+                    vm: QuestEngageViewModel(
+                        quest: questRouter.selectedQuest,
+                        challengeNetwork: dependencies.challengeNetwork
+                    ),
+                    submitVM: SubmitRouterViewModel(
+                        selectedImage: nil,
+                        selectedQuest: questRouter.selectedQuest,
+                        submitService: dependencies.imageChallengeSubmitService,
+                        challengeNetwork: dependencies.challengeNetwork
+                    )
+                )
+            }
+        // 도전내역 상세
+            .navigationDestination(isPresented: $questRouter.showChallengeImage) {
+                ApprovalDetailView(missionId: questRouter.selectedQuest.missionId)
+            }
+        // 일상존 선택
+            .navigationDestination(isPresented: $questRouter.showIllsangZoneSelection) {
+                IllsangZoneSelectionView(
+                    userRepository: dependencies.userRepository,
+                    areaRepository: dependencies.areaRepository
+                ) { area in
+                    questRouter.handleIllsangZoneSelection(area)
+                }
+                .environmentObject(dependencies)
+            }
+        
+        // 일상존 알럿
+            .overlay(
+                Group {
+                    if let alertType = questRouter.alertType {
+                        IllsangZoneAlertView(
+                            alertType: alertType,
+                            isNeverShowSelected: $questRouter.isNeverShowAlertSelected,
+                            onCancel: { questRouter.handleAlertCancel() },
+                            onConfirm: { questRouter.handleAlertConfirm() }
+                        )
+                    }
+                }
+            )
+    }
+}

--- a/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
+++ b/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
@@ -1,0 +1,153 @@
+//
+//  QuestRouter.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/3/25.
+//
+
+
+import SwiftUI
+
+@MainActor
+class QuestRouter: ObservableObject {
+    // States
+    @Published var showQuestSheet = false
+    @Published var showSubmitRouter = false
+    @Published var showQuestEngage = false
+    @Published var showChallengeImage = false
+    
+    // IllsangZone States
+    @Published var showIllsangZoneSelection = false
+    @Published var alertType: IllsangZoneAlertType?
+    @Published var isNeverShowAlertSelected = false
+    @Published var isQuestSheetPending: Bool = false
+    
+    // Data
+    @Published var selectedQuest: QuestViewModelItem = .mockData
+    
+    // Dependencies
+    private let illsangZoneManager: IllsangZoneManager
+    private let questRepository: QuestRepositoryInterface
+    
+    // Callbacks
+    private var onFavoriteToggle: ((QuestViewModelItem) -> Void)?
+    
+    init(illsangZoneManager: IllsangZoneManager, questRepository: QuestRepositoryInterface) {
+        self.illsangZoneManager = illsangZoneManager
+        self.questRepository = questRepository
+    }
+    
+    // Navigation Methods
+    func presentQuestDetail(
+        quest: QuestViewModelItem,
+        onFavoriteToggle: @escaping (QuestViewModelItem) -> Void
+    ) {
+        self.onFavoriteToggle = onFavoriteToggle
+        self.selectedQuest = quest  // 임시 데이터 세팅
+        
+        // 퀘스트 상세 정보 로드
+        Task {
+            do {
+                let questDetail = try await questRepository.getQuestDetail(questId: quest.id).get().toQuestItem()
+                if let imageId = questDetail.imageId {
+                    questDetail.image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+                }
+                self.selectedQuest = questDetail
+                
+                // 일상존 체크 후 시트 표시
+                self.checkIllsangZoneAndPresentSheet()
+            } catch {
+                Log("퀘스트 상세 정보 로드 실패: \(error)")
+            }
+        }
+    }
+    
+    private func checkIllsangZoneAndPresentSheet() {
+        if !illsangZoneManager.isZoneSelected() && illsangZoneManager.shouldShowWarning {
+            isQuestSheetPending = true
+            alertType = .illsangZoneNotSelected
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                self.showQuestSheet = true
+            }
+        }
+    }
+    
+    func handleQuestApproval() {
+        showQuestSheet = false
+        
+        if selectedQuest.missionType == .photo {
+            showSubmitRouter = true
+        } else {
+            showQuestEngage = true
+        }
+    }
+    
+    func handleChallengeExImage() {
+        showQuestSheet = false
+        showChallengeImage = true
+    }
+    
+    func handleFavoriteToggle() {
+        onFavoriteToggle?(selectedQuest)
+    }
+    
+    // MARK: - IllsangZone Navigation Methods
+    func handleIllsangZoneButtonTap() {
+        if illsangZoneManager.canChangeZone() {
+            showIllsangZoneSelection = true
+        } else {
+            alertType = .illsangZoneChangeNotAllowed
+        }
+    }
+    
+    func handleIllsangZoneSelection(_ area: CommercialArea) {
+        illsangZoneManager.setZone(area)
+        showIllsangZoneSelection = false
+        alertType = .illsangZoneSetSuccess
+    }
+    
+    // MARK: - Alert Handling
+    func handleAlertCancel() {
+        switch alertType {
+        case .illsangZoneNotSelected:
+            if isNeverShowAlertSelected {
+                illsangZoneManager.saveDontShowPreference()
+            }
+            if isQuestSheetPending {
+                isQuestSheetPending = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.showQuestSheet = true
+                }
+            }
+        default:
+            break
+        }
+        dismissAlert()
+    }
+    
+    func handleAlertConfirm() {
+        switch alertType {
+        case .illsangZoneNotSelected:
+            if isNeverShowAlertSelected {
+                illsangZoneManager.saveDontShowPreference()
+            }
+            showIllsangZoneSelection = true
+        case .illsangZoneSetSuccess:
+            if isQuestSheetPending {
+                isQuestSheetPending = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.showQuestSheet = true
+                }
+            }
+        default:
+            break
+        }
+        dismissAlert()
+    }
+    
+    func dismissAlert() {
+        alertType = nil
+        isNeverShowAlertSelected = false
+    }
+}

--- a/ILSANG/Sources/Views/Router/User/UserNavigationSetup.swift
+++ b/ILSANG/Sources/Views/Router/User/UserNavigationSetup.swift
@@ -1,0 +1,36 @@
+//
+//  UserNavigationSetup.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/3/25.
+//
+
+
+import SwiftUI
+
+extension View {
+    func withUserNavigation(userRouter: UserRouter) -> some View {
+        self.modifier(UserNavigationSetup(userRouter: userRouter))
+    }
+}
+
+struct UserNavigationSetup: ViewModifier {
+    @ObservedObject var userRouter: UserRouter
+    @EnvironmentObject var dependencies: AppDependencies
+    
+    func body(content: Content) -> some View {
+        content
+            .navigationDestination(isPresented: $userRouter.showUserProfile) {
+                if let userId = userRouter.selectedUserId {
+                    OtherUserProfileView(
+                        userId: userId,
+                        userRepository: dependencies.userRepository,
+                        missionHistoryRepository: dependencies.missionHistoryRepository,
+                        areaNameService: dependencies.areaNameService,
+                        seasonManager: dependencies.seasonManager
+                    )
+                    .environmentObject(dependencies)
+                }
+            }
+    }
+}

--- a/ILSANG/Sources/Views/Router/User/UserRouter.swift
+++ b/ILSANG/Sources/Views/Router/User/UserRouter.swift
@@ -1,0 +1,20 @@
+//
+//  UserRouter.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/3/25.
+//
+
+
+import SwiftUI
+
+@MainActor
+class UserRouter: ObservableObject {
+    @Published var showUserProfile = false
+    @Published var selectedUserId: String?
+    
+    func navigateToUserProfile(userId: String) {
+        selectedUserId = userId
+        showUserProfile = true
+    }
+}

--- a/ILSANG/Sources/Views/Setting/Component/SettingAlertView.swift
+++ b/ILSANG/Sources/Views/Setting/Component/SettingAlertView.swift
@@ -7,15 +7,23 @@
 
 import SwiftUI
 
+protocol AlertPresentable {
+    var title: String { get }
+    var subtitle: String? { get }
+    var disagree: String { get }
+    var agree: String { get }
+    var titleColor: Color { get }
+    var icon: UIImage? { get }
+}
+
 struct SettingAlertView<Content: View>: View {
-    
-    let alertType: AlertType
+    let alertType: AlertPresentable
     var onCancel: (() -> Void)? = nil
     var onConfirm: (() -> Void)? = nil
     let content: Content
     
     init(
-        alertType: AlertType,
+        alertType: AlertPresentable,
         onCancel: (() -> Void)? = nil,
         onConfirm: (() -> Void)? = nil,
         @ViewBuilder content: () -> Content = { EmptyView() }
@@ -83,19 +91,70 @@ struct SettingAlertView<Content: View>: View {
     }
 }
 
-enum AlertType {
+enum IllsangZoneAlertType: AlertPresentable {
+    case illsangZoneSetWarning
+    case illsangZoneSetSuccess
+    case illsangZoneSetFailed
+    case illsangZoneNotSelected
+    case illsangZoneChangeNotAllowed
+    var title: String {
+        switch self {
+        
+        case .illsangZoneSetWarning: "한 번 선택한 일상존은 시즌 중에는\n변경이 불가합니다"
+        case .illsangZoneSetSuccess: "일상존이 설정되었습니다"
+        case .illsangZoneSetFailed: "일상존 변경에 실패했습니다"
+        case .illsangZoneNotSelected: "일상존이 선택되지 않았어요"
+        case .illsangZoneChangeNotAllowed: "내 일상존은 시즌 중에는\n변경이 불가합니다"
+        }
+    }
+    var subtitle: String? {
+        switch self {
+        case .illsangZoneSetWarning: nil
+        case .illsangZoneSetSuccess: "퀘스트를 수행하러 가 볼까요?"
+        case .illsangZoneSetFailed: "다시 한번 시도해 주세요"
+        case .illsangZoneNotSelected: "일상존을 선택하고 퀘스트를 수행하면\n기여도 포인트를 2배나 받을 수 있어요!"
+        case .illsangZoneChangeNotAllowed: nil
+        }
+    }
+    
+    var disagree: String {
+        switch self {
+        case .illsangZoneSetWarning, .illsangZoneNotSelected:
+            "취소"
+        default:
+            ""
+        }
+    }
+    var agree: String {
+        switch self {
+        case .illsangZoneNotSelected:
+            "일상존 선택하기"
+        default:
+            "확인"
+        }
+    }
+    var titleColor: Color {
+        switch self {
+        case .illsangZoneSetWarning: .accentRed
+        default: .black
+        }
+    }
+    
+    var icon: UIImage? {
+        switch self {
+        case .illsangZoneSetFailed: .retry
+        default: nil
+        }
+    }
+}
+
+enum AlertType: AlertPresentable {
     case CancleEditProfile
     case DeleteProfileImage
     case Logout
     case Withdrawal
     case Report
     case ChallengeDelete
-    
-    case illsangZoneSetWarning
-    case illsangZoneSetSuccess
-    case illsangZoneSetFailed
-    case illsangZoneNotSelected
-    case illsangZoneChangeNotAllowed
 
     case myRegionChangeSuccess
     
@@ -113,11 +172,6 @@ enum AlertType {
             "신고하시겠습니까?"
         case .ChallengeDelete:
             "챌린지를 삭제 할까요?"
-        case .illsangZoneSetWarning: "한 번 선택한 일상존은 시즌 중에는\n변경이 불가합니다"
-        case .illsangZoneSetSuccess: "일상존이 설정되었습니다"
-        case .illsangZoneSetFailed: "일상존 변경에 실패했습니다"
-        case .illsangZoneNotSelected: "일상존이 선택되지 않았어요"
-        case .illsangZoneChangeNotAllowed: "내 일상존은 시즌 중에는\n변경이 불가합니다"
         case .myRegionChangeSuccess: "내 지역이 설정되었습니다"
         }
     }
@@ -136,18 +190,13 @@ enum AlertType {
             "확인 후 빠른 시일 내 조치하도록 하겠습니다"
         case .ChallengeDelete:
             "삭제하면 복구가 불가합니다"
-        case .illsangZoneSetWarning: nil
-        case .illsangZoneSetSuccess: "퀘스트를 수행하러 가 볼까요?"
-        case .illsangZoneSetFailed: "다시 한번 시도해 주세요"
-        case .illsangZoneNotSelected: "일상존을 선택하고 퀘스트를 수행하면\n기여도 포인트를 2배나 받을 수 있어요!"
-        case .illsangZoneChangeNotAllowed: nil
         case .myRegionChangeSuccess: "퀘스트를 수행하러 가 볼까요?"
         }
     }
     
     var disagree: String {
         switch self {
-        case .CancleEditProfile, .DeleteProfileImage, .Withdrawal, .Report, .ChallengeDelete, .illsangZoneSetWarning, .illsangZoneNotSelected:
+        case .CancleEditProfile, .DeleteProfileImage, .Withdrawal, .Report, .ChallengeDelete:
             "취소"
         case .Logout:
             "아니요"
@@ -160,34 +209,26 @@ enum AlertType {
         switch self {
         case .Logout:
             "예"
-        case .illsangZoneNotSelected:
-            "일상존 선택하기"
         default:
             "확인"
         }
     }
     
     var titleColor: Color {
-        switch self {
-        case .illsangZoneSetWarning: .accentRed
-        default: .black
-        }
+        .black
     }
     
     var icon: UIImage? {
-        switch self {
-        case .illsangZoneSetFailed: .retry
-        default: nil
-        }
+        nil
     }
 }
 
 #Preview {
     VStack{
-        SettingAlertView(alertType: .Logout,onCancel: {print("Yes")},onConfirm: {print("NO")})
-        SettingAlertView(alertType: .CancleEditProfile,onCancel: {print("Yes")},onConfirm: {print("NO")})
-        SettingAlertView(alertType: .DeleteProfileImage,onCancel: {print("Yes")},onConfirm: {print("NO")})
-        SettingAlertView(alertType: .Withdrawal,onCancel: {print("Yes")},onConfirm: {print("NO")})
-        SettingAlertView(alertType: .ChallengeDelete,onCancel: {print("Yes")},onConfirm: {print("NO")})
+        SettingAlertView(alertType: AlertType.Logout, onCancel: {print("Yes")},onConfirm: {print("NO")})
+        SettingAlertView(alertType: AlertType.CancleEditProfile,onCancel: {print("Yes")},onConfirm: {print("NO")})
+        SettingAlertView(alertType: AlertType.DeleteProfileImage,onCancel: {print("Yes")},onConfirm: {print("NO")})
+        SettingAlertView(alertType: AlertType.Withdrawal,onCancel: {print("Yes")},onConfirm: {print("NO")})
+        SettingAlertView(alertType: AlertType.ChallengeDelete,onCancel: {print("Yes")},onConfirm: {print("NO")})
     }
 }

--- a/ILSANG/Sources/Views/Setting/DeleteAccountView.swift
+++ b/ILSANG/Sources/Views/Setting/DeleteAccountView.swift
@@ -100,7 +100,7 @@ struct DeleteAccountView: View {
             
             if delAlert {
                 SettingAlertView(
-                    alertType: .Withdrawal,
+                    alertType: AlertType.Withdrawal,
                     onCancel: { delAlert = false },
                     onConfirm: { withdraw() }
                 )

--- a/ILSANG/Sources/Views/Setting/SettingView.swift
+++ b/ILSANG/Sources/Views/Setting/SettingView.swift
@@ -58,7 +58,7 @@ struct SettingView: View {
         .overlay {
             if logoutAlert {
                 SettingAlertView(
-                    alertType: .Logout,
+                    alertType: AlertType.Logout,
                     onCancel: { logoutAlert = false },
                     onConfirm: { logout() }
                 )


### PR DESCRIPTION
#### close #363

### ✏️ 개요
화면 전환 로직을 모듈화하여 구조적 일관성과 확장성을 확보합니다.

### 💻 작업 사항
- 퀘스트/유저 관련 화면 전환 흐름에 존재하던 중복 로직을 Router로 통합
- 기존 View 내부의 전환 처리 코드를 제거하고, 모듈화된 라우터로 대체 (홈/퀘스트/인증/랭킹 화면)
- SettingAlert 분리