### PR TITLE
[Bug/#441] titleHistoryId 옵셔널화 및 nil 여부 기반 TitleItem 선택 로직 수정

### DIFF
--- a/ILSANG/Sources/Domain/Entity/Title/UserTitle.swift
+++ b/ILSANG/Sources/Domain/Entity/Title/UserTitle.swift
@@ -6,7 +6,7 @@
 //
 
 struct UserTitle {
-    let titleHistoryId: Int
+    let titleHistoryId: Int?
     let name: String
     let grade: HonorGrade
 }

--- a/ILSANG/Sources/Global/Mapper/Title+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/Title+UIMapper.swift
@@ -18,7 +18,7 @@ extension Title {
             condition: condition,
             grade: grade,
             historyId: userTitle?.titleHistoryId,
-            isSelected: userTitle?.titleHistoryId == currentSelectedId
+            isSelected: (userTitle?.titleHistoryId != nil && userTitle?.titleHistoryId == currentSelectedId)
         )
     }
 }

--- a/ILSANG/Sources/Network/Response/Title/UserTitleResponse.swift
+++ b/ILSANG/Sources/Network/Response/Title/UserTitleResponse.swift
@@ -6,6 +6,6 @@
 //
 
 struct UserTitleResponse: Decodable {
-    let titleHistoryId: Int
+    let titleHistoryId: Int?
     let name, grade, type: String
 }


### PR DESCRIPTION
#### relate #441 

### 💻 작업 사항
칭호 선택 화면에서 `userTitle?.titleHistoryId == currentSelectedId`가 nil == nil 로 계산되어,
nil일 경우 false가 되도록 수정했습니다.