### PR TITLE
[Ref/#441] 전설 칭호 랭킹 API 재연결 및 화면 연결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -274,6 +274,15 @@
 		60DA1D262E6D717900AE314E /* BannerQuestResponse+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DA1D252E6D717900AE314E /* BannerQuestResponse+Mapping.swift */; };
 		60DA1D2C2E6EF5F500AE314E /* BannerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DA1D2B2E6EF5F500AE314E /* BannerDetailView.swift */; };
 		60DADF552C6B4EC7001A0B3A /* Data++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DADF542C6B4EC7001A0B3A /* Data++.swift */; };
+		60E401A82E72C93200BB0B6C /* LegendRankResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401A72E72C93200BB0B6C /* LegendRankResponse.swift */; };
+		60E401AA2E72CA6B00BB0B6C /* LegendRank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401A92E72CA6B00BB0B6C /* LegendRank.swift */; };
+		60E401AC2E72CC6000BB0B6C /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401AB2E72CC6000BB0B6C /* User.swift */; };
+		60E401AE2E72CC7900BB0B6C /* User+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401AD2E72CC7900BB0B6C /* User+Mapping.swift */; };
+		60E401B02E72CD7A00BB0B6C /* UserItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401AF2E72CD7A00BB0B6C /* UserItem.swift */; };
+		60E401B22E72CDD400BB0B6C /* LegendRankItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B12E72CDD400BB0B6C /* LegendRankItem.swift */; };
+		60E401B42E72CED500BB0B6C /* User+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B32E72CED500BB0B6C /* User+UIMapper.swift */; };
+		60E401B62E72D25700BB0B6C /* LegendRankResponse+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */; };
+		60E401B82E72D33000BB0B6C /* LegendRank+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */; };
 		60FB50CD2D15CEAE00C55E82 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FB50CC2D15CEAE00C55E82 /* HomeView.swift */; };
 		60FF5EC32E4937A6007A5B40 /* MyRegionAreaSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */; };
 		60FF5EC52E4949F8007A5B40 /* RegionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */; };
@@ -310,7 +319,7 @@
 		A1F770642C2AABCE00DB24A0 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F770632C2AABCE00DB24A0 /* MyPageViewModel.swift */; };
 		A1FF916E2C250C3B00F03E4B /* UserNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF916D2C250C3B00F03E4B /* UserNetwork.swift */; };
 		A1FF91702C25119200F03E4B /* PointNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF916F2C25119200F03E4B /* PointNetwork.swift */; };
-		A1FF91722C257E9A00F03E4B /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF91712C257E9A00F03E4B /* User.swift */; };
+		A1FF91722C257E9A00F03E4B /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF91712C257E9A00F03E4B /* UserResponse.swift */; };
 		A1FF91742C257F6400F03E4B /* XpLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF91732C257F6400F03E4B /* XpLog.swift */; };
 /* End PBXBuildFile section */
 
@@ -602,6 +611,15 @@
 		60DA1D252E6D717900AE314E /* BannerQuestResponse+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BannerQuestResponse+Mapping.swift"; sourceTree = "<group>"; };
 		60DA1D2B2E6EF5F500AE314E /* BannerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerDetailView.swift; sourceTree = "<group>"; };
 		60DADF542C6B4EC7001A0B3A /* Data++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data++.swift"; sourceTree = "<group>"; };
+		60E401A72E72C93200BB0B6C /* LegendRankResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegendRankResponse.swift; sourceTree = "<group>"; };
+		60E401A92E72CA6B00BB0B6C /* LegendRank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegendRank.swift; sourceTree = "<group>"; };
+		60E401AB2E72CC6000BB0B6C /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		60E401AD2E72CC7900BB0B6C /* User+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+Mapping.swift"; sourceTree = "<group>"; };
+		60E401AF2E72CD7A00BB0B6C /* UserItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserItem.swift; sourceTree = "<group>"; };
+		60E401B12E72CDD400BB0B6C /* LegendRankItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegendRankItem.swift; sourceTree = "<group>"; };
+		60E401B32E72CED500BB0B6C /* User+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+UIMapper.swift"; sourceTree = "<group>"; };
+		60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRankResponse+Mapping.swift"; sourceTree = "<group>"; };
+		60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRank+UIMapper.swift"; sourceTree = "<group>"; };
 		60FB50CC2D15CEAE00C55E82 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRegionAreaSelectionView.swift; sourceTree = "<group>"; };
 		60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionPickerView.swift; sourceTree = "<group>"; };
@@ -640,7 +658,7 @@
 		A1F770632C2AABCE00DB24A0 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		A1FF916D2C250C3B00F03E4B /* UserNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNetwork.swift; sourceTree = "<group>"; };
 		A1FF916F2C25119200F03E4B /* PointNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointNetwork.swift; sourceTree = "<group>"; };
-		A1FF91712C257E9A00F03E4B /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		A1FF91712C257E9A00F03E4B /* UserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponse.swift; sourceTree = "<group>"; };
 		A1FF91732C257F6400F03E4B /* XpLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XpLog.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -679,7 +697,6 @@
 			isa = PBXGroup;
 			children = (
 				60C6B4DB2C2D042700926C0E /* Image.swift */,
-				A1FF91712C257E9A00F03E4B /* User.swift */,
 				A1FF91732C257F6400F03E4B /* XpLog.swift */,
 				6057361B2D8AC8A800CF7051 /* Quiz.swift */,
 				60FF5ED02E4CDC2B007A5B40 /* Season.swift */,
@@ -952,6 +969,7 @@
 		606C3EC12E60E9290050C4D6 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				A1FF91712C257E9A00F03E4B /* UserResponse.swift */,
 				606C3EC02E60E9290050C4D6 /* PointResponse.swift */,
 				606C3EC52E60E94B0050C4D6 /* PointCommercialResponse.swift */,
 				606C3EC32E60E9410050C4D6 /* PointSummaryResponse.swift */,
@@ -962,6 +980,7 @@
 		606C3EC82E60E97E0050C4D6 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				60E401AB2E72CC6000BB0B6C /* User.swift */,
 				6091976C2E5F8E9B00F1D81B /* UserMissionHistory.swift */,
 				606C3EC92E60E9C20050C4D6 /* PointCommercial.swift */,
 				606C3ECB2E60EA220050C4D6 /* PointSummary.swift */,
@@ -972,6 +991,7 @@
 		606C3ED12E60EDCC0050C4D6 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				60E401AD2E72CC7900BB0B6C /* User+Mapping.swift */,
 				609197702E5F8F4E00F1D81B /* UserMissionHistory+Mapping.swift */,
 				606C3ECF2E60EDC50050C4D6 /* PointCommercial+Mapping.swift */,
 				606C3ED22E60EDE10050C4D6 /* PointSummary+Mapping.swift */,
@@ -1033,6 +1053,8 @@
 				606C3F102E6AA8B80050C4D6 /* CouponItem.swift */,
 				606C3F0E2E6AA8B30050C4D6 /* UserCouponItem.swift */,
 				60DA1D1F2E6CC77F00AE314E /* TitleItem.swift */,
+				60E401AF2E72CD7A00BB0B6C /* UserItem.swift */,
+				60E401B12E72CDD400BB0B6C /* LegendRankItem.swift */,
 			);
 			path = ViewModelItem;
 			sourceTree = "<group>";
@@ -1426,6 +1448,8 @@
 				606C3ED82E61ADD50050C4D6 /* Point+UIMapper.swift */,
 				606C3F0C2E69FE620050C4D6 /* Coupon+UIMapper.swift */,
 				60DA1D212E6CC81400AE314E /* Title+UIMapper.swift */,
+				60E401B32E72CED500BB0B6C /* User+UIMapper.swift */,
+				60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -1435,6 +1459,7 @@
 			children = (
 				60DA1D0C2E6CC2B700AE314E /* TitleResponse.swift */,
 				60DA1D0D2E6CC2B700AE314E /* UserTitleResponse.swift */,
+				60E401A72E72C93200BB0B6C /* LegendRankResponse.swift */,
 			);
 			path = Title;
 			sourceTree = "<group>";
@@ -1444,6 +1469,7 @@
 			children = (
 				60DA1D152E6CC49E00AE314E /* Title.swift */,
 				60DA1D172E6CC4A400AE314E /* UserTitle.swift */,
+				60E401A92E72CA6B00BB0B6C /* LegendRank.swift */,
 			);
 			path = Title;
 			sourceTree = "<group>";
@@ -1453,6 +1479,7 @@
 			children = (
 				60DA1D1D2E6CC6CA00AE314E /* TitleResponse+Mapping.swift */,
 				60DA1D1B2E6CC6C200AE314E /* UserTitleResponse+Mapping.swift */,
+				60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */,
 			);
 			path = Title;
 			sourceTree = "<group>";
@@ -1835,12 +1862,14 @@
 				601BCF1A2D7C134500138387 /* ProgressBar.swift in Sources */,
 				601189232C3E95D40070F2AD /* AuthNetwork.swift in Sources */,
 				605E81402D9FE45C00ECDB15 /* QuestDetailInfoView.swift in Sources */,
+				60E401AC2E72CC6000BB0B6C /* User.swift in Sources */,
 				605445D62DD78EE50005742D /* LegendRankingViewModel.swift in Sources */,
 				60DA1D1E2E6CC6CA00AE314E /* TitleResponse+Mapping.swift in Sources */,
 				609197242E59EC2C00F1D81B /* RecommendQuestResponse+Mapping.swift in Sources */,
 				609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */,
 				605F28522CF1B2C5007EA739 /* QuestDetailView.swift in Sources */,
 				60A2ADF52DAE66BD007AC375 /* SettingToggleItemView.swift in Sources */,
+				60E401B02E72CD7A00BB0B6C /* UserItem.swift in Sources */,
 				A1AB3D6A2C1141B3001EB9D8 /* AppleLoginButtonView.swift in Sources */,
 				60D8972B2E53B5AE006A8480 /* MissionHistoryNetwork.swift in Sources */,
 				600211EC2C1EEED7000CC02E /* APIManager.swift in Sources */,
@@ -1883,6 +1912,7 @@
 				6044B7332C33F754002C13A0 /* ErrorView.swift in Sources */,
 				606C3EF12E68D4710050C4D6 /* CouponListView.swift in Sources */,
 				600D63982E48E5BC009FE14F /* AreaResponse.swift in Sources */,
+				60E401A82E72C93200BB0B6C /* LegendRankResponse.swift in Sources */,
 				605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */,
 				6060B2EA2C08947B0083944D /* Image++.swift in Sources */,
 				606C3F072E69FDB20050C4D6 /* UserCoupon.swift in Sources */,
@@ -1931,7 +1961,7 @@
 				60299E312CBFFF160039663F /* TransferableUIImage.swift in Sources */,
 				601BCF3B2D7F13E900138387 /* ProfileEditViewModel.swift in Sources */,
 				60ADF9D42D5DDD2000556958 /* QuestEngageInfoView.swift in Sources */,
-				A1FF91722C257E9A00F03E4B /* User.swift in Sources */,
+				A1FF91722C257E9A00F03E4B /* UserResponse.swift in Sources */,
 				6091975F2E5DEA2B00F1D81B /* BannerRepository.swift in Sources */,
 				60ADF9D22D5DDC5B00556958 /* QuizView.swift in Sources */,
 				605445D22DD7169A0005742D /* LegendRankingView.swift in Sources */,
@@ -1962,6 +1992,7 @@
 				60ADF8892D57B53100556958 /* QuestEngageViewModel.swift in Sources */,
 				6048D5272E50259600CC74F5 /* BannerDetailViewModel.swift in Sources */,
 				609169DE2DFD59C100A34D4F /* Notification++.swift in Sources */,
+				60E401B62E72D25700BB0B6C /* LegendRankResponse+Mapping.swift in Sources */,
 				60D8974B2E57645D006A8480 /* Reward.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				605445D82DD8BD120005742D /* HonorPopupContainerView.swift in Sources */,
@@ -1991,6 +2022,7 @@
 				608EBFA12C39C5BB00B862CC /* String++.swift in Sources */,
 				605445C42DD36CE60005742D /* HonorListItemView.swift in Sources */,
 				600211EA2C1EEE6D000CC02E /* APITarget.swift in Sources */,
+				60E401B22E72CDD400BB0B6C /* LegendRankItem.swift in Sources */,
 				A1BB60282BFE129000AAADD4 /* UserMissionHistoryList.swift in Sources */,
 				6011891D2C3E8B3B0070F2AD /* UserService.swift in Sources */,
 				606C3ECC2E60EA220050C4D6 /* PointSummary.swift in Sources */,
@@ -2043,13 +2075,17 @@
 				609197512E5C295100F1D81B /* UserRankViewModelItem.swift in Sources */,
 				A10EF9392C87292C003D78A2 /* OpenSourceInfoView.swift in Sources */,
 				609197462E5C272E00F1D81B /* CommercialAreaRankResponse.swift in Sources */,
+				60E401B82E72D33000BB0B6C /* LegendRank+UIMapper.swift in Sources */,
 				604687AC2D213B890056E394 /* SelectableTabHeader.swift in Sources */,
+				60E401B42E72CED500BB0B6C /* User+UIMapper.swift in Sources */,
 				607FCBDD2BFA686700BB2D04 /* MyPageView.swift in Sources */,
 				60D897232E537421006A8480 /* MIssionHistory+UIMapper.swift in Sources */,
 				606C3EDD2E65D9640050C4D6 /* AppDependencies.swift in Sources */,
 				60004AD72D4221F500CD2254 /* BannerNetwork.swift in Sources */,
 				60DA1D122E6CC2DB00AE314E /* TitleRepository.swift in Sources */,
 				609197282E59EC7100F1D81B /* RewardResponse+Mapping.swift in Sources */,
+				60E401AA2E72CA6B00BB0B6C /* LegendRank.swift in Sources */,
+				60E401AE2E72CC7900BB0B6C /* User+Mapping.swift in Sources */,
 				606C3F112E6AA8B80050C4D6 /* CouponItem.swift in Sources */,
 				6091972A2E5A226600F1D81B /* RankingDetailView.swift in Sources */,
 				6091976B2E5F307A00F1D81B /* AreaNameService.swift in Sources */,

--- a/ILSANG/Sources/Domain/Entity/Title/LegendRank.swift
+++ b/ILSANG/Sources/Domain/Entity/Title/LegendRank.swift
@@ -1,0 +1,17 @@
+//
+//  LegendRank.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+import Foundation
+
+struct LegendRank {
+    let userId: String
+    let profileImageId: String?
+    let nickName: String?
+    let point: Int?
+    let rank: Int?
+    let title: UserTitle?
+}

--- a/ILSANG/Sources/Domain/Entity/Title/UserTitle.swift
+++ b/ILSANG/Sources/Domain/Entity/Title/UserTitle.swift
@@ -5,8 +5,11 @@
 //  Created by Lee Jinhee on 9/7/25.
 //
 
+import Foundation
+
 struct UserTitle {
     let titleHistoryId: Int?
     let name: String
     let grade: HonorGrade
+    let createdAt: Date?
 }

--- a/ILSANG/Sources/Domain/Entity/User/User.swift
+++ b/ILSANG/Sources/Domain/Entity/User/User.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct User {
+    let id: String
+    let email: String
+    let channel: String
+    let status: String
+    let nickname: String
+    let profileImageId: String?
+    let commercialAreaCode: String?
+    let title: UserTitle?
+}

--- a/ILSANG/Sources/Domain/Mapper/MissionHistoryResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/MissionHistoryResponse+Mapping.swift
@@ -11,7 +11,7 @@ extension MissionHistoryResponse {
     func toDomain() -> MissionHistory { 
         let userTitle = user.title.flatMap { title in
             HonorGrade(rawValue: title.grade).flatMap { gradeEnum in
-                UserTitle(titleHistoryId: title.titleHistoryId, name: title.name, grade: gradeEnum)
+                UserTitle(titleHistoryId: title.titleHistoryId, name: title.name, grade: gradeEnum, createdAt: nil)
             }
         }
         

--- a/ILSANG/Sources/Domain/Mapper/Title/LegendRankResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/Title/LegendRankResponse+Mapping.swift
@@ -1,0 +1,19 @@
+//
+//  LegendRankResponse+Mapping.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+extension LegendRankResponse: DomainConvertible {
+    func toDomain() -> LegendRank {
+        LegendRank(
+            userId: userId,
+            profileImageId: profileImageId,
+            nickName: nickName,
+            point: point,
+            rank: rank,
+            title: title?.toDomain()
+        )
+    }
+}

--- a/ILSANG/Sources/Domain/Mapper/Title/UserTitleResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/Title/UserTitleResponse+Mapping.swift
@@ -10,7 +10,8 @@ extension UserTitleResponse: DomainConvertible {
         UserTitle(
             titleHistoryId: titleHistoryId,
             name: name,
-            grade: HonorGrade(rawValue: grade) ?? .standard
+            grade: HonorGrade(rawValue: grade) ?? .standard,
+            createdAt: createdAt?.toISO8601Date()
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/User/User+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/User/User+Mapping.swift
@@ -1,0 +1,22 @@
+//
+//  User+Mapping.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+
+extension UserResponse: DomainConvertible {
+    func toDomain() -> User {
+        User(
+            id: id,
+            email: email,
+            channel: channel,
+            status: status,
+            nickname: nickname,
+            profileImageId: profileImageId,
+            commercialAreaCode: commercialAreaCode,
+            title: title?.toDomain()
+        )
+    }
+}

--- a/ILSANG/Sources/Domain/Repository/TitleRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/TitleRepository.swift
@@ -12,6 +12,7 @@ protocol TitleRepositoryInterface {
     func getTitleHistories() async -> Result<[UserTitle], Error>
     func getUnreadTitleHistories() async -> Result<[UserTitle], Error>
     func readTitleHistory(historyId: Int) async -> Result<Void, Error>
+    func getLegendRank(titleId: String, page: Int, size: Int) async ->  Result<(data: [LegendRank], total: Int), Error>
 }
 
 final class TitleRepository: TitleRepositoryInterface {
@@ -41,6 +42,17 @@ final class TitleRepository: TitleRepositoryInterface {
         switch result {
         case .success:
             return .success(Void())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+    
+    func getLegendRank(titleId: String, page: Int, size: Int) async ->  Result<(data: [LegendRank], total: Int), Error> {
+        let result = await network.getLegendRank(titleId: titleId, page: page, size: size)
+        switch result {
+        case .success(let response):
+            let domainModels = response.content.map { $0.toDomain() }
+            return .success((domainModels, response.totalElements))
         case .failure(let error):
             return .failure(error)
         }

--- a/ILSANG/Sources/Domain/Repository/UserRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/UserRepository.swift
@@ -29,22 +29,12 @@ final class UserRepository: UserRepositoryInterface {
     
     func getUser() async -> Result<User, Error> {
         let res = await network.getUser()
-        switch res {
-        case .success(let user):
-            return .success(user)
-        case .failure(let error):
-            return .failure(error)
-        }
+        return ResponseMapper.mapResponse(res)
     }
     
     func getUser(userId: String) async -> Result<User, Error> {
         let res = await network.getUser(userId: userId)
-        switch res {
-        case .success(let user):
-            return .success(user)
-        case .failure(let error):
-            return .failure(error)
-        }
+        return ResponseMapper.mapResponse(res)
     }
     
     func putUser(nickname: String) async -> Bool {

--- a/ILSANG/Sources/Global/Mapper/LegendRank+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/LegendRank+UIMapper.swift
@@ -1,0 +1,24 @@
+//
+//  LegendRank+UIMapper.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+extension LegendRank {
+    func toItem() -> LegendRankItem? {
+        guard let nickName, let rank else {
+            return nil
+        }
+        
+        return LegendRankItem(
+            userId: userId,
+            nickname: nickName,
+            profileImage: nil,
+            profileImageId: profileImageId,
+            rank: rank,
+            point: point,
+            title: title
+        )
+    }
+}

--- a/ILSANG/Sources/Global/Mapper/User+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/User+UIMapper.swift
@@ -1,0 +1,23 @@
+//
+//  User+UIMapping.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+
+extension User {
+    func toItem() -> UserItem {
+        return UserItem(
+            id: id,
+            email: email,
+            channel: channel,
+            status: status,
+            nickname: nickname,
+            profileImageId: profileImageId,
+            profileImage: nil,
+            commercialAreaCode: commercialAreaCode,
+            title: title
+        )
+    }
+}

--- a/ILSANG/Sources/Global/ViewModelItem/LegendRankItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/LegendRankItem.swift
@@ -1,0 +1,28 @@
+//
+//  LegendRankItem.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+import UIKit
+
+class LegendRankItem: ObservableObject {
+    let userId: String
+    let nickname: String
+    @Published var profileImage: UIImage?
+    let profileImageId: String?
+    let rank: Int
+    let point: Int?
+    let title: UserTitle?
+    
+    init(userId: String, nickname: String, profileImage: UIImage? = nil, profileImageId: String?, rank: Int, point: Int?, title: UserTitle?) {
+        self.userId = userId
+        self.nickname = nickname
+        self.profileImage = profileImage
+        self.profileImageId = profileImageId
+        self.rank = rank
+        self.point = point
+        self.title = title
+    }
+}

--- a/ILSANG/Sources/Global/ViewModelItem/UserItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/UserItem.swift
@@ -1,0 +1,32 @@
+//
+//  UserItem.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+import UIKit
+
+class UserItem: ObservableObject {
+    let id: String
+    let email: String
+    let channel: String
+    let status: String
+    let nickname: String
+    let profileImageId: String?
+    @Published var profileImage: UIImage?
+    let commercialAreaCode: String?
+    let title: UserTitle?
+    
+    init(id: String, email: String, channel: String, status: String, nickname: String, profileImageId: String?, profileImage: UIImage? = nil, commercialAreaCode: String?, title: UserTitle?) {
+        self.id = id
+        self.email = email
+        self.channel = channel
+        self.status = status
+        self.nickname = nickname
+        self.profileImageId = profileImageId
+        self.profileImage = profileImage
+        self.commercialAreaCode = commercialAreaCode
+        self.title = title
+    }
+}

--- a/ILSANG/Sources/Network/Response/Title/LegendRankResponse.swift
+++ b/ILSANG/Sources/Network/Response/Title/LegendRankResponse.swift
@@ -1,0 +1,16 @@
+//
+//  LegendRankResponse.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/11/25.
+//
+
+
+struct LegendRankResponse: Decodable {
+    let userId: String
+    let profileImageId: String?
+    let nickName: String
+    let point: Int?
+    let rank: Int?
+    let title: UserTitleResponse?
+}

--- a/ILSANG/Sources/Network/Response/Title/TitleResponse.swift
+++ b/ILSANG/Sources/Network/Response/Title/TitleResponse.swift
@@ -31,9 +31,3 @@ extension TitleResponse {
     static let mockRare: TitleResponse = .mock(name: "희귀 칭호", grade: "RARE")
     static let mockLegend: TitleResponse = .mock(name: "전설 칭호", grade: "LEGEND")
 }
-
-
-struct HistoryRank: Decodable {
-    let user: User
-    let titleHistory: TitleResponse
-}

--- a/ILSANG/Sources/Network/Response/Title/UserTitleResponse.swift
+++ b/ILSANG/Sources/Network/Response/Title/UserTitleResponse.swift
@@ -8,4 +8,5 @@
 struct UserTitleResponse: Decodable {
     let titleHistoryId: Int?
     let name, grade, type: String
+    let createdAt: String?
 }

--- a/ILSANG/Sources/Network/Response/User/UserResponse.swift
+++ b/ILSANG/Sources/Network/Response/User/UserResponse.swift
@@ -1,13 +1,11 @@
 //
-//  UserModel.swift
+//  UserResponse.swift
 //  ILSANG
 //
 //  Created by Kim Andrew on 6/21/24.
 //
 
-import Foundation
-
-struct User: Decodable {
+struct UserResponse: Decodable {
     let id: String
     let email: String
     let channel: String

--- a/ILSANG/Sources/Network/TitleNetwork.swift
+++ b/ILSANG/Sources/Network/TitleNetwork.swift
@@ -13,10 +13,11 @@ protocol TitleNetworkInterface{
     func getTitleHistories() async -> Result<[UserTitleResponse], Error>
     func getUnreadTitleHistories() async -> Result<[UserTitleResponse], Error>
     func readTitleHistory(historyId: Int) async -> Result<ResponseWithEmpty, Error>
+    func getLegendRank(titleId: String, page: Int, size: Int) async -> Result<ResponseWithPage<[LegendRankResponse]>, Error>
 }
 
 struct MockTitleNetwork: TitleNetworkInterface {
-    let userTitle = UserTitleResponse(titleHistoryId: 1, name: "김민준", grade: "12", type: "교내")
+    let userTitle = UserTitleResponse(titleHistoryId: 1, name: "김민준", grade: "12", type: "교내", createdAt: "")
     
     func getTitles() async -> Result<[TitleResponse], Error> {
         .success([TitleResponse.mockStandard])
@@ -32,6 +33,10 @@ struct MockTitleNetwork: TitleNetworkInterface {
     
     func readTitleHistory(historyId: Int) async -> Result<ResponseWithEmpty, any Error> {
         .success(.emptyValue())
+    }
+    
+    func getLegendRank(titleId: String, page: Int, size: Int) async -> Result<ResponseWithPage<[LegendRankResponse]>, Error> {
+        .success(.init(size: size, content: [], totalPages: 1, totalElements: 0, page: page, isLast: true))
     }
 }
 
@@ -59,9 +64,9 @@ final class TitleNetwork: TitleNetworkInterface {
         return await Network.requestData(url: userUrl+"/\(historyId)/read", method: .put)
     }
     
-    // TODO: API 추가시 스펙 대응
-//    func getLegendRank(honorId: String) async -> Result<[HistoryRank], Error> {
-//        let params = ["titleId": "\(honorId)"]
-//        return await Network.requestData(url: url+"/rank", method: .get, parameters: params, withToken: true)
-//    }
+    /// 전설 랭킹 조회
+    func getLegendRank(titleId: String, page: Int, size: Int) async -> Result<ResponseWithPage<[LegendRankResponse]>, Error> {
+        let params = ["titleId": "\(titleId)", "page": "\(page)", "size": "\(size)"]
+        return await Network.requestData(url: userUrl+"/legend", method: .get, parameters: params)
+    }
 }

--- a/ILSANG/Sources/Network/UserNetwork.swift
+++ b/ILSANG/Sources/Network/UserNetwork.swift
@@ -11,11 +11,11 @@ import Alamofire
 final class UserNetwork {
     private let url = APIManager.makeURL(NoTarget(path: "user", version: 1))
     
-    func getUser() async -> Result<User, Error> {
+    func getUser() async -> Result<UserResponse, Error> {
         return await Network.requestData(url: url, method: .get)
     }
     
-    func getUser(userId id: String) async -> Result<User, Error> {
+    func getUser(userId id: String) async -> Result<UserResponse, Error> {
         return await Network.requestData(url: url, method: .get, parameters: ["id": id])
     }
     

--- a/ILSANG/Sources/Service/UserService.swift
+++ b/ILSANG/Sources/Service/UserService.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AuthenticationServices
 
 final class UserService: ObservableObject {
-    let userNetwork: UserNetwork = UserNetwork()
+    let userRepository: UserRepositoryInterface = UserRepository(network: UserNetwork())
     let authService: AuthService = AuthService()
     
     @AppStorage("isLogin") var isLogin = Bool()
@@ -17,7 +17,7 @@ final class UserService: ObservableObject {
     @AppStorage("refreshToken") var refreshToken: String = ""
     @AppStorage("authChannel") var authChannel = ""
     
-    @Published var currentUser: User?
+    @Published var currentUser: UserItem?
     
     static let shared = UserService()
     
@@ -50,10 +50,14 @@ final class UserService: ObservableObject {
     
     @MainActor
     func fetchUserInfo() async {
-        let userInfo = await userNetwork.getUser()
+        let userInfo = await userRepository.getUser()
         switch userInfo {
         case .success(let res):
-            self.currentUser = res
+            self.currentUser = res.toItem()
+            // TODO: 현재 유저 프로필 이미지 접근하는 부분 페치하는거 제외하기
+            if let profileImageId = res.profileImageId {
+                self.currentUser?.profileImage = await ImageCacheService.shared.loadImageAsync(imageId: profileImageId)
+            }
         case .failure:
             self.currentUser = nil
         }

--- a/ILSANG/Sources/Views/Approval/ApprovalMissionHistoryItem.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalMissionHistoryItem.swift
@@ -78,7 +78,7 @@ class ApprovalMissionHistoryItem: Identifiable {
             nickname: "유저1",
             profileImageId: "profile_001",
             profileImage: nil,
-            userTitle: UserTitle(titleHistoryId: 1, name: "칭호1", grade: .standard),
+            userTitle: UserTitle(titleHistoryId: 1, name: "칭호1", grade: .standard, createdAt: .now),
             emojis: .init(emojis: [.hate])
         ),
         ApprovalMissionHistoryItem(
@@ -96,7 +96,7 @@ class ApprovalMissionHistoryItem: Identifiable {
             nickname: "유저2",
             profileImageId: "profile_002",
             profileImage: nil,
-            userTitle: UserTitle(titleHistoryId: 2, name: "칭호2", grade: .legend),
+            userTitle: UserTitle(titleHistoryId: 2, name: "칭호2", grade: .legend, createdAt: .now),
             emojis: .init(emojis: [.hate])
         ),
         ApprovalMissionHistoryItem(
@@ -114,7 +114,7 @@ class ApprovalMissionHistoryItem: Identifiable {
             nickname: "유저3",
             profileImageId: "profile_003",
             profileImage: .img2,
-            userTitle: UserTitle(titleHistoryId: 3, name: "칭호3", grade: .rare),
+            userTitle: UserTitle(titleHistoryId: 3, name: "칭호3", grade: .rare, createdAt: .now),
             emojis: .init(emojis: [.hate])
         )
     ]

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -82,6 +82,7 @@ struct HomeView: View {
         }
         .task {
             await vm.loadDataIfNeeded()
+            await dependencies.honorAcquisitionManager.fetchUnreadHonorHistory()
         }
         .background(Color.background)
         .overlay(

--- a/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingView.swift
@@ -1,101 +1,61 @@
-////
-////  LegendRankView.swift
-////  ILSANG
-////
-////  Created by Lee Jinhee on 5/16/25.
-////
 //
-//import SwiftUI
+//  LegendRankView.swift
+//  ILSANG
 //
-//struct LegendRankingView: View {
-//    @StateObject var vm: LegendRankingViewModel
-//    
-//    @Environment(\.dismiss) var dismiss
-//    private let leadingTrailingColumnWidth: CGFloat = 50
-//    
-//    init(honorId: String, honorName: String) {
-//        self._vm = StateObject(wrappedValue: LegendRankingViewModel(honorId: honorId, honorName: honorName, honorNetwork: HonorNetwork()))
-//    }
-//    
-//    var body: some View {
-//        VStack(spacing: 0) {
-//            NavigationTitleView(title: "", isSeparatorHidden: true, background: .background) {
-//                dismiss()
-//            }
-//            .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
-//            .overlay {
-//                HonorIconView(
-//                    honorTitle: vm.honorName,
-//                    grade: .legend,
-//                    imageSize: 18,
-//                    spacing: 8,
-//                    font: .init(size: 17, weight: .bold, lineHeight: 22, tracking: 0),
-//                    fgColor: .gray500
-//                )
-//            }
-//            
-//            if vm.historyRanks.isEmpty {
-//                EmptyStateView(message: "해당 칭호를 획득한\n유저가 없어요", fontScale: .big)
-//            } else {
-//                ScrollView {
-//                    LazyVStack(spacing: 12) {
-//                        ForEach(Array(vm.historyRanks.enumerated()), id: \.offset) { idx, rank in
-//                            RankingItemView(style: .legendRank(rank))
-//                        }
-//                    }
-//                    .padding(.top, 16)
-//                    .padding(.bottom, 72)
-//                }
-//            }
-//        }
-//        .frame(maxWidth: .infinity)
-//        .background(Color.background)
-//        .navigationBarBackButtonHidden()
-//        .task {
-//            await vm.fetchLegendRanks()
-//        }
-//    }
-//}
+//  Created by Lee Jinhee on 5/16/25.
 //
-//#Preview {
-//    LegendRankingView(honorId: "TQ00030", honorName: "체력왕")
-//}
-//
-//struct HistoryRankViewModelItem {
-//    let xpPoint: Int
-//    let nickname: String
-//    let title: String?
-//    let titleType: HonorGrade?
-//    let createdAt: String
-//    let profileImageId: String?
-//    let profileImage: UIImage?
-//   
-//    init(xpPoint: Int, nickname: String, title: String?, titleType: HonorGrade?, createdAt: String, profileImageId: String?, profileImage: UIImage?) {
-//        self.xpPoint = xpPoint
-//        self.nickname = nickname
-//        self.title = title
-//        self.titleType = titleType
-//        self.createdAt = createdAt
-//        self.profileImageId = profileImageId
-//        self.profileImage = profileImage
-//    }
-//    
-//    static func make(from historyRank: HistoryRank) async -> HistoryRankViewModelItem {
-//        let profileImage: UIImage?
-//        if let imageId = historyRank.customer.profileImage {
-//            profileImage = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
-//        } else {
-//            profileImage = nil
-//        }
-//        
-//        return HistoryRankViewModelItem(
-//            xpPoint: historyRank.customer.xpPoint,
-//            nickname: historyRank.customer.nickname,
-//            title: historyRank.customer.title?.name,
-//            titleType: historyRank.customer.title.flatMap { HonorGrade(rawValue: $0.type) },
-//            createdAt: historyRank.titleHistory.createdAt,
-//            profileImageId: historyRank.customer.profileImage,
-//            profileImage: profileImage
-//        )
-//    }
-//}
+
+import SwiftUI
+
+struct LegendRankingView: View {
+    @StateObject var vm: LegendRankingViewModel
+    @Environment(\.dismiss) var dismiss
+    private let leadingTrailingColumnWidth: CGFloat = 50
+    
+    init(titleId: String, titleName: String, titleRepository: TitleRepositoryInterface) {
+        self._vm = StateObject(wrappedValue: LegendRankingViewModel(titleId: titleId, titleName: titleName, titleRepository: titleRepository))
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            NavigationTitleView(title: "", isSeparatorHidden: true, background: .background) {
+                dismiss()
+            }
+            .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
+            .overlay {
+                HonorIconView(
+                    honorTitle: vm.titleName,
+                    grade: .legend,
+                    imageSize: 18,
+                    spacing: 8,
+                    font: .init(size: 17, weight: .bold, lineHeight: 22, tracking: 0),
+                    fgColor: .gray500
+                )
+            }
+            
+            if vm.historyRanks.isEmpty {
+                EmptyStateView(message: "해당 칭호를 획득한\n유저가 없어요", fontScale: .big)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(vm.historyRanks, id: \.userId) { rank in
+                            RankingItemView(style: .legendRank(rank))
+                        }
+                    }
+                    .padding(.top, 16)
+                    .padding(.bottom, 72)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color.background)
+        .navigationBarBackButtonHidden()
+        .task {
+            await vm.fetchLegendRanks()
+        }
+    }
+}
+
+#Preview {
+    LegendRankingView(titleId: "T001", titleName: "체력왕", titleRepository: TitleRepository(network: TitleNetwork()))
+}

--- a/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageHonor/LegendRankingViewModel.swift
@@ -1,48 +1,53 @@
-////
-////  LegendRankingViewModel.swift
-////  ILSANG
-////
-////  Created by Lee Jinhee on 5/17/25.
-////
 //
-//import Foundation
+//  LegendRankingViewModel.swift
+//  ILSANG
 //
-//final class LegendRankingViewModel: ObservableObject {
-//    @Published var historyRanks: [HistoryRankViewModelItem] = []
-//    private let honorId: String
-//    let honorName: String
-//    private let honorNetwork: HonorNetwork
+//  Created by Lee Jinhee on 5/17/25.
 //
-//    init(honorId: String, honorName: String, honorNetwork: HonorNetwork) {
-//        self.honorId = honorId
-//        self.honorName = honorName
-//        self.honorNetwork = honorNetwork
-//    }
-//    
-//    @MainActor
-//    func fetchLegendRanks() async {
-//        let result = await honorNetwork.getLegendRank(honorId: honorId)
-//        switch result {
-//        case .success(let res):
-//            let items = await withTaskGroup(of: (Int, HistoryRankViewModelItem).self) { group in
-//                for (index, rank) in res.data.enumerated() {
-//                    group.addTask {
-//                        let item = await HistoryRankViewModelItem.make(from: rank)
-//                        return (index, item)
-//                    }
-//                }
-//                
-//                var results = Array<HistoryRankViewModelItem?>(repeating: nil, count: res.data.count)
-//                for await (index, item) in group {
-//                    results[index] = item
-//                }
-//                
-//                return results.compactMap { $0 } // nil 제거
-//            }
-//            
-//            self.historyRanks = items
-//        case .failure(let error):
-//            Log("전설 칭호 조회 실패: \(error)")
-//        }
-//    }
-//}
+
+import UIKit
+
+final class LegendRankingViewModel: ObservableObject {
+    @Published var historyRanks: [LegendRankItem] = []
+    private let titleId: String
+    let titleName: String
+    private let titleRepository: TitleRepositoryInterface
+    
+    init(titleId: String, titleName: String, titleRepository: TitleRepositoryInterface) {
+        self.titleId = titleId
+        self.titleName = titleName
+        self.titleRepository = titleRepository
+    }
+    
+    @MainActor
+    func fetchLegendRanks(page: Int = 1, size: Int = 10) async {
+        let result = await titleRepository.getLegendRank(titleId: titleId, page: page, size: size)
+        switch result {
+        case .success(let res):
+            self.historyRanks = res.data.compactMap { $0.toItem() }
+            await self.getProfileImages()
+        case .failure(let error):
+            Log("전설 칭호 조회 실패: \(error)")
+        }
+    }
+    
+    func getProfileImages() async {
+        await withTaskGroup(of: (Int, UIImage?).self) { group in
+            for (index, rank) in historyRanks.enumerated() {
+                group.addTask {
+                    guard let imageId = rank.profileImageId else {
+                        return (index, nil)
+                    }
+                    let image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
+                    return (index, image)
+                }
+            }
+            
+            for await (index, image) in group {
+                if let image {
+                    self.historyRanks[index].profileImage = image
+                }
+            }
+        }
+    }
+}

--- a/ILSANG/Sources/Views/MyPage/MyPageHonor/MyPageHonorManageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageHonor/MyPageHonorManageView.swift
@@ -135,12 +135,11 @@ struct MyPageHonorManageView: View {
                     honorListItemView(honor: honor)
                 }
             }
-            // TODO: 칭호 UI&API 대기
-//            .navigationDestination(isPresented: $vm.showRankingView) {
-//                if let honor = vm.selectedHonorToShowRanking  {
-//                     LegendRankingView(honorId: honor.titleId, honorName: honor.title)
-//                }
-//            }
+            .navigationDestination(isPresented: $vm.showRankingView) {
+                if let honor = vm.selectedHonorToShowRanking  {
+                    LegendRankingView(titleId: honor.titleId, titleName: honor.name, titleRepository: dependencies.titleRepository)
+                }
+            }
         }
     }
     

--- a/ILSANG/Sources/Views/MyPage/MyPageHonor/MyPageHonorManageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageHonor/MyPageHonorManageViewModel.swift
@@ -25,7 +25,7 @@ final class MyPageHonorManageViewModel: ObservableObject {
     init(userNetwork: UserNetwork, titleRepository: TitleRepositoryInterface) {
         self.userNetwork = userNetwork
         self.titleRepository = titleRepository
-        self.initialHonor = UserService.shared.currentUser?.title?.toDomain() ?? nil
+        self.initialHonor = UserService.shared.currentUser?.title ?? nil
         self.initialHistoryId = initialHonor?.titleHistoryId
     }
     

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -53,13 +53,13 @@ struct MyPageView: View {
                 // 프로필
                 VStack(spacing: 20) {
                     MyPageProfile(
-                        nickName: vm.userData?.nickname,
-                        profileImage: vm.userProfileImage,
-                        profileImageId: vm.userData?.profileImageId,
+                        nickName: vm.currentUser?.nickname,
+                        profileImage: vm.currentUser?.profileImage,
+                        profileImageId: vm.currentUser?.profileImageId,
                         level: vm.xpStatus.currentLv,
                         progress: vm.xpStatus.progress,
-                        honorTitle: vm.honorTitle,
-                        honorType: vm.honorType
+                        honorTitle: vm.currentUser?.title?.name,
+                        honorType: vm.currentUser?.title?.grade
                     )
                     
                     HStack {
@@ -146,7 +146,7 @@ struct MyPageView: View {
                         style: .my,
                         content:
                             SeasonSummaryView(
-                                nickname: vm.userData?.nickname, season: currentSeason, summary: vm.pointSummary
+                                nickname: vm.currentUser?.nickname, season: currentSeason, summary: vm.pointSummary
                             )
                             .padding(.horizontal, 20)
                     )

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -30,12 +30,8 @@ struct XpStatus {
 
 @MainActor
 final class MyPageViewModel: ObservableObject {
-    @Published var userData: User?
+    @Published var currentUser: UserItem?
     @Published var xpStatus: XpStatus = XpStatus(currentXp: 0)
-    
-    @Published var honorTitle: String? = ""
-    @Published var honorType: HonorGrade?
-    @Published var userProfileImage: UIImage?
     
     @Published var pointCommercial: PointCommercialItem? // 내 일상존
     @Published var completedQuestCount: Int = 0
@@ -61,7 +57,7 @@ final class MyPageViewModel: ObservableObject {
         self.areaNameService = areaNameService
         self.seasonManager = seasonManager
         
-        self.userData = UserService.shared.currentUser
+        self.currentUser = UserService.shared.currentUser
         
         // 초기값을 -1로 통일
         seasonFilterState = DynamicFilterPickerState(
@@ -127,21 +123,14 @@ final class MyPageViewModel: ObservableObject {
     @MainActor
     func fetchUser() async {
         let res = await userRepository.getUser()
-        
         switch res {
-        case .success(let model):
-            self.userData = model
-            if let profileImage = userData?.profileImageId {
-                self.userProfileImage = await getImage(imageId: profileImage) /// 프로필 이미지 불러오기
-            } else {
-                self.userProfileImage = nil
+        case .success(let res):
+            self.currentUser = res.toItem()
+            if let profileImageId = res.profileImageId {
+                self.currentUser?.profileImage = await getImage(imageId: profileImageId)
             }
-            self.honorTitle = userData?.title?.name
-            self.honorType = HonorGrade(rawValue: userData?.title?.type ?? "")
-            UserService.shared.currentUser = model
-        case .failure(let err):
-            self.userData = nil
-            Log(err)
+        case .failure:
+            self.currentUser = nil
         }
     }
     

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
@@ -77,10 +77,10 @@ struct OtherUserProfileView: View {
                     .foregroundStyle(.gray500)
                     .multilineTextAlignment(.leading)
                 
-                if let honor = vm.userData?.title, let grade = HonorGrade(rawValue: honor.type)  {
+                if let honor = vm.userData?.title {
                     HonorIconView(
                         honorTitle: honor.name,
-                        grade: grade,
+                        grade: honor.grade,
                         imageSize: 20,
                         spacing: 4,
                         font: .badge1,

--- a/ILSANG/Sources/Views/Ranking/RankingItemView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingItemView.swift
@@ -15,7 +15,7 @@ struct RankingItemView: View {
         case userRank(UserRankViewModelItem)
         case areaRank(AreaRankViewModelItem)
         case currentUserRank(UserRankViewModelItem)
-        case legendRank(UserRankViewModelItem)
+        case legendRank(LegendRankItem)
     }
     
     var body: some View {
@@ -173,8 +173,7 @@ fileprivate struct CurrentUserRankItemView: View {
 }
 
 fileprivate struct LegendRankItemView: View {
-    @ObservedObject var rank: UserRankViewModelItem
-    let createdTitleAt: String? = nil // TODO: API 추가 요청
+    let rank: LegendRankItem
     
     var body: some View {
         HStack(spacing: 0) {
@@ -184,26 +183,24 @@ fileprivate struct LegendRankItemView: View {
             RankProfileImageView(image: rank.profileImage, size: 48)
                 .padding(.trailing, 16)
             
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
                 Text(rank.nickname)
                     .styledFont(.heading2)
                     .foregroundStyle(.black)
-                    .padding(.bottom, 4)
                 
                 if let title = rank.title {
                     HonorIconView(
                         honorTitle: title.name,
-                        grade: HonorGrade(rawValue: title.grade) ?? .standard,
+                        grade: title.grade,
                         imageSize: 12,
                         spacing: 4,
-                        font: .badge1,
+                        font: .badge2,
                         fgColor: .gray400
                     )
-                    .padding(.bottom, 12)
                 }
                 
-                if let createAt = createdTitleAt {
-                    Text("\(createAt.timeAgoCreatedAt()) 획득")
+                if let createAt = rank.title?.createdAt {
+                    Text("\(createAt.toDisplayFormat(.short)) 획득")
                         .styledFont(.caption1)
                         .foregroundColor(.gray400)
                 }

--- a/ILSANG/Sources/Views/Ranking/UserRankViewModelItem.swift
+++ b/ILSANG/Sources/Views/Ranking/UserRankViewModelItem.swift
@@ -30,7 +30,7 @@ class UserRankViewModelItem: ObservableObject {
 }
 
 extension UserRankViewModelItem {
-    static let mockData1 = UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "일상", point: 100000, rank: 1, title: .init(titleHistoryId: 0, name: "칭호", grade: "LEGEND", type: "METRO"), pointGap: nil)
-    static let mockData100 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: nil, nickname: "김일상", point: 100, rank: 100, title: .init(titleHistoryId: 5, name: "칭호", grade: "LEGEND", type: "METRO"), pointGap: 10)
-    static let mockData1000 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "김일상", point: 1000, rank: 1000, title: .init(titleHistoryId: 3, name: "칭호", grade: "STANDARD", type: "METRO"), pointGap: nil)
+    static let mockData1 = UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "일상", point: 100000, rank: 1, title: .init(titleHistoryId: 0, name: "칭호", grade: "LEGEND", type: "METRO", createdAt: ""), pointGap: nil)
+    static let mockData100 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: nil, nickname: "김일상", point: 100, rank: 100, title: .init(titleHistoryId: 5, name: "칭호", grade: "LEGEND", type: "METRO", createdAt: ""), pointGap: 10)
+    static let mockData1000 =  UserRankViewModelItem(userId: "", profileImageId: "", profileImage: .img0, nickname: "김일상", point: 1000, rank: 1000, title: .init(titleHistoryId: 3, name: "칭호", grade: "STANDARD", type: "METRO", createdAt: ""), pointGap: nil)
 }


### PR DESCRIPTION
#### close #441

### ✏️ 개요
전설 칭호 랭킹 API를 재연결합니다.
기존에 User로만 사용하던 모델을 UserResponse와 구분합니다.

### 💻 작업 사항
- 전설 칭호 랭킹 API 재연결 및 화면 연결
- UserTitleResponse에 createdAt 필드 추가
- UserResponse 추가
- 홈화면: 안읽은 칭호 조회 API 호출
