### PR TITLE
[Feat/#449] 퀘스트 제출 후 뷰 갱신 트리거 추가, 뷰모델 초기화 및 해제 개선

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		60E401B42E72CED500BB0B6C /* User+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B32E72CED500BB0B6C /* User+UIMapper.swift */; };
 		60E401B62E72D25700BB0B6C /* LegendRankResponse+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */; };
 		60E401B82E72D33000BB0B6C /* LegendRank+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */; };
+		60E401BA2E74477A00BB0B6C /* QuestSubmissionNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B92E74477A00BB0B6C /* QuestSubmissionNotifier.swift */; };
 		60FB50CD2D15CEAE00C55E82 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FB50CC2D15CEAE00C55E82 /* HomeView.swift */; };
 		60FF5EC32E4937A6007A5B40 /* MyRegionAreaSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */; };
 		60FF5EC52E4949F8007A5B40 /* RegionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */; };
@@ -620,6 +621,7 @@
 		60E401B32E72CED500BB0B6C /* User+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+UIMapper.swift"; sourceTree = "<group>"; };
 		60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRankResponse+Mapping.swift"; sourceTree = "<group>"; };
 		60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRank+UIMapper.swift"; sourceTree = "<group>"; };
+		60E401B92E74477A00BB0B6C /* QuestSubmissionNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSubmissionNotifier.swift; sourceTree = "<group>"; };
 		60FB50CC2D15CEAE00C55E82 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRegionAreaSelectionView.swift; sourceTree = "<group>"; };
 		60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionPickerView.swift; sourceTree = "<group>"; };
@@ -748,6 +750,7 @@
 				6053345B2D31182500599159 /* XpLevelCalculator.swift */,
 				609197582E5C950B00F1D81B /* SeasonManager.swift */,
 				606C3EE02E662E3E0050C4D6 /* IllsangZoneManager.swift */,
+				60E401B92E74477A00BB0B6C /* QuestSubmissionNotifier.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -1994,6 +1997,7 @@
 				609169DE2DFD59C100A34D4F /* Notification++.swift in Sources */,
 				60E401B62E72D25700BB0B6C /* LegendRankResponse+Mapping.swift in Sources */,
 				60D8974B2E57645D006A8480 /* Reward.swift in Sources */,
+				60E401BA2E74477A00BB0B6C /* QuestSubmissionNotifier.swift in Sources */,
 				60C6B4D52C2C565700926C0E /* ChallengeNetwork.swift in Sources */,
 				605445D82DD8BD120005742D /* HonorPopupContainerView.swift in Sources */,
 				60A6B64D2E2C819E00872DE5 /* ApprovalDetailView.swift in Sources */,

--- a/ILSANG/Sources/Manager/QuestSubmissionNotifier.swift
+++ b/ILSANG/Sources/Manager/QuestSubmissionNotifier.swift
@@ -1,0 +1,24 @@
+//
+//  QuestStateManager.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 9/12/25.
+//
+
+
+import SwiftUI
+
+final class QuestSubmissionNotifier: ObservableObject {
+    // 갱신 트리거 - 이 값이 변경되면 구독하고 있는 뷰들을 갱신
+    @Published var refreshTrigger = UUID()
+    
+    init() {}
+        
+    /// 퀘스트 제출 완료 시 호출
+    func markQuestAsSubmitted() {
+        // 구독자에게 갱신 신호 전송
+        refreshTrigger = UUID()
+        
+        Log("🎯 Quest submitted: triggering refresh...")
+    }
+}

--- a/ILSANG/Sources/Views/Approval/ApprovalDetailView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalDetailView.swift
@@ -21,12 +21,10 @@ struct ApprovalDetailView: View {
             .padding(.bottom, 8)
 
             ApprovalView(
-                vm: ApprovalViewModel(
-                    approvalSource: .detail(missionId: missionId),
-                    emojiNetwork: dependencies.emojiNetwork,
-                    missionHistoryRepository: dependencies.missionHistoryRepository,
-                    areaNameService: dependencies.areaNameService
-                )
+                approvalSource: .detail(missionId: missionId),
+                emojiNetwork: dependencies.emojiNetwork,
+                missionHistoryRepository: dependencies.missionHistoryRepository,
+                areaNameService: dependencies.areaNameService
             )
         }
         .navigationBarBackButtonHidden()

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -8,14 +8,24 @@
 import SwiftUI
 
 struct ApprovalView: View {
-    @State var vm: ApprovalViewModel
+    @StateObject var vm: ApprovalViewModel
     @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
     
     init(
-        vm: ApprovalViewModel,
+        approvalSource: ApprovalSource,
+        emojiNetwork: EmojiNetwork,
+        missionHistoryRepository: MissionHistoryRepository,
+        areaNameService: AreaNameProvider
     ) {
-        _vm = State(wrappedValue: vm)
+        _vm = StateObject(
+            wrappedValue: ApprovalViewModel(
+                approvalSource: approvalSource,
+                emojiNetwork: emojiNetwork,
+                missionHistoryRepository: missionHistoryRepository,
+                areaNameService: areaNameService
+            )
+        )
         _userRouter = StateObject(wrappedValue: UserRouter())
     }
     
@@ -165,12 +175,9 @@ struct ApprovalView: View {
 
 #Preview {
     ApprovalView(
-        vm:
-            ApprovalViewModel(
-                approvalSource: .tab,
-                emojiNetwork: EmojiNetwork(),
-                missionHistoryRepository: MissionHistoryRepository(network: MissionHistoryNetwork(),),
-                areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork()))
-            )
+        approvalSource: .tab,
+        emojiNetwork: EmojiNetwork(),
+        missionHistoryRepository: MissionHistoryRepository(network: MissionHistoryNetwork(),),
+        areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork()))
     )
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -22,21 +22,20 @@ enum ApprovalSource: Equatable {
     case detail(missionId: Int)
 }
 
