### PR TITLE
[Ref/#451] 홈화면: 인기 퀘스트 섹션 표시 로직 개선 (0~3개: 비표시, 4~7개: 싱글, 8개 이상: 멀티)

### DIFF
--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -240,16 +240,19 @@ struct HomeView: View {
     
     @ViewBuilder
     private var popularQuestSectionContent: some View {
-        if vm.popularQuestList.count <= vm.popularChunkSize {
-            singlePageContent
-        } else {
-            multiPageContent
+        switch vm.popularQuestList.count {
+        case 0..<vm.popularChunkSize:
+            EmptyView() // 0~3개면 미표시
+        case vm.popularChunkSize..<(vm.popularChunkSize * 2):
+            singlePageContent // 4~7개면 싱글
+        default:
+            multiPageContent  // 8개 이상이면 멀티
         }
     }
     
     private var singlePageContent: some View {
         LazyHGrid(rows: gridItem, alignment: .top, spacing: LayoutConstants.lazyHGridSpacing) {
-            ForEach(vm.popularQuestList) { quest in
+            ForEach(vm.popularQuestList[0..<vm.popularChunkSize]) { quest in
                 PopularQuestItemView(
                     quest: quest,
                     imageSize: CGSize(width: (UIScreen.main.bounds.width - 40 - 2) / 2, height: 137)

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -156,6 +156,11 @@ final class HomeViewModel: ObservableObject {
             group.addTask {
                 do {
                     try await self.loadPopularQuestList()
+                    if self.popularQuestList.count < self.popularChunkSize {
+                        await MainActor.run {
+                            self.showPopularQuest = false
+                        }
+                    }
                 } catch {
                     Log("Failed to load popular quests: \(error.localizedDescription)")
                     self.errorCnt += 1


### PR DESCRIPTION
#### close #451

### ✏️ 개요
인기퀘스트 섹션 표시 로직을 개선합니다.

### 💻 작업 사항
0~3개: 미표시
4~7개: singlePageContent 표시
8개 이상: multiPageContent 표시