### PR TITLE
[Feat/#435] 즐겨찾기 화면: UI 및 API 연결, 퀘스트 수행 플로우 연결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -236,6 +236,8 @@
 		60B8BA022BF9EEF3005F6DE3 /* ILSANGUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8BA012BF9EEF3005F6DE3 /* ILSANGUITests.swift */; };
 		60B8BA042BF9EEF3005F6DE3 /* ILSANGUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8BA032BF9EEF3005F6DE3 /* ILSANGUITestsLaunchTests.swift */; };
 		60B8BA112BF9EF50005F6DE3 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60B8BA102BF9EF50005F6DE3 /* Launch Screen.storyboard */; };
+		60BDE2BE2E6C5EEF00968725 /* FavoriteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60BDE2BD2E6C5EEF00968725 /* FavoriteListView.swift */; };
+		60BDE2C02E6C5EFF00968725 /* FavoriteListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60BDE2BF2E6C5EFF00968725 /* FavoriteListViewModel.swift */; };
 		60C0F4242CCE9B2F00DB19AB /* UIDevice++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C0F4232CCE9B2F00DB19AB /* UIDevice++.swift */; };
 		60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4D42C2C565700926C0E /* ChallengeNetwork.swift */; };
 		60C6B4D72C2C569800926C0E /* Challenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4D62C2C569800926C0E /* Challenge.swift */; };
@@ -556,6 +558,8 @@
 		60B8BA032BF9EEF3005F6DE3 /* ILSANGUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANGUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		60B8BA102BF9EF50005F6DE3 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		60B8BA142BF9F354005F6DE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		60BDE2BD2E6C5EEF00968725 /* FavoriteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteListView.swift; sourceTree = "<group>"; };
+		60BDE2BF2E6C5EFF00968725 /* FavoriteListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteListViewModel.swift; sourceTree = "<group>"; };
 		60C0F4232CCE9B2F00DB19AB /* UIDevice++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice++.swift"; sourceTree = "<group>"; };
 		60C6B4D42C2C565700926C0E /* ChallengeNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeNetwork.swift; sourceTree = "<group>"; };
 		60C6B4D62C2C569800926C0E /* Challenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Challenge.swift; sourceTree = "<group>"; };
@@ -1080,6 +1084,7 @@
 				60299E2F2CBFF8D20039663F /* UserMissionHistory */,
 				6053345D2D3126F900599159 /* MyPageInfo */,
 				600657E22DBD2DD10022D117 /* MyPageHonor */,
+				60BDE2BC2E6C5EDA00968725 /* Favorite */,
 				606C3EF52E69F07B0050C4D6 /* Coupon */,
 			);
 			path = MyPage;
@@ -1290,6 +1295,15 @@
 				607FCBDE2BFA693F00BB2D04 /* Views */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		60BDE2BC2E6C5EDA00968725 /* Favorite */ = {
+			isa = PBXGroup;
+			children = (
+				60BDE2BD2E6C5EEF00968725 /* FavoriteListView.swift */,
+				60BDE2BF2E6C5EFF00968725 /* FavoriteListViewModel.swift */,
+			);
+			path = Favorite;
 			sourceTree = "<group>";
 		};
 		60C6B4DD2C2D046000926C0E /* Submit */ = {
@@ -1749,6 +1763,7 @@
 				6091976D2E5F8E9B00F1D81B /* UserMissionHistory.swift in Sources */,
 				6057361C2D8AC8A800CF7051 /* Quiz.swift in Sources */,
 				6053345F2D31272B00599159 /* MyPageInfoCardView.swift in Sources */,
+				60BDE2C02E6C5EFF00968725 /* FavoriteListViewModel.swift in Sources */,
 				60054FA02D931AA300E7C5A6 /* PDFKitView.swift in Sources */,
 				605DA0D62C07123400CC9450 /* View++.swift in Sources */,
 				60299E392CC13DEC0039663F /* ImageCacheService.swift in Sources */,
@@ -1839,6 +1854,7 @@
 				60D897292E537653006A8480 /* ApprovalMissionHistoryItem.swift in Sources */,
 				60943FE62C0A38FB00C8A714 /* ApprovalViewModel.swift in Sources */,
 				60C6B4DC2C2D042700926C0E /* Image.swift in Sources */,
+				60BDE2BE2E6C5EEF00968725 /* FavoriteListView.swift in Sources */,
 				6048D5252E4E632C00CC74F5 /* BannerDetailView.swift in Sources */,
 				A18EB9B02C26B61C00405D56 /* WithdrawNetwork.swift in Sources */,
 				606C3F032E69FCBC0050C4D6 /* CouponRepository.swift in Sources */,

--- a/ILSANG/Sources/Domain/Repository/QuestRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/QuestRepository.swift
@@ -12,6 +12,7 @@ protocol QuestRepositoryInterface {
     func getRepeatQuests(commercialAreaCode: String, repeatFrequency: RepeatType, orderRewardDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getEventQuests(commercialAreaCode: String, orderRewardDesc: Bool?, orderExpiredDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getCompletedQuests(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
+    func getFavoriteQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getRecommendQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getPopularQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getLargeRewardQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
@@ -42,6 +43,11 @@ final class QuestRepository: QuestRepositoryInterface {
     
     func getCompletedQuests(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
         let res = await network.getCompletedQuests(page: page, size: size)
+        return ResponseMapper.mapPagedResponse(res)
+    }
+    
+    func getFavoriteQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
+        let res = await network.getFavoriteQuests(commercialAreaCode: commercialAreaCode, page: page, size: size)
         return ResponseMapper.mapPagedResponse(res)
     }
     
@@ -130,6 +136,10 @@ final class MockQuestRepository: QuestRepositoryInterface {
     }
     
     func getCompletedQuests(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
+        .success(ResponseWithPage(size: size, content: mockQuests+mockRepeatQuests+mockEventQuests, totalPages: 1, totalElements: mockQuests.count, page: page, isLast: true))
+    }
+    
+    func getFavoriteQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, any Error> {
         .success(ResponseWithPage(size: size, content: mockQuests+mockRepeatQuests+mockEventQuests, totalPages: 1, totalElements: mockQuests.count, page: page, isLast: true))
     }
     

--- a/ILSANG/Sources/Network/QuestNetwork.swift
+++ b/ILSANG/Sources/Network/QuestNetwork.swift
@@ -76,6 +76,19 @@ final class QuestNetwork {
         return await getQuests(parameters: parameters)
     }
     
+    /// 즐겨찾기 퀘스트 조회
+    func getFavoriteQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[BaseQuestResponse]>, Error> {
+        let parameters: Parameters = [
+            "completedYn": false,
+            "favoriteYn": true,
+            "commercialAreaCode": commercialAreaCode,
+            "page": page,
+            "size": size
+        ]
+        
+        return await getQuests(parameters: parameters)
+    }
+    
     /// 퀘스트 유형별 조회
     private func getQuests(parameters: Parameters) async -> Result<ResponseWithPage<[BaseQuestResponse]>, Error> {
         return await Network.requestData(url: questUrl+"/search/type", method: .get, parameters: parameters)

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
@@ -86,7 +86,7 @@ extension FavoriteListView {
     }
     
     private var selectScopeView: some View {
-        RegionPickerView(title: sharedState.selectedCommercialArea.areaName) {
+        RegionPickerView(title: viewModel.selectedArea.areaName) {
             viewModel.showSelectRegionView = true
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
@@ -1,0 +1,170 @@
+//
+//  FavoriteListView.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/6/25.
+//
+
+import SwiftUI
+
+struct FavoriteListView: View {
+    @StateObject var viewModel: FavoriteListViewModel
+    @StateObject var questRouter: QuestRouter
+    @StateObject var userRouter: UserRouter
+    @EnvironmentObject var sharedState: SharedState
+    @EnvironmentObject var dependencies: AppDependencies
+    @Environment(\.dismiss) var dismiss
+    
+    init(
+        viewModel: FavoriteListViewModel,
+        questRepository: QuestRepositoryInterface,
+        illsangZoneManager: IllsangZoneManager
+    ) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        _questRouter = StateObject(
+            wrappedValue: QuestRouter(
+                illsangZoneManager: illsangZoneManager, questRepository: questRepository
+            )
+        )
+        _userRouter = StateObject(wrappedValue: UserRouter())
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            headerView
+            
+            VStack(spacing: 0) {
+                switch viewModel.viewStatus {
+                case .loading:
+                    selectScopeView
+                    ProgressView()
+                        .frame(maxHeight: .infinity, alignment: .center)
+                case .loaded:
+                    questListView
+                case .error:
+                    selectScopeView
+                    networkErrorView
+                }
+            }
+            .scrollDisabled(viewModel.viewStatus != .loaded || viewModel.quests.isEmpty)
+            .refreshable {
+                await viewModel.loadInitialData()
+            }
+        }
+        .background(Color.background)
+        .navigationBarBackButtonHidden()
+        .task {
+            await viewModel.loadDataIfNeeded()
+        }
+        .withQuestNavigation(questRouter: questRouter)
+        .withUserNavigation(userRouter: userRouter)
+        .onChange(of: questRouter.showQuestEngage, { oldValue, newValue in
+            if !newValue {
+                Task { await viewModel.loadInitialData() }
+            }
+        })
+        .onChange(of: questRouter.showSubmitRouter, { oldValue, newValue in
+            if !newValue {
+                Task { await viewModel.loadInitialData() }
+            }
+        })
+        // TODO: Destination으로 변경
+        .sheet(isPresented: $viewModel.showSelectRegionView) {
+            MyRegionAreaSelectionView(areaRepository: dependencies.areaRepository) { area in
+                viewModel.handleAreaSelection(area)
+            }
+        }
+    }
+}
+
+extension FavoriteListView {
+    private var headerView: some View {
+        NavigationTitleView(title: "즐겨찾기 퀘스트", isSeparatorHidden: true, background: .background) {
+            dismiss()
+        }
+        .padding(.bottom, 8)
+    }
+    
+    private var selectScopeView: some View {
+        RegionPickerView(title: sharedState.selectedCommercialArea.areaName) {
+            viewModel.showSelectRegionView = true
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 14)
+        .padding(.leading, 20)
+    }
+    
+    @ViewBuilder
+    private var questListView: some View {
+        if viewModel.quests.isEmpty {
+            selectScopeView
+            emptyView
+        } else {
+            ScrollView {
+                selectScopeView
+                
+                LazyVStack(spacing: 8) {
+                    ForEach(viewModel.quests, id: \.id) { quest in
+                        FavoriteQuestItemView(
+                            quest: quest,
+                            action: {
+                                AnalyticsService.logEvent(.questItemClick(questId: quest.id, questType: quest.questType?.rawValue.uppercased() ?? ""))
+                                questRouter.presentQuestDetail(quest: quest) { quest in
+                                    viewModel.toggleFavoriteStatus(quest: quest)
+                                }
+                            },
+                            favoriteAction: { viewModel.toggleFavoriteStatus(quest: quest) }
+                        )
+                    }
+                    
+                    if viewModel.paginationManager.canLoadMoreData() {
+                        ProgressView()
+                            .task { await viewModel.loadMoreData() }
+                    }
+                }
+                .padding(.top, 20)
+                .padding(.bottom, 72)
+            }
+        }
+    }
+    
+    private var emptyView: some View {
+        ErrorView(
+            title: "즐겨찾기한 퀘스트가 없어요",
+            subTitle: "관심 있는 지역의 퀘스트를\n즐겨찾기 해보세요!",
+            buttonTitle: "퀘스트 바로가기"
+        ) {
+            sharedState.selectedTab = .home
+            dismiss()
+        }
+    }
+    private var networkErrorView: some View {
+        ErrorView(
+            systemImageName: "wifi.exclamationmark",
+            title: "네트워크 연결 상태를 확인해주세요",
+            subTitle: "네트워크 연결 상태가 좋지 않아\n퀘스트를 불러올 수 없어요",
+            emoticon: "🥲"
+        ) {
+            Task { await viewModel.loadInitialData() }
+        }
+    }
+}
+
+#Preview {
+    FavoriteListView(
+        viewModel: FavoriteListViewModel(
+            questRepository: MockQuestRepository(),
+            favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
+            selectedCommercialArea: .init(code: "R100", areaName: "서현", metroAreaCode: "S01")
+        ),
+        questRepository: QuestRepository(network: QuestNetwork()),
+        illsangZoneManager: IllsangZoneManager(
+            areaNameService: AreaNameService(
+                areaRepository: AreaRepository(network: AreaNetwork())
+            ),
+            seasonManager: SeasonManager(
+                seasonNetwork: SeasonNetwork()
+            )
+        )
+    )
+}

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 class FavoriteListViewModel: ObservableObject {
     @Published var viewStatus: ViewStatus = .loading
     @Published var showSelectRegionView: Bool = false
-    @Published var selectedArea: CommercialArea?
+    @Published var selectedArea: CommercialArea
     @Published var quests: [QuestViewModelItem] = []
     
     // TODO: 페이지네이션 수정 필요
@@ -33,8 +33,7 @@ class FavoriteListViewModel: ObservableObject {
         self.paginationManager = PaginationManager(size: 20, threshold: 18)
         self.paginationManager.loadPageData = { [weak self] page in
             guard let self = self else { return ([], 0) }
-            guard let areaCode = selectedArea?.code else { return ([], 0) }
-            return await self.loadQuestListWithImage(areaCode: areaCode, page: page, size: 20)
+            return await self.loadQuestListWithImage(areaCode: selectedArea.code, page: page, size: 20)
         }
     }
     
@@ -49,8 +48,7 @@ class FavoriteListViewModel: ObservableObject {
         refreshTask?.cancel()
         refreshTask = Task {
             changeViewStatus(.loading)
-            guard let areaCode = selectedArea?.code else { return }
-            await loadQuestListWithImage(areaCode: areaCode, page: 0, size: 10)
+            await loadQuestListWithImage(areaCode: selectedArea.code, page: 0, size: 10)
             changeViewStatus(.loaded)
         }
         await refreshTask?.value

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
@@ -1,0 +1,137 @@
+//
+//  FavoriteListViewModel.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/6/25.
+//
+
+import UIKit
+
+class FavoriteListViewModel: ObservableObject {
+    @Published var viewStatus: ViewStatus = .loading
+    @Published var showSelectRegionView: Bool = false
+    @Published var selectedArea: CommercialArea?
+    @Published var quests: [QuestViewModelItem] = []
+    
+    // TODO: 페이지네이션 수정 필요
+    let paginationManager: PaginationManager<QuestViewModelItem>
+    
+    private let questRepository: QuestRepositoryInterface
+    private let favoriteService: FavoriteService
+    
+    private var refreshTask: Task<Void, Never>?
+    
+    init(
+        questRepository: QuestRepositoryInterface,
+        favoriteService: FavoriteService,
+        selectedCommercialArea: CommercialArea
+    ) {
+        self.questRepository = questRepository
+        self.favoriteService = favoriteService
+        self.selectedArea = selectedCommercialArea
+        
+        self.paginationManager = PaginationManager(size: 20, threshold: 18)
+        self.paginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            guard let areaCode = selectedArea?.code else { return ([], 0) }
+            return await self.loadQuestListWithImage(areaCode: areaCode, page: page, size: 20)
+        }
+    }
+    
+    func loadDataIfNeeded() async {
+        if quests.isEmpty {
+            await loadInitialData()
+        }
+    }
+    
+    @MainActor
+    func loadInitialData() async {
+        refreshTask?.cancel()
+        refreshTask = Task {
+            changeViewStatus(.loading)
+            guard let areaCode = selectedArea?.code else { return }
+            await loadQuestListWithImage(areaCode: areaCode, page: 0, size: 10)
+            changeViewStatus(.loaded)
+        }
+        await refreshTask?.value
+    }
+    
+    @discardableResult @MainActor
+    func loadQuestListWithImage(
+        areaCode: String,
+        page: Int,
+        size: Int
+    ) async -> ([QuestViewModelItem], Int) {
+        let getQuestList = await getQuestList(areaCode: areaCode, page: page, size: size)
+        let newQuestList = getQuestList.data
+        let existingList = quests
+        
+        var mergedList: [QuestViewModelItem]
+        if page == 0 {
+            mergedList = newQuestList
+        } else {
+            mergedList = existingList + newQuestList
+        }
+        
+        await withTaskGroup(of: (Int, UIImage?).self) { group in
+            for (index, quest) in newQuestList.enumerated() {
+                group.addTask {
+                    guard let imageId = quest.imageId else {
+                        return (index, nil)
+                    }
+                    let image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+                    return (index, image)
+                }
+            }
+            
+            for await (index, image) in group {
+                if let image = image {
+                    if page == 0 {
+                        mergedList[index].image = image
+                    } else {
+                        mergedList[mergedList.count - newQuestList.count + index].image = image
+                    }
+                }
+            }
+        }
+        self.quests = mergedList
+        return (mergedList, getQuestList.total)
+    }
+    
+    private func getQuestList(areaCode: String, page: Int, size: Int) async -> (data: [QuestViewModelItem], total: Int) {
+        switch await questRepository.getFavoriteQuests(commercialAreaCode: areaCode, page: page, size: size) {
+        case .success(let response):
+            return (response.content.map { $0.toQuestItem() }, response.totalElements)
+        case .failure:
+            return ([], 0)
+        }
+    }
+    
+    // 내 지역 선택 완료 시
+    @MainActor
+    func handleAreaSelection(_ area: CommercialArea) {
+        self.selectedArea = area
+        Task { await loadInitialData() }
+    }
+    
+    /// 즐겨찾기 상태를 UI에 즉시 반영하고,  서버 반영은 디바운싱 처리
+    func toggleFavoriteStatus(quest: QuestViewModelItem) {
+        favoriteService.toggle(quest: quest)
+    }
+    
+    func loadMoreData() async {
+        guard paginationManager.canLoadMoreData() else { return }
+        await paginationManager.loadData(isRefreshing: false)
+    }
+    
+    @MainActor
+    func changeViewStatus(_ viewStatus: ViewStatus) {
+        self.viewStatus = viewStatus
+    }
+    
+    enum ViewStatus {
+        case error
+        case loading
+        case loaded
+    }
+}

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -73,7 +73,15 @@ struct MyPageView: View {
                             navigationButtonLabel(title: "수행한 퀘스트", image: .myQuest)
                         }
                         NavigationLink {
-                            EmptyView()
+                            FavoriteListView(
+                                viewModel: FavoriteListViewModel(
+                                    questRepository: dependencies.questRepository,
+                                    favoriteService: dependencies.favoriteService,
+                                    selectedCommercialArea: sharedState.selectedCommercialArea
+                                ),
+                                questRepository: dependencies.questRepository,
+                                illsangZoneManager: dependencies.illsangZoneManager
+                            )
                         } label: {
                             navigationButtonLabel(title: "즐겨찾기 퀘스트", image: .myStar)
                         }

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -169,6 +169,46 @@ struct UncompletedBannerQuestItemView: View {
     }
 }
 
+struct FavoriteQuestItemView: View {
+    let quest: QuestViewModelItem
+    let action: (() -> Void)
+    let favoriteAction: (() -> Void)
+
+    var body: some View {
+        BaseQuestItemView(
+            quest: quest,
+            tagConfig: tagConfig(for: quest.questType ?? .normal),
+            imageSize: .init(width: 60, height: 60),
+            trailingPadding: 20,
+            isDisabled: false,
+            trailingView: TrailingStarView(favoriteYn: quest.favoriteYn),
+            action: action,
+            favoriteAction: favoriteAction
+        )
+    }
+    
+    private func tagConfig(for type: QuestType) -> TagConfig? {
+        switch type {
+        case .normal:
+            return nil
+        case .repeat:
+            if let repeatType = quest.repeatType {
+                return TagConfig(style: .repeat(repeatType), image: nil, offset: (48, 0), title: repeatType.description)
+            } else {
+                return nil
+            }
+        case .event:
+            return TagConfig(style: .eventWithIcon, image: .event, offset: (48, 0), title: "한정")
+        }
+    }
+    
+    private func tagImage(for type: QuestType) -> ImageResource? {
+        switch type {
+        case .event: return .event
+        default: return nil
+        }
+    }
+}
 
 struct CompletedQuestItemView: View {
     let quest: QuestViewModelItem

--- a/ILSANG/Sources/Views/Router/AppDependencies.swift
+++ b/ILSANG/Sources/Views/Router/AppDependencies.swift
@@ -27,11 +27,11 @@ class AppDependencies: ObservableObject {
     // MARK: - Repositories
     let userRepository: UserRepositoryInterface
     let missionHistoryRepository: MissionHistoryRepository
-    let areaRepository: AreaRepository
-    let rankRepository: RankRepository
-    let questRepository: QuestRepository
-    let bannerRepository: BannerRepository
-    let couponRepository: CouponRepository
+    let areaRepository: AreaRepositoryInterface
+    let rankRepository: RankRepositoryInterface
+    let questRepository: QuestRepositoryInterface
+    let bannerRepository: BannerRepositoryInterface
+    let couponRepository: CouponRepositoryInterface
     
     // MARK: - Services
     let illsangZoneManager: IllsangZoneManager


### PR DESCRIPTION
#### close #435 

### ✏️ 개요
마이탭 내의 즐겨찾기 화면을 구현합니다.

### 💻 작업 사항
- 즐겨찾기 화면 UI 구현
- 지역별 즐겨찾기 조회 API 연결
- 퀘스트 수행 플로우 연결 (일상존선택/다른사용자인증보기/다른사용자프로필확인)

### 📱결과 화면(optional)
<img width="393" alt="image" src="https://github.com/user-attachments/assets/f15786eb-bb2c-4e6d-8d2a-77de3ee0cdc1" />
