### PR TITLE
[Fix/#433] Combine 구독 및 AppDependencies 재생성 개선

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -1677,7 +1677,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Source Root: ${SRCROOT}\"\n\ncase \"${CONFIGURATION}\" in\n  \"Debug\" )\ncp -r \"$SRCROOT/${PROJECT_NAME}/Resources/FirebaseConfig/Release/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\" ;;\n  \"Staging\" )\ncp -r \"$SRCROOT/${PROJECT_NAME}/Resources/FirebaseConfig/Staging/GoogleService-Info-dev.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\" ;;\n  \"Release\" )\ncp -r \"$SRCROOT/${PROJECT_NAME}/Resources/FirebaseConfig/Release/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\" ;;\n*)\n;;\nesac\n";
+			shellScript = "echo \"Source Root: ${SRCROOT}\"\n\ncase \"${CONFIGURATION}\" in\n  \"Debug\" )\ncp -r \"$SRCROOT/${PROJECT_NAME}/Resources/FirebaseConfig/Debug/GoogleService-Info-dev.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\" ;;\n  \"Staging\" )\ncp -r \"$SRCROOT/${PROJECT_NAME}/Resources/FirebaseConfig/Staging/GoogleService-Info-dev.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\" ;;\n  \"Release\" )\ncp -r \"$SRCROOT/${PROJECT_NAME}/Resources/FirebaseConfig/Release/GoogleService-Info.plist\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\" ;;\n*)\n;;\nesac\n";
 		};
 		609169E02DFE976000A34D4F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ILSANG/Sources/Manager/IllsangZoneManager.swift
+++ b/ILSANG/Sources/Manager/IllsangZoneManager.swift
@@ -26,6 +26,7 @@ class IllsangZoneManager: ObservableObject {
         
         // 시즌 변경 시 currentSeason 업데이트
         seasonManager.$currentSeason
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newSeason in
                 self?.currentSeason = newSeason

--- a/ILSANG/Sources/Views/ILSANGApp.swift
+++ b/ILSANG/Sources/Views/ILSANGApp.swift
@@ -35,7 +35,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct ILSANGApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-
+    @StateObject private var dependencies = AppDependencies()
+    @StateObject private var sharedState = SharedState()
     @AppStorage("isLogin") var isLogin = Bool()
     
     @State private var isTutorialVisible = Bool()
@@ -59,6 +60,8 @@ struct ILSANGApp: App {
                     LoginView(vm: LoginViewModel())
                 } else {
                     MainTabView()
+                        .environmentObject(dependencies)
+                        .environmentObject(sharedState)
                         .fullScreenCover(isPresented: $isTutorialVisible) {
                             TutorialView()
                         }
@@ -88,6 +91,7 @@ struct ILSANGApp: App {
             .onChange(of: isLogin, { _, newValue in // 로그인 후 튜토리얼 UI 표시
                 if newValue {
                     isTutorialVisible = true
+                    Task { await dependencies.seasonManager.fetchSeasons() }
                 }
             })
             .task {

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -8,9 +8,15 @@
 import SwiftUI
 
 struct MyPageView: View {
-    @ObservedObject var vm: MyPageViewModel
+    @StateObject var vm: MyPageViewModel
     @EnvironmentObject var dependencies: AppDependencies
     @EnvironmentObject var sharedState: SharedState
+    
+    init(
+        vm: MyPageViewModel
+    ) {
+        _vm = StateObject(wrappedValue: vm)
+    }
     
     var body: some View {
         VStack(spacing: 0) {

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -79,14 +79,17 @@ final class MyPageViewModel: ObservableObject {
         selectedSeasonNumber = seasonManager.currentSeason?.seasonNumber ?? -1 // 현재시즌으로 초기화
         
         currentSeason = seasonManager.currentSeason ?? nil
-        
         seasonManager.$currentSeason
+            .dropFirst()
+            .removeDuplicates()
             .sink { [weak self] season in
                 guard let self else { return }
                 self.currentSeason = season
             }
             .store(in: &cancellables)
         seasonManager.$seasons
+            .dropFirst()
+            .removeDuplicates()
             .sink { [weak self] seasons in
                 guard let self else { return }
                 self.updateSeasonsFromServer(seasons.map { $0.seasonNumber })

--- a/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
@@ -47,6 +47,7 @@ class RankingViewModel: ObservableObject {
         
         selectedSeason = seasonManager.currentSeason ?? nil // 현재시즌으로 초기화
         seasonManager.$seasons
+            .removeDuplicates()
             .sink { [weak self] seasons in
                 guard let self else { return }
                 self.seasons = seasons
@@ -54,6 +55,7 @@ class RankingViewModel: ObservableObject {
             .store(in: &cancellables)
         
         seasonManager.$currentSeason
+            .removeDuplicates()
             .sink { [weak self] season in
                 guard let self else { return }
                 self.selectedSeason = season

--- a/ILSANG/Sources/Views/Router/MainTabView.swift
+++ b/ILSANG/Sources/Views/Router/MainTabView.swift
@@ -8,63 +8,8 @@
 import SwiftUI
 
 struct MainTabView: View {
-    @StateObject var dependencies = AppDependencies()
-    @StateObject var sharedState = SharedState()
-    
-    @State var homeViewModel: HomeViewModel
-    @State var questViewModel: QuestViewModel
-    @State var approvalViewModel: ApprovalViewModel
-    @StateObject var rankViewModel: RankingViewModel
-    @StateObject var myPageViewModel: MyPageViewModel
-    
-    init() {
-        let dependencies = AppDependencies()
-        _dependencies = StateObject(wrappedValue: dependencies)
-        
-        let sharedState = SharedState()
-        _sharedState = StateObject(wrappedValue: sharedState)
-
-        self._homeViewModel = State(wrappedValue: HomeViewModel(
-            userRepository: dependencies.userRepository,
-            areaNameService: dependencies.areaNameService,
-            questRepository: dependencies.questRepository,
-            rankRepository: dependencies.rankRepository,
-            bannerRepository: dependencies.bannerRepository,
-            favoriteService: dependencies.favoriteService,
-            sharedState: sharedState
-        ))
-        
-        self._questViewModel = State(wrappedValue: QuestViewModel(
-            questRepository: dependencies.questRepository,
-            favoriteService: dependencies.favoriteService,
-            sharedState: sharedState
-        ))
-        
-        self.approvalViewModel = ApprovalViewModel(
-            approvalSource: .tab,
-            emojiNetwork: dependencies.emojiNetwork,
-            missionHistoryRepository: dependencies.missionHistoryRepository,
-            areaNameService: dependencies.areaNameService
-        )
-        
-        self._rankViewModel = StateObject(
-            wrappedValue:
-                RankingViewModel(
-                    rankRepository: dependencies.rankRepository,
-                    areaNameService: dependencies.areaNameService,
-                    seasonManager: dependencies.seasonManager
-                )
-        )
-        
-        self._myPageViewModel = StateObject(
-            wrappedValue: MyPageViewModel(
-                userRepository: dependencies.userRepository,
-                imageNetwork: dependencies.imageNetwork,
-                areaNameService: dependencies.areaNameService,
-                seasonManager: dependencies.seasonManager
-            )
-        )
-    }
+    @EnvironmentObject var dependencies: AppDependencies
+    @EnvironmentObject var sharedState: SharedState
     
     var body: some View {
         NavigationStack {
@@ -91,24 +36,65 @@ struct MainTabView: View {
                 }
             )
         }
-        .environmentObject(dependencies)
-        .environmentObject(sharedState)
-//        .environmentObject(dependencies.seasonManager)
     }
     
     @ViewBuilder
     func createTabView(for tab: Tab) -> some View {
         switch tab {
         case .home:
-            HomeView(vm: homeViewModel, questRepository: dependencies.questRepository, illsangZoneManager: dependencies.illsangZoneManager)
+            HomeView(
+                vm: HomeViewModel(
+                    userRepository: dependencies.userRepository,
+                    areaNameService: dependencies.areaNameService,
+                    questRepository: dependencies.questRepository,
+                    rankRepository: dependencies.rankRepository,
+                    bannerRepository: dependencies.bannerRepository,
+                    favoriteService: dependencies.favoriteService,
+                    sharedState: sharedState
+                ),
+                questRepository: dependencies.questRepository,
+                illsangZoneManager: dependencies.illsangZoneManager
+            )
+            
         case .quest:
-            QuestView(vm: questViewModel, questRepository: dependencies.questRepository, illsangZoneManager: dependencies.illsangZoneManager)
+            QuestView(
+                vm: QuestViewModel(
+                    questRepository: dependencies.questRepository,
+                    favoriteService: dependencies.favoriteService,
+                    sharedState: sharedState
+                ),
+                questRepository: dependencies.questRepository,
+                illsangZoneManager: dependencies.illsangZoneManager
+            )
+            
         case .approval:
-            ApprovalView(vm: approvalViewModel)
+            ApprovalView(
+                vm: ApprovalViewModel(
+                    approvalSource: .tab,
+                    emojiNetwork: dependencies.emojiNetwork,
+                    missionHistoryRepository: dependencies.missionHistoryRepository,
+                    areaNameService: dependencies.areaNameService
+                )
+            )
+            
         case .ranking:
-            RankingView(vm: rankViewModel)
+            RankingView(
+                vm: RankingViewModel(
+                    rankRepository: dependencies.rankRepository,
+                    areaNameService: dependencies.areaNameService,
+                    seasonManager: dependencies.seasonManager
+                )
+            )
+            
         case .mypage:
-            MyPageView(vm: myPageViewModel)
+            MyPageView(
+                vm: MyPageViewModel(
+                    userRepository: dependencies.userRepository,
+                    imageNetwork: dependencies.imageNetwork,
+                    areaNameService: dependencies.areaNameService,
+                    seasonManager: dependencies.seasonManager
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
#### close #433

### ✏️ 개요
앱이 백그라운드에서 포그라운드로 돌아올 때 MainTabView와 관련 뷰모델이 새로 초기화되면서 기존의 Combine 구독이 끊기고 AppDependencies가 재생성되는 현상 발생

### 💻 작업 사항
- 기존 MainTabView 내에서 생성하던 AppDependencies를 앱 전역에서 생성하도록 변경
- Combine 구독 중복 방지
- 서버 환경 분리 완료에 따른 Google Service Info(dev) 파일 로드 로직 수정