-@Observable
-final class ApprovalViewModel {
+final class ApprovalViewModel: ObservableObject {
     enum ViewStatus {
         case error
         case loading
         case loaded
     }
     
-    var viewStatus: ViewStatus = .loading
-    var itemList: [ApprovalMissionHistoryItem] = []
+    @Published var viewStatus: ViewStatus = .loading
+    @Published var itemList: [ApprovalMissionHistoryItem] = []
     
-    var showReportAlert = false
-    var selectedChallenge: ApprovalMissionHistoryItem?
+    @Published var showReportAlert = false
+    @Published var selectedChallenge: ApprovalMissionHistoryItem?
     
-    var paginationManager: PaginationManager<ApprovalMissionHistoryItem>?    
+    var paginationManager: PaginationManager<ApprovalMissionHistoryItem>?
     let approvalSource: ApprovalSource
 
     private let emojiNetwork: EmojiNetwork
@@ -62,7 +61,13 @@ final class ApprovalViewModel {
             guard let self = self else { return ([], 0) }
             return await self.getChallengesWithImage(page: page)
         }
+        Log("✨ ApprovalViewModel: init")
     }
+    
+    deinit {
+        Log("✨ ApprovalViewModel: deinit")
+    }
+    
     
     @MainActor
     func loadDataIfNeeded() async {

--- a/ILSANG/Sources/Views/Home/Banner/BannerDetailView.swift
+++ b/ILSANG/Sources/Views/Home/Banner/BannerDetailView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-// TODO: 퀘스트 수행시 리프레시, 외부도 리프레시
 // TODO: 일상존 선택 시 홈뷰에서 일상존 선택 상태 변경
 struct BannerDetailView: View {
     @StateObject var viewModel: BannerDetailViewModel
@@ -22,7 +21,8 @@ struct BannerDetailView: View {
         questRepository: QuestRepositoryInterface,
         areaRepository: AreaRepositoryInterface,
         favoriteService: FavoriteService,
-        illsangZoneManager: IllsangZoneManager
+        illsangZoneManager: IllsangZoneManager,
+        questSubmissionNotifier: QuestSubmissionNotifier
     ) {
         _viewModel = StateObject(
             wrappedValue: BannerDetailViewModel(
@@ -30,7 +30,8 @@ struct BannerDetailView: View {
                 userRepository: userRepository,
                 questRepository: questRepository,
                 areaRepository: areaRepository,
-                favoriteService: favoriteService
+                favoriteService: favoriteService,
+                questSubmissionNotifier: questSubmissionNotifier
             )
         )
         self._questRouter = StateObject(
@@ -61,16 +62,6 @@ struct BannerDetailView: View {
         .withQuestNavigation(questRouter: questRouter)
         .withUserNavigation(userRouter: userRouter)
         .task { await viewModel.loadDataIfNeeded() }
-        .onChange(of: questRouter.showQuestEngage) { _, show in
-            if !show {
-                viewModel.refreshData()
-            }
-        }
-        .onChange(of: questRouter.showSubmitRouter) { _, show in
-            if !show {
-                viewModel.refreshData()
-            }
-        }
         .onChange(of: viewModel.selectedHeader) { _, _ in
             viewModel.closeFilterPicker()
         }
@@ -271,6 +262,7 @@ enum BannerQuestStatus: String, Equatable, SelectableTabItem {
         illsangZoneManager: IllsangZoneManager(
             areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
             seasonManager: SeasonManager(seasonNetwork: SeasonNetwork())
-        )
+        ),
+        questSubmissionNotifier: QuestSubmissionNotifier()
     )
 }

--- a/ILSANG/Sources/Views/Home/Banner/BannerDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Home/Banner/BannerDetailViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Lee Jinhee on 8/16/25.
 //
 
-
+import Combine
 import UIKit
 
 class BannerDetailViewModel: ObservableObject {
@@ -35,19 +35,24 @@ class BannerDetailViewModel: ObservableObject {
     private let questRepository: QuestRepositoryInterface
     private let areaRepository: AreaRepositoryInterface
     private let favoriteService: FavoriteService
+    private let questSubmissionNotifier: QuestSubmissionNotifier
     
+    private var cancellables = Set<AnyCancellable>()
+
     init(
         banner: BannerViewModelItem,
         userRepository: UserRepositoryInterface,
         questRepository: QuestRepositoryInterface,
         areaRepository: AreaRepositoryInterface,
-        favoriteService: FavoriteService
+        favoriteService: FavoriteService,
+        questSubmissionNotifier: QuestSubmissionNotifier
     ) {
         self.banner = banner
         self.userRepository = userRepository
         self.questRepository = questRepository
         self.areaRepository = areaRepository
         self.favoriteService = favoriteService
+        self.questSubmissionNotifier = questSubmissionNotifier
         
         self.eventFilterState = StaticFilterPickerState(initialValue: .upcoming)
         self.uncompletedPaginationManager = PaginationManager(size: 20, threshold: 18)
@@ -55,12 +60,15 @@ class BannerDetailViewModel: ObservableObject {
         
         setupFilterStateObserver()
         setupPaginationManagers()
+        Task { await setupBindings() }
+        Log("🎪 BannerDetailViewModel init")
     }
     
     deinit {
         refreshTask?.cancel()
         refreshTask = nil
-        print("🗑️ BannerDetailViewModel deinit")
+        cancellables.removeAll()
+        Log("🎪 BannerDetailViewModel deinit")
     }
     
     private func setupFilterStateObserver() {
@@ -81,6 +89,20 @@ class BannerDetailViewModel: ObservableObject {
             guard let self = self else { return ([], 0) }
             return await self.loadQuestListWithImage(page: page, size: 10, status: .complete)
         }
+    }
+    
+    @MainActor
+    private func setupBindings() {
+        questSubmissionNotifier.$refreshTrigger
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] _ in
+                Log("🏠 BannerDetailViewModel: 퀘스트 제출 완료 > 리프레시 예정")
+                Task {
+                    self?.refreshData()
+                }
+            }
+            .store(in: &cancellables)
     }
     
     func loadDataIfNeeded() async {

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 // TODO: 에러처리 재정의 필요
 struct HomeView: View {
-    @State var vm: HomeViewModel
+    @StateObject var vm: HomeViewModel
     @StateObject var questRouter: QuestRouter
     @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
@@ -29,14 +29,32 @@ struct HomeView: View {
     }
     
     init(
-        vm: HomeViewModel,
+        userRepository: UserRepositoryInterface,
+        areaNameService: AreaNameProvider,
         questRepository: QuestRepositoryInterface,
+        rankRepository: RankRepositoryInterface,
+        bannerRepository: BannerRepositoryInterface,
+        favoriteService: FavoriteService,
+        questSubmissionNotifier: QuestSubmissionNotifier,
+        sharedState: SharedState,
         illsangZoneManager: IllsangZoneManager
     ) {
-        _vm = State(wrappedValue: vm)
+        self._vm = StateObject(
+            wrappedValue: HomeViewModel(
+                userRepository: userRepository,
+                areaNameService: areaNameService,
+                questRepository: questRepository,
+                rankRepository: rankRepository,
+                bannerRepository: bannerRepository,
+                favoriteService: favoriteService,
+                questSubmissionNotifier: questSubmissionNotifier,
+                sharedState: sharedState
+            )
+        )
         _questRouter = StateObject(
             wrappedValue: QuestRouter(
-                illsangZoneManager: illsangZoneManager, questRepository: questRepository
+                illsangZoneManager: illsangZoneManager,
+                questRepository: questRepository
             )
         )
         _userRouter = StateObject(wrappedValue: UserRouter())
@@ -52,11 +70,8 @@ struct HomeView: View {
                         content
                     }
                 }
-                .task {
-                    await dependencies.honorAcquisitionManager.fetchUnreadHonorHistory()
-                }
                 .refreshable {
-                    await vm.loadInitialData()
+                    await vm.loadInitialDataSafe()
                 }
                 .disabled(vm.viewStatus == .loading)
                 .withQuestNavigation(questRouter: questRouter)
@@ -72,7 +87,8 @@ struct HomeView: View {
                 questRepository: dependencies.questRepository,
                 areaRepository: dependencies.areaRepository,
                 favoriteService: dependencies.favoriteService,
-                illsangZoneManager: dependencies.illsangZoneManager
+                illsangZoneManager: dependencies.illsangZoneManager,
+                questSubmissionNotifier: dependencies.questSubmissionNotifier
             )
         }
         .navigationDestination(isPresented: $vm.showSelectMyRegionView) {
@@ -90,7 +106,7 @@ struct HomeView: View {
                 if let _ = dependencies.honorAcquisitionManager.currentHonor {
                     HonorPopupContainerView()
                 } else if let alert = vm.alertType {
-                     alertView(alert)
+                    alertView(alert)
                 }
             }
         )
@@ -120,10 +136,10 @@ struct HomeView: View {
                 if vm.showMainBanners {
                     mainBannerSection
                 }
-                if vm.showPopularRewardQuest {
+                if vm.showPopularQuest {
                     popularQuestSection
                 }
-                if vm.showRecommendRewardQuest {
+                if vm.showRecommendQuest {
                     recommendQuestSection
                 }
                 if vm.showLargestRewardQuest {
@@ -384,17 +400,15 @@ struct HomeView: View {
 }
 
 #Preview {
-    let viewModel = HomeViewModel(
+    HomeView(
         userRepository: UserRepository(network: UserNetwork()),
         areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
         questRepository: QuestRepository(network: QuestNetwork()),
         rankRepository: RankRepository(network: RankNetwork()),
         bannerRepository: BannerRepository(network: BannerNetwork()),
-        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()), sharedState: SharedState()
-    )
-    HomeView(
-        vm: viewModel,
-        questRepository: QuestRepository(network: QuestNetwork()),
+        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
+        questSubmissionNotifier: QuestSubmissionNotifier(),
+        sharedState: SharedState(),
         illsangZoneManager: IllsangZoneManager(
             areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
             seasonManager: SeasonManager(seasonNetwork: SeasonNetwork())

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -14,10 +14,9 @@ enum ViewStatus {
     case loaded
 }
 
-@Observable
-final class HomeViewModel {
-    var viewStatus: ViewStatus = .loading
-    var userProfileImage: UIImage?
+final class HomeViewModel: ObservableObject {
+    @Published var viewStatus: ViewStatus = .loading
+    @Published var userProfileImage: UIImage?
     var recommendQuestTitle: String {
         if let nickname = UserService.shared.currentUser?.nickname {
             return nickname + "님을 위한 추천 퀘스트"
@@ -25,38 +24,33 @@ final class HomeViewModel {
             return "추천 퀘스트"
         }
     }
-    var mainBanners: [BannerViewModelItem] = []
-    var userRankList: [UserRankViewModelItem] = [] // 10개
-    var largestRewardQuestList: [QuestViewModelItem] = [] // 3*5개
-    var recommendQuestList: [QuestViewModelItem] = [] //QuestViewModelItem.mockQuestList // 10개
-    var popularQuestList: [QuestViewModelItem] = [] // 4n개
+    @Published var mainBanners: [BannerViewModelItem] = []
+    @Published var userRankList: [UserRankViewModelItem] = [] // 10개
+    @Published var largestRewardQuestList: [QuestViewModelItem] = [] // 3*5개
+    @Published var recommendQuestList: [QuestViewModelItem] = [] //QuestViewModelItem.mockQuestList // 10개
+    @Published var popularQuestList: [QuestViewModelItem] = [] // 4n개
     
-    var currentBanner: Int = 0
+    @Published var currentBanner: Int = 0
     
-    var selectedPopularTabIndex: Int = 0
+    @Published var selectedPopularTabIndex: Int = 0
     let popularChunkSize: Int = 4
     var paginatedPopularQuests: [[QuestViewModelItem]] {
         popularQuestList.chunks(of: popularChunkSize)
     }
     
-    var showSelectMyRegionView: Bool = false
-    var selectedBanner: BannerViewModelItem? = nil
+    @Published var showSelectMyRegionView: Bool = false
+    @Published var selectedBanner: BannerViewModelItem? = nil
     
-    var alertType: AlertType? = nil
-    
-//    var shouldShowIllsangZoneWarning: Bool = false
-//    
-//    private let dontShowKey = "DontShowIllsangZoneWarning"
-//    private let seasonKey = "IllsangZoneSeason"
-    
-//    let currentSeason: Int = 1 // TODO: 서버에서 가져오도록 수정
+    @Published var alertType: AlertType? = nil
     
     var errorCnt = 0
-    var showMainBanners: Bool = true
-    var showLargestRewardQuest: Bool = true
-    var showRecommendRewardQuest: Bool = true
-    var showPopularRewardQuest: Bool = true
-    var showRankList = true
+    @Published var showMainBanners: Bool = true
+    @Published var showLargestRewardQuest: Bool = true
+    @Published var showRecommendQuest: Bool = true
+    @Published var showPopularQuest: Bool = true
+    @Published var showRankList = true
+    
+    private var loadTask: Task<Void, Never>? = nil
     
     private let userRepository: UserRepositoryInterface
     private let areaNameService: AreaNameProvider
@@ -64,6 +58,7 @@ final class HomeViewModel {
     private let rankRepository: RankRepositoryInterface
     private let bannerRepository: BannerRepositoryInterface
     private let favoriteService: FavoriteService
+    private let questSubmissionNotifier: QuestSubmissionNotifier
     private let sharedState: SharedState
     
     private var cancellables = Set<AnyCancellable>()
@@ -75,6 +70,7 @@ final class HomeViewModel {
         rankRepository: RankRepositoryInterface,
         bannerRepository: BannerRepositoryInterface,
         favoriteService: FavoriteService,
+        questSubmissionNotifier: QuestSubmissionNotifier,
         sharedState: SharedState
     )  {
         self.userRepository = userRepository
@@ -83,9 +79,16 @@ final class HomeViewModel {
         self.rankRepository = rankRepository
         self.bannerRepository = bannerRepository
         self.favoriteService = favoriteService
+        self.questSubmissionNotifier = questSubmissionNotifier
         self.sharedState = sharedState
         
         Task { await setupBindings() }
+        Log("🏠 HomeViewModel: init")
+    }
+    
+    deinit {
+        Log("🏠 HomeViewModel: deinit")
+        self.cancellables.removeAll()
     }
     
     @MainActor
@@ -98,26 +101,17 @@ final class HomeViewModel {
             }
             .store(in: &cancellables)
         
-        // 퀘스트 라우터 완료 시 데이터 새로고침
-//        questRouter.$showSubmitRouter
-//            .removeDuplicates()
-//            .dropFirst()
-//            .sink { [weak self] isPresented in
-//                if !isPresented {
-//                    Task { await self?.loadInitialData() }
-//                }
-//            }
-//            .store(in: &cancellables)
-//        
-//        questRouter.$showQuestEngage
-//            .removeDuplicates()
-//            .dropFirst()
-//            .sink { [weak self] isPresented in
-//                if !isPresented {
-//                    Task { await self?.loadInitialData() }
-//                }
-//            }
-//            .store(in: &cancellables)
+        // 퀘스트 수행 후 데이터 갱신
+        questSubmissionNotifier.$refreshTrigger
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] _ in
+                Log("🏠 HomeViewModel: 퀘스트 제출 트리거 > 리프레시 예정")
+                Task {
+                    await self?.loadInitialDataSafe()
+                }
+            }
+            .store(in: &cancellables)
     }
     
     @MainActor
@@ -131,13 +125,21 @@ final class HomeViewModel {
         }
     }
     
+    func loadInitialDataSafe() async {
+        loadTask?.cancel()
+        loadTask = Task {
+            await loadInitialData()
+        }
+        await loadTask?.value
+    }
+    
     @MainActor
     func loadInitialData() async {
         self.errorCnt = 0
         changeViewStatus(.loading)
         self.showMainBanners = true
-        self.showPopularRewardQuest = true
-        self.showRecommendRewardQuest = true
+        self.showPopularQuest = true
+        self.showRecommendQuest = true
         self.showLargestRewardQuest = true
         self.showRankList = true
         
@@ -157,7 +159,7 @@ final class HomeViewModel {
                 } catch {
                     Log("Failed to load popular quests: \(error.localizedDescription)")
                     self.errorCnt += 1
-                    self.showPopularRewardQuest = false
+                    self.showPopularQuest = false
                 }
             }
             group.addTask {
@@ -166,7 +168,7 @@ final class HomeViewModel {
                 } catch {
                     Log("Failed to load recommend quests: \(error.localizedDescription)")
                     self.errorCnt += 1
-                    self.showRecommendRewardQuest = false
+                    self.showRecommendQuest = false
                 }
             }
             group.addTask {
@@ -191,14 +193,14 @@ final class HomeViewModel {
         }
         
         if errorCnt >= 3 {
-             changeViewStatus(.error)
-             return
+            changeViewStatus(.error)
+            return
         }
-
+        
         if let userProfileImageId = UserService.shared.currentUser?.profileImageId {
             self.userProfileImage = await ImageCacheService.shared.loadImageAsync(imageId: userProfileImageId)
         }
-
+        
         changeViewStatus(.loaded)
     }
     
@@ -261,7 +263,7 @@ final class HomeViewModel {
     @MainActor
     func loadLargeRewardQuestList() async throws {
         let res = await questRepository.getLargeRewardQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: 0, size: 3)
-
+        
         switch res {
         case .success(let quests):
             self.largestRewardQuestList = quests.content.map { $0.toQuestItem() }
@@ -269,7 +271,7 @@ final class HomeViewModel {
         case .failure(let error):
             throw error
         }
-    }  
+    }
     
     @MainActor
     func loadRankList() async throws {

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
@@ -16,11 +16,20 @@ struct FavoriteListView: View {
     @Environment(\.dismiss) var dismiss
     
     init(
-        viewModel: FavoriteListViewModel,
         questRepository: QuestRepositoryInterface,
+        favoriteService: FavoriteService,
+        selectedCommercialArea: CommercialArea,
+        questSubmissionNotifier: QuestSubmissionNotifier,
         illsangZoneManager: IllsangZoneManager
     ) {
-        self._viewModel = StateObject(wrappedValue: viewModel)
+        self._viewModel = StateObject(
+            wrappedValue: FavoriteListViewModel(
+                questRepository: questRepository,
+                favoriteService: favoriteService,
+                selectedCommercialArea: selectedCommercialArea,
+                questSubmissionNotifier: questSubmissionNotifier
+            )
+        )
         _questRouter = StateObject(
             wrappedValue: QuestRouter(
                 illsangZoneManager: illsangZoneManager, questRepository: questRepository
@@ -58,16 +67,6 @@ struct FavoriteListView: View {
         }
         .withQuestNavigation(questRouter: questRouter)
         .withUserNavigation(userRouter: userRouter)
-        .onChange(of: questRouter.showQuestEngage, { oldValue, newValue in
-            if !newValue {
-                Task { await viewModel.loadInitialData() }
-            }
-        })
-        .onChange(of: questRouter.showSubmitRouter, { oldValue, newValue in
-            if !newValue {
-                Task { await viewModel.loadInitialData() }
-            }
-        })
         // TODO: Destination으로 변경
         .sheet(isPresented: $viewModel.showSelectRegionView) {
             MyRegionAreaSelectionView(areaRepository: dependencies.areaRepository) { area in
@@ -107,7 +106,8 @@ extension FavoriteListView {
                     ForEach(viewModel.quests, id: \.id) { quest in
                         FavoriteQuestItemView(
                             quest: quest,
-                            action: {
+                            action: { [weak viewModel, weak questRouter] in
+                                guard let viewModel = viewModel, let questRouter = questRouter else { return }
                                 AnalyticsService.logEvent(.questItemClick(questId: quest.id, questType: quest.questType?.rawValue.uppercased() ?? ""))
                                 questRouter.presentQuestDetail(quest: quest) { quest in
                                     viewModel.toggleFavoriteStatus(quest: quest)
@@ -152,12 +152,10 @@ extension FavoriteListView {
 
 #Preview {
     FavoriteListView(
-        viewModel: FavoriteListViewModel(
-            questRepository: MockQuestRepository(),
-            favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
-            selectedCommercialArea: .init(code: "R100", areaName: "서현", metroAreaCode: "S01")
-        ),
-        questRepository: QuestRepository(network: QuestNetwork()),
+        questRepository: MockQuestRepository(),
+        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
+        selectedCommercialArea: .init(code: "R100", areaName: "서현", metroAreaCode: "S01"),
+        questSubmissionNotifier: QuestSubmissionNotifier(),
         illsangZoneManager: IllsangZoneManager(
             areaNameService: AreaNameService(
                 areaRepository: AreaRepository(network: AreaNetwork())

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Lee Jinhee on 9/6/25.
 //
 
+import Combine
 import UIKit
 
 class FavoriteListViewModel: ObservableObject {
@@ -18,23 +19,50 @@ class FavoriteListViewModel: ObservableObject {
     
     private let questRepository: QuestRepositoryInterface
     private let favoriteService: FavoriteService
+    private let questSubmissionNotifier: QuestSubmissionNotifier
     
     private var refreshTask: Task<Void, Never>?
+    private var cancellables = Set<AnyCancellable>()
     
     init(
         questRepository: QuestRepositoryInterface,
         favoriteService: FavoriteService,
-        selectedCommercialArea: CommercialArea
+        selectedCommercialArea: CommercialArea,
+        questSubmissionNotifier: QuestSubmissionNotifier
     ) {
         self.questRepository = questRepository
         self.favoriteService = favoriteService
         self.selectedArea = selectedCommercialArea
+        self.questSubmissionNotifier = questSubmissionNotifier
         
         self.paginationManager = PaginationManager(size: 20, threshold: 18)
         self.paginationManager.loadPageData = { [weak self] page in
             guard let self = self else { return ([], 0) }
             return await self.loadQuestListWithImage(areaCode: selectedArea.code, page: page, size: 20)
         }
+        
+        setupBindings()
+        Log("🏠 FavoriteListViewModel: init")
+    }
+    
+    deinit {
+        Log("🏠 FavoriteListViewModel: deinit")
+        refreshTask?.cancel()
+        refreshTask = nil
+        cancellables.removeAll()
+    }
+    
+    private func setupBindings() {
+        questSubmissionNotifier.$refreshTrigger
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] _ in
+                Log("🏠 FavoriteListViewModel: 퀘스트 제출 트리거 > 리프레시 예정")
+                Task {
+                    await self?.loadInitialData()
+                }
+            }
+            .store(in: &cancellables)
     }
     
     func loadDataIfNeeded() async {
@@ -46,10 +74,11 @@ class FavoriteListViewModel: ObservableObject {
     @MainActor
     func loadInitialData() async {
         refreshTask?.cancel()
-        refreshTask = Task {
-            changeViewStatus(.loading)
-            await loadQuestListWithImage(areaCode: selectedArea.code, page: 0, size: 10)
-            changeViewStatus(.loaded)
+        refreshTask = Task { [weak self] in
+            guard let areaCode = self?.selectedArea.code else { return }
+            self?.changeViewStatus(.loading)
+            await self?.loadQuestListWithImage(areaCode: areaCode, page: 0, size: 10)
+            self?.changeViewStatus(.loaded)
         }
         await refreshTask?.value
     }

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -13,9 +13,19 @@ struct MyPageView: View {
     @EnvironmentObject var sharedState: SharedState
     
     init(
-        vm: MyPageViewModel
+        userRepository: UserRepositoryInterface,
+        imageNetwork: ImageNetwork,
+        areaNameService: AreaNameProvider,
+        seasonManager: SeasonManager
     ) {
-        _vm = StateObject(wrappedValue: vm)
+        _vm = StateObject(
+            wrappedValue: MyPageViewModel(
+                userRepository: userRepository,
+                imageNetwork: imageNetwork,
+                areaNameService: areaNameService,
+                seasonManager: seasonManager
+            )
+        )
     }
     
     var body: some View {
@@ -202,11 +212,9 @@ struct EmptyStateView: View {
 
 #Preview {
     MyPageView(
-        vm: MyPageViewModel(
-            userRepository: UserRepository(network: UserNetwork()),
-            imageNetwork: ImageNetwork(),
-            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
-            seasonManager: SeasonManager(seasonNetwork: SeasonNetwork())
-        )
+        userRepository: UserRepository(network: UserNetwork()),
+        imageNetwork: ImageNetwork(),
+        areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
+        seasonManager: SeasonManager(seasonNetwork: SeasonNetwork())
     )
 }

--- a/ILSANG/Sources/Views/MyPage/MyPageView.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageView.swift
@@ -74,12 +74,10 @@ struct MyPageView: View {
                         }
                         NavigationLink {
                             FavoriteListView(
-                                viewModel: FavoriteListViewModel(
-                                    questRepository: dependencies.questRepository,
-                                    favoriteService: dependencies.favoriteService,
-                                    selectedCommercialArea: sharedState.selectedCommercialArea
-                                ),
                                 questRepository: dependencies.questRepository,
+                                favoriteService: dependencies.favoriteService,
+                                selectedCommercialArea: sharedState.selectedCommercialArea,
+                                questSubmissionNotifier: dependencies.questSubmissionNotifier,
                                 illsangZoneManager: dependencies.illsangZoneManager
                             )
                         } label: {

--- a/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/MyPageViewModel.swift
@@ -91,6 +91,13 @@ final class MyPageViewModel: ObservableObject {
                 self.updateSeasonsFromServer(seasons.map { $0.seasonNumber })
             }
             .store(in: &cancellables)
+        
+        Log("👤 MyPageViewModel: init")
+    }
+    
+    deinit {
+        cancellables.removeAll()
+        Log("👤 MyPageViewModel: deinit")
     }
     
     func updateSeasonsFromServer(_ seasonNumbers: [Int]) {

--- a/ILSANG/Sources/Views/Quest/QuestEngage/QuestEngageView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestEngage/QuestEngageView.swift
@@ -15,9 +15,27 @@ struct QuestEngageView: View {
     @EnvironmentObject var sharedState: SharedState
     @Environment(\.dismiss) var dismiss
     
-    init(vm: QuestEngageViewModel, submitVM: SubmitRouterViewModel) {
-        _vm = StateObject(wrappedValue: vm)
-        _submitVM = StateObject(wrappedValue: submitVM)
+    init(
+        quest: QuestViewModelItem,
+        selectedImage: UIImage?,
+        selectedQuest: QuestViewModelItem,
+        challengeNetwork: ChallengeNetwork,
+        submitService: ImageChallengeSubmitService
+    ) {
+        _vm = StateObject(
+            wrappedValue: QuestEngageViewModel(
+                quest: quest,
+                challengeNetwork: challengeNetwork
+            )
+        )
+        _submitVM = StateObject(
+            wrappedValue: SubmitRouterViewModel(
+                selectedImage: selectedImage,
+                selectedQuest: selectedQuest,
+                submitService: submitService,
+                challengeNetwork: challengeNetwork
+            )
+        )
     }
     
     var body: some View {
@@ -81,14 +99,13 @@ struct QuestEngageView: View {
 
 #Preview {
     QuestEngageView(
-        vm: QuestEngageViewModel(quest: .mockData, challengeNetwork: ChallengeNetwork()),
-        submitVM: SubmitRouterViewModel(
-            selectedImage: nil,
-            selectedQuest: .mockData,
-            submitService: ImageChallengeSubmitService(
-                imageNetwork: ImageNetwork(),
-                challengeNetwork: ChallengeNetwork()
-            ), challengeNetwork: ChallengeNetwork()
+        quest: .mockData,
+        selectedImage: nil,
+        selectedQuest: .mockData,
+        challengeNetwork: ChallengeNetwork(),
+        submitService: ImageChallengeSubmitService(
+            imageNetwork: ImageNetwork(),
+            challengeNetwork: ChallengeNetwork()
         )
     )
     // QuestEngageView(vm: QuestEngageViewModel(quest: .mockRepeatData, questNetwork: QuestNetwork()))

--- a/ILSANG/Sources/Views/Quest/QuestEngage/QuestEngageViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestEngage/QuestEngageViewModel.swift
@@ -26,6 +26,11 @@ class QuestEngageViewModel: ObservableObject {
     init(quest: QuestViewModelItem, challengeNetwork: ChallengeNetwork) {
         self.quest = quest
         self.challengeNetwork = challengeNetwork
+        Log("🏃🏻‍♂️ QuestEngageViewModel: init")
+    }
+    
+    deinit {
+        Log("🏃🏻‍♂️ QuestEngageViewModel: deinit")
     }
     
     @MainActor

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -9,18 +9,27 @@ import SwiftUI
 import Combine
 
 struct QuestView: View {
-    @State var vm: QuestViewModel
+    @StateObject var vm: QuestViewModel
     @StateObject var questRouter: QuestRouter
     @StateObject var userRouter: UserRouter
     @EnvironmentObject var dependencies: AppDependencies
     @EnvironmentObject var sharedState: SharedState
 
     init(
-        vm: QuestViewModel,
         questRepository: QuestRepositoryInterface,
-        illsangZoneManager: IllsangZoneManager
+        favoriteService: FavoriteService,
+        questSubmissionNotifier: QuestSubmissionNotifier,
+        sharedState: SharedState,
+        illsangZoneManager: IllsangZoneManager,
     ) {
-        _vm = State(wrappedValue: vm)
+        self._vm = StateObject(
+            wrappedValue: QuestViewModel(
+                questRepository: questRepository,
+                favoriteService: favoriteService,
+                questSubmissionNotifier: questSubmissionNotifier,
+                sharedState: sharedState
+            )
+        )
         _questRouter = StateObject(
             wrappedValue: QuestRouter(
                 illsangZoneManager: illsangZoneManager, questRepository: questRepository
@@ -261,14 +270,14 @@ extension QuestView {
 
 #Preview {
     QuestView(
-        vm: QuestViewModel(
-            questRepository: QuestRepository(network: QuestNetwork()),
-            favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
-            sharedState: SharedState()
-        ),
         questRepository: QuestRepository(network: QuestNetwork()),
+        favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
+        questSubmissionNotifier: QuestSubmissionNotifier(),
+        sharedState: SharedState(),
         illsangZoneManager: IllsangZoneManager(
-            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
+            areaNameService: AreaNameService(
+                areaRepository: AreaRepository(network: AreaNetwork())
+            ),
             seasonManager: SeasonManager(
                 seasonNetwork: SeasonNetwork()
             )

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -8,8 +8,7 @@
 import UIKit
 import Combine
 
-@Observable
-class QuestViewModel {
+class QuestViewModel: ObservableObject {
     // TODO: API 요청 실패 시 에러상태로 변경하기
     enum ViewStatus {
         case error
@@ -17,23 +16,22 @@ class QuestViewModel {
         case loaded
     }
     
-     var viewStatus: ViewStatus = .loading
+    @Published var viewStatus: ViewStatus = .loading
     
-    // TODO: 바뀔 때 api 요청하도록 수정 (refresh, init 고려)
-     var selectedHeader: QuestStatus = .default
+    @Published var selectedHeader: QuestStatus = .default
     
-     var showSelectMyRegionView: Bool = false
-     var alertType: AlertType? = nil
+    @Published var showSelectMyRegionView: Bool = false
+    @Published var alertType: AlertType? = nil
     
     // 필터
      var questFilterState: StaticFilterPickerState<QuestFilterType>
      var repeatFilterState: StaticFilterPickerState<RepeatType>
      var eventFilterState: StaticFilterPickerState<EventQuestFilterType>
        
-     var defaultQuestListByFilter: [QuestFilterType: [QuestViewModelItem]] = [:]
-     var repeatQuestListByFilter: [RepeatType: [QuestFilterType: [QuestViewModelItem]]] = [:]
-     var eventQuestListByFilter: [EventQuestFilterType: [QuestViewModelItem]] = [:]
-     var completedQuestList: [QuestViewModelItem] = []
+    @Published var defaultQuestListByFilter: [QuestFilterType: [QuestViewModelItem]] = [:]
+    @Published var repeatQuestListByFilter: [RepeatType: [QuestFilterType: [QuestViewModelItem]]] = [:]
+    @Published var eventQuestListByFilter: [EventQuestFilterType: [QuestViewModelItem]] = [:]
+    @Published var completedQuestList: [QuestViewModelItem] = []
 
     var currentQuests: [QuestViewModelItem] {
         switch selectedHeader {
@@ -64,6 +62,7 @@ class QuestViewModel {
     
     private let questRepository: QuestRepositoryInterface
     private let favoriteService: FavoriteService
+    private let questSubmissionNotifier: QuestSubmissionNotifier
     private let sharedState: SharedState
         
     private var cancellables = Set<AnyCancellable>()
@@ -71,10 +70,12 @@ class QuestViewModel {
     init(
         questRepository: QuestRepositoryInterface,
         favoriteService: FavoriteService,
+        questSubmissionNotifier: QuestSubmissionNotifier,
         sharedState: SharedState
     ) {
         self.questRepository = questRepository
         self.favoriteService = favoriteService
+        self.questSubmissionNotifier = questSubmissionNotifier
         self.sharedState = sharedState
         
         questFilterState = StaticFilterPickerState<QuestFilterType>(initialValue: .popular)
@@ -120,8 +121,14 @@ class QuestViewModel {
             guard let self = self else { return }
             Task { await self.repeatPaginationManager.loadData(isRefreshing: true) }
         }
-        
+        Log("🍭 QuestViewModel: init")
+
         Task { await setupBindings() }
+    }
+    
+    deinit {
+        cancellables.removeAll()
+        Log("🍭 QuestViewModel: deinit")
     }
     
     @MainActor
@@ -134,25 +141,18 @@ class QuestViewModel {
             }
             .store(in: &cancellables)
         
-//        questRouter.$showSubmitRouter
-//            .removeDuplicates()
-//            .dropFirst()
-//            .sink { [weak self] isPresented in
-//                if !isPresented {
-//                    Task { await self?.loadInitialData() }
-//                }
-//            }
-//            .store(in: &cancellables)
-//        
-//        questRouter.$showQuestEngage
-//            .removeDuplicates()
-//            .dropFirst()
-//            .sink { [weak self] isPresented in
-//                if !isPresented {
-//                    Task { await self?.loadInitialData() }
-//                }
-//            }
-//            .store(in: &cancellables)
+        // refreshTrigger가 변경될 때마다 데이터 갱신
+        questSubmissionNotifier.$refreshTrigger
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                Log("🏠 QuestViewModel: 퀘스트 제출 트리거 > 리프레시 예정")
+                Task {
+                    await self?.loadInitialData()
+                }
+            }
+            .store(in: &cancellables)
     }
     
     func loadDataIfNeeded() async {

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitAlertView.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitAlertView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SubmitAlertView: View {
     @ObservedObject var vm: SubmitRouterViewModel
+    @EnvironmentObject var dependencies: AppDependencies
     @Environment(\.scenePhase) var scenePhase
     @Environment(\.dismiss) var dismiss
     
@@ -40,6 +41,7 @@ struct SubmitAlertView: View {
         case .complete:
             SubmitCompleteView(quest: vm.selectedQuest) {
                 vm.showSubmitAlertView = false
+                dependencies.questSubmissionNotifier.markQuestAsSubmitted()
                 dismiss()
             }
         }

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitRouterViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitRouterViewModel.swift
@@ -24,6 +24,12 @@ class SubmitRouterViewModel: ObservableObject {
         self.selectedQuest = selectedQuest
         self.submitService = submitService
         self.challengeNetwork = challengeNetwork
+        Log("🛣️ SubmitRouterViewModel: init")
+    }
+    
+    deinit {
+        submitTask = nil
+        Log("🛣️ SubmitRouterViewModel: deinit")
     }
     
     /// 제출 요청

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -16,9 +16,17 @@ struct RankingView: View {
     @State private var isRefreshing = false
    
     init(
-        vm: RankingViewModel,
+        rankRepository: RankRepositoryInterface,
+        areaNameService: AreaNameProvider,
+        seasonManager: SeasonManager
     ) {
-        _vm = StateObject(wrappedValue: vm)
+        _vm = StateObject(
+            wrappedValue: RankingViewModel(
+                rankRepository: rankRepository,
+                areaNameService: areaNameService,
+                seasonManager: seasonManager
+            )
+        )
         _userRouter = StateObject(wrappedValue: UserRouter())
     }
     
@@ -332,12 +340,10 @@ extension RankingView {
 
 #Preview {
     RankingView(
-        vm: RankingViewModel(
-            rankRepository: RankRepository(network: RankNetwork()),
-            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
-            seasonManager: SeasonManager(
-                seasonNetwork: SeasonNetwork()
-            )
+        rankRepository: RankRepository(network: RankNetwork()),
+        areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
+        seasonManager: SeasonManager(
+            seasonNetwork: SeasonNetwork()
         )
     )
 }

--- a/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingViewModel.swift
@@ -61,6 +61,13 @@ class RankingViewModel: ObservableObject {
                 self.selectedSeason = season
             }
             .store(in: &cancellables)
+        
+        Log("🏆 RankingViewModel: init")
+    }
+    
+    deinit {
+        cancellables.removeAll()
+        Log("🏆 RankingViewModel: deinit")
     }
     
     func reset() {

--- a/ILSANG/Sources/Views/Router/AppDependencies.swift
+++ b/ILSANG/Sources/Views/Router/AppDependencies.swift
@@ -41,7 +41,8 @@ class AppDependencies: ObservableObject {
     let imageChallengeSubmitService: ImageChallengeSubmitService
     let favoriteService: FavoriteService
     let honorAcquisitionManager: HonorAcquisitionManager
-    
+    let questSubmissionNotifier: QuestSubmissionNotifier
+
     init() {
         // Networks
         self.userNetwork = UserNetwork()
@@ -75,5 +76,6 @@ class AppDependencies: ObservableObject {
         self.imageChallengeSubmitService = ImageChallengeSubmitService(imageNetwork: imageNetwork, challengeNetwork: challengeNetwork)
         self.favoriteService = FavoriteService(favoriteNetwork: favoriteNetwork)
         self.honorAcquisitionManager = HonorAcquisitionManager(titleRepository: titleRepository)
+        self.questSubmissionNotifier = QuestSubmissionNotifier()
     }
 }

--- a/ILSANG/Sources/Views/Router/MainTabView.swift
+++ b/ILSANG/Sources/Views/Router/MainTabView.swift
@@ -65,31 +65,25 @@ struct MainTabView: View {
             
         case .approval:
             ApprovalView(
-                vm: ApprovalViewModel(
-                    approvalSource: .tab,
-                    emojiNetwork: dependencies.emojiNetwork,
-                    missionHistoryRepository: dependencies.missionHistoryRepository,
-                    areaNameService: dependencies.areaNameService
-                )
+                approvalSource: .tab,
+                emojiNetwork: dependencies.emojiNetwork,
+                missionHistoryRepository: dependencies.missionHistoryRepository,
+                areaNameService: dependencies.areaNameService
             )
             
         case .ranking:
             RankingView(
-                vm: RankingViewModel(
-                    rankRepository: dependencies.rankRepository,
-                    areaNameService: dependencies.areaNameService,
-                    seasonManager: dependencies.seasonManager
-                )
+                rankRepository: dependencies.rankRepository,
+                areaNameService: dependencies.areaNameService,
+                seasonManager: dependencies.seasonManager
             )
             
         case .mypage:
             MyPageView(
-                vm: MyPageViewModel(
-                    userRepository: dependencies.userRepository,
-                    imageNetwork: dependencies.imageNetwork,
-                    areaNameService: dependencies.areaNameService,
-                    seasonManager: dependencies.seasonManager
-                )
+                userRepository: dependencies.userRepository,
+                imageNetwork: dependencies.imageNetwork,
+                areaNameService: dependencies.areaNameService,
+                seasonManager: dependencies.seasonManager
             )
         }
     }

--- a/ILSANG/Sources/Views/Router/MainTabView.swift
+++ b/ILSANG/Sources/Views/Router/MainTabView.swift
@@ -43,27 +43,23 @@ struct MainTabView: View {
         switch tab {
         case .home:
             HomeView(
-                vm: HomeViewModel(
-                    userRepository: dependencies.userRepository,
-                    areaNameService: dependencies.areaNameService,
-                    questRepository: dependencies.questRepository,
-                    rankRepository: dependencies.rankRepository,
-                    bannerRepository: dependencies.bannerRepository,
-                    favoriteService: dependencies.favoriteService,
-                    sharedState: sharedState
-                ),
+                userRepository: dependencies.userRepository,
+                areaNameService: dependencies.areaNameService,
                 questRepository: dependencies.questRepository,
+                rankRepository: dependencies.rankRepository,
+                bannerRepository: dependencies.bannerRepository,
+                favoriteService: dependencies.favoriteService,
+                questSubmissionNotifier: dependencies.questSubmissionNotifier,
+                sharedState: sharedState,
                 illsangZoneManager: dependencies.illsangZoneManager
             )
             
         case .quest:
             QuestView(
-                vm: QuestViewModel(
-                    questRepository: dependencies.questRepository,
-                    favoriteService: dependencies.favoriteService,
-                    sharedState: sharedState
-                ),
                 questRepository: dependencies.questRepository,
+                favoriteService: dependencies.favoriteService,
+                questSubmissionNotifier: dependencies.questSubmissionNotifier,
+                sharedState: sharedState,
                 illsangZoneManager: dependencies.illsangZoneManager
             )
             

--- a/ILSANG/Sources/Views/Router/Quest/QuestNavigationSetup.swift
+++ b/ILSANG/Sources/Views/Router/Quest/QuestNavigationSetup.swift
@@ -51,16 +51,11 @@ struct QuestNavigationSetup: ViewModifier {
         // 퀘스트 참여
             .navigationDestination(isPresented: $questRouter.showQuestEngage) {
                 QuestEngageView(
-                    vm: QuestEngageViewModel(
-                        quest: questRouter.selectedQuest,
-                        challengeNetwork: dependencies.challengeNetwork
-                    ),
-                    submitVM: SubmitRouterViewModel(
-                        selectedImage: nil,
-                        selectedQuest: questRouter.selectedQuest,
-                        submitService: dependencies.imageChallengeSubmitService,
-                        challengeNetwork: dependencies.challengeNetwork
-                    )
+                    quest: questRouter.selectedQuest,
+                    selectedImage: nil,
+                    selectedQuest: questRouter.selectedQuest,
+                    challengeNetwork: dependencies.challengeNetwork,
+                    submitService: dependencies.imageChallengeSubmitService
                 )
             }
         // 도전내역 상세


### PR DESCRIPTION
#### close #449 

### ✏️ 개요

AS-IS
퀘스트 제출 시트를 닫을 때. 퀘스트 참여 화면을 닫을 때만 뷰가 갱신됨
지역 시스템 변환 과정에서 일부 갱신 로직 누락 발생

TO-BE
퀘스트 제출 완료 시 관련 뷰들이 즉시 갱신되도록 개선
갱신 신호를 전달하는 로직 및 뷰모델 구독 로직 추가 필요

리프레시 조건
홈 화면 ↔ 퀘스트 화면 상호 갱신
배너 상세 & 즐겨찾기 화면 동작 시 → 홈 & 퀘스트 화면 갱신


### 💻 작업 사항
- 퀘스트 제출 후 뷰 갱신 구현
    - QuestStateManager 클래스 추가
    - SubmitAlertView에서 확인 버튼 누르면 QuestStateManager.markQuestAsSubmitted 메서드 호출
    - 홈,퀘스트,배너상세,즐겨찾기 화면에서 갱신 신호 구독
- 퀘스트 수행 시 뷰모델 관리 개선
     - 뷰모델 1회 초기화
     - 뷰 해제 시 메모리 정리