### PR TITLE
[Feat/#437] 전체 랭킹, 전설 랭킹 프로필 이미지 적용

### DIFF
--- a/ILSANG/Sources/Views/Ranking/RankingItemView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingItemView.swift
@@ -173,7 +173,7 @@ fileprivate struct CurrentUserRankItemView: View {
 }
 
 fileprivate struct LegendRankItemView: View {
-    let rank: UserRankViewModelItem
+    @ObservedObject var rank: UserRankViewModelItem
     let createdTitleAt: String? = nil // TODO: API 추가 요청
     
     var body: some View {
@@ -221,7 +221,7 @@ fileprivate struct LegendRankItemView: View {
 }
 
 fileprivate struct TotalRankItemView: View {
-    let rank: UserRankViewModelItem
+    @ObservedObject var rank: UserRankViewModelItem
     
     var body: some View {
         VStack(spacing: 6) {


### PR DESCRIPTION
#### close #437

### ✏️ 개요
홈화면의 전체 랭킹과 전설 랭킹화면에 표시되는 사용자의 프로필 이미지가 바로 적용되도록 수정합니다.

### 💻 작업 사항
TotalRankItemView/LegendRankItemView에서 UserRankViewModelItem을 @ObservedObject로 선언하여 profileImage 변경 즉시 반영되도록 수정

### 📱결과 화면(optional)
<img width="393" alt="IMG_4776" src="https://github.com/user-attachments/assets/e6b9078f-b1b5-4b21-9073-cd6956d25710" />
