### PR TITLE
[Feat/#453] 시즌 보상 화면: API 연결

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		60C6B4DC2C2D042700926C0E /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DB2C2D042700926C0E /* Image.swift */; };
 		60C6B4DF2C2D053600926C0E /* SubmitRouterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */; };
 		60D5EB582E783EBC00C5B78F /* QuestCouponView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D5EB572E783EBC00C5B78F /* QuestCouponView.swift */; };
+		60D5EB5A2E78668E00C5B78F /* RankingRewardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D5EB592E78668E00C5B78F /* RankingRewardViewModel.swift */; };
 		60D897122E536D2C006A8480 /* MissionHistoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D897112E536D2C006A8480 /* MissionHistoryResponse.swift */; };
 		60D8971A2E537188006A8480 /* MissionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D897182E537188006A8480 /* MissionHistory.swift */; };
 		60D8971E2E5372B3006A8480 /* MissionHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D8971D2E5372B3006A8480 /* MissionHistoryRepository.swift */; };
@@ -578,6 +579,7 @@
 		60C6B4DB2C2D042700926C0E /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterViewModel.swift; sourceTree = "<group>"; };
 		60D5EB572E783EBC00C5B78F /* QuestCouponView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestCouponView.swift; sourceTree = "<group>"; };
+		60D5EB592E78668E00C5B78F /* RankingRewardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingRewardViewModel.swift; sourceTree = "<group>"; };
 		60D897112E536D2C006A8480 /* MissionHistoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryResponse.swift; sourceTree = "<group>"; };
 		60D897182E537188006A8480 /* MissionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistory.swift; sourceTree = "<group>"; };
 		60D8971D2E5372B3006A8480 /* MissionHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryRepository.swift; sourceTree = "<group>"; };
@@ -1523,6 +1525,7 @@
 				609197292E5A226600F1D81B /* RankingDetailView.swift */,
 				609197312E5AE7F300F1D81B /* RankingDetailViewModel.swift */,
 				6091972B2E5A228700F1D81B /* RankingRewardView.swift */,
+				60D5EB592E78668E00C5B78F /* RankingRewardViewModel.swift */,
 				6091972D2E5A22A800F1D81B /* SeasonTimerView.swift */,
 			);
 			path = Ranking;
@@ -1961,6 +1964,7 @@
 				609197572E5C399000F1D81B /* AreaUserRankViewModelItem.swift in Sources */,
 				601BCF122D7B449C00138387 /* OtherUserProfileViewModel.swift in Sources */,
 				603CF4CB2D7057BF00A2D19E /* ImageChallengeSubmitService.swift in Sources */,
+				60D5EB5A2E78668E00C5B78F /* RankingRewardViewModel.swift in Sources */,
 				606C3ED32E60EDE10050C4D6 /* PointSummary+Mapping.swift in Sources */,
 				6090A5F52D53AC3300A01429 /* AppVersionManager.swift in Sources */,
 				60ADF9BD2D59D3FD00556958 /* FontStyle.swift in Sources */,

--- a/ILSANG/Sources/Domain/Repository/TitleRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/TitleRepository.swift
@@ -12,6 +12,7 @@ protocol TitleRepositoryInterface {
     func getTitleHistories() async -> Result<[UserTitle], Error>
     func getUnreadTitleHistories() async -> Result<[UserTitle], Error>
     func readTitleHistory(historyId: Int) async -> Result<Void, Error>
+    func getSeasonTitles(type: PointType) async -> Result<[Title], Error>
     func getLegendRank(titleId: String, page: Int, size: Int) async ->  Result<(data: [LegendRank], total: Int), Error>
 }
 
@@ -45,6 +46,11 @@ final class TitleRepository: TitleRepositoryInterface {
         case .failure(let error):
             return .failure(error)
         }
+    }
+    
+    func getSeasonTitles(type: PointType) async -> Result<[Title], Error> {
+        let res = await network.getSeasonTitles(type: type)
+        return ResponseMapper.mapArrayResponse(res)
     }
     
     func getLegendRank(titleId: String, page: Int, size: Int) async ->  Result<(data: [LegendRank], total: Int), Error> {

--- a/ILSANG/Sources/Global/Mapper/Title+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/Title+UIMapper.swift
@@ -21,4 +21,15 @@ extension Title {
             isSelected: (userTitle?.titleHistoryId != nil && userTitle?.titleHistoryId == currentSelectedId)
         )
     }
+    
+    func toItem() -> TitleItem {
+        TitleItem(
+            titleId: id,
+            name: name,
+            condition: condition,
+            grade: grade,
+            historyId: nil,
+            isSelected: false
+        )
+    }
 }

--- a/ILSANG/Sources/Global/ViewModelItem/TitleItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/TitleItem.swift
@@ -22,6 +22,32 @@ final class TitleItem: ObservableObject, Identifiable, Equatable {
     
     @Published var isSelected: Bool
     
+    var displayType: DisplayType {
+        // 1등, 2등, 3등 => 이미지
+        if let match = condition.range(of: #"(\d+)등"#, options: .regularExpression) {
+            let rankStr = condition[match].replacingOccurrences(of: "등", with: "")
+            if let rank = Int(rankStr), (1...3).contains(rank) {
+                return .image("rank\(rank)")
+            }
+        }
+        
+        // 범위 => 텍스트
+        if let match = condition.range(of: #"(\d+)~(\d+)등"#, options: .regularExpression) {
+            let rangeText = String(condition[match])
+                .replacingOccurrences(of: "등", with: "")
+                .replacingOccurrences(of: "~", with: "     ~     ") // 공백 추가
+            return .text(rangeText) // 예: "4     ~     10"
+        }
+        
+        // 그 외
+        return .text(condition)
+    }
+    
+    enum DisplayType {
+        case image(String) // 이미지 이름
+        case text(String)  // 보여줄 텍스트
+    }
+    
     init(
         titleId: String,
         name: String,

--- a/ILSANG/Sources/Network/TitleNetwork.swift
+++ b/ILSANG/Sources/Network/TitleNetwork.swift
@@ -13,6 +13,7 @@ protocol TitleNetworkInterface{
     func getTitleHistories() async -> Result<[UserTitleResponse], Error>
     func getUnreadTitleHistories() async -> Result<[UserTitleResponse], Error>
     func readTitleHistory(historyId: Int) async -> Result<ResponseWithEmpty, Error>
+    func getSeasonTitles(type: PointType) async -> Result<[TitleResponse], Error>
     func getLegendRank(titleId: String, page: Int, size: Int) async -> Result<ResponseWithPage<[LegendRankResponse]>, Error>
 }
 
@@ -33,6 +34,10 @@ struct MockTitleNetwork: TitleNetworkInterface {
     
     func readTitleHistory(historyId: Int) async -> Result<ResponseWithEmpty, any Error> {
         .success(.emptyValue())
+    }
+    
+    func getSeasonTitles(type: PointType) async -> Result<[TitleResponse], Error> {
+        .success([TitleResponse.mockStandard])
     }
     
     func getLegendRank(titleId: String, page: Int, size: Int) async -> Result<ResponseWithPage<[LegendRankResponse]>, Error> {
@@ -62,6 +67,11 @@ final class TitleNetwork: TitleNetworkInterface {
     /// 사용자 칭호 읽음 처리
     func readTitleHistory(historyId: Int) async -> Result<ResponseWithEmpty, Error> {
         return await Network.requestData(url: userUrl+"/\(historyId)/read", method: .put)
+    }
+    
+    /// 시즌  보상 조회
+    func getSeasonTitles(type: PointType) async -> Result<[TitleResponse], Error> {
+        return await Network.requestData(url: url+"/season/title/\(type.parameterText)", method: .get)
     }
     
     /// 전설 랭킹 조회

--- a/ILSANG/Sources/Views/Ranking/RankingRewardView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingRewardView.swift
@@ -9,9 +9,17 @@ import SwiftUI
 
 struct RankingRewardView: View {
     @Environment(\.dismiss) var dismiss
-    @State private var viewStatus: ViewStatus = .loaded
-    @State private var selectedScope: PointType = .commercial
-    @State var items: [SeasonReward] = [.init(idx: 0, honor: .init(titleId: "", name: "", condition: "조건", grade: .legend, historyId: 0, isSelected: false), subtitle: "서브타이틀")]
+    @StateObject private var viewModel: RankingRewardViewModel
+    
+    init(
+        titleRepository: TitleRepositoryInterface,
+    ) {
+        self._viewModel = StateObject(
+            wrappedValue: RankingRewardViewModel(
+                titleRepository: titleRepository
+            )
+        )
+    }
     
     var body: some View {
         VStack (spacing: 0){
@@ -22,7 +30,7 @@ struct RankingRewardView: View {
             
             selectScopeView
             
-            switch viewStatus {
+            switch viewModel.viewStatus {
             case .loading:
                 ProgressView().frame(maxHeight: .infinity)
             case .loaded:
@@ -35,15 +43,19 @@ struct RankingRewardView: View {
         .background(Color.background)
         .navigationBarBackButtonHidden()
         .task {
-            // TODO: 보상 조회 로직 추가
+            await viewModel.getRewards(pointType: viewModel.pointType)
+        }
+        .onChange(of: viewModel.pointType) { _, pointType in
+            Task {
+                await viewModel.loadRewardsIfNeeded(pointType: pointType)
+            }
         }
         .background(Color.background)
     }
     
-    
     private var selectScopeView: some View {
         ScopeHeaderView(
-            selectedScope: $selectedScope,
+            selectedScope: $viewModel.pointType,
             horizontalPadding: 0,
             height: 44,
             hasBottomLine: true
@@ -53,8 +65,8 @@ struct RankingRewardView: View {
     private var rewardListView: some View {
         ScrollView {
             LazyVStack(spacing: 8) {
-                ForEach(items, id: \.idx) { reward in
-                    rewardListItemView(reward: reward)
+                ForEach(viewModel.currentRewards, id: \.titleId) { reward in
+                    rewardListItemView(title: reward)
                 }
             }
             .padding(.top, 12)
@@ -62,38 +74,36 @@ struct RankingRewardView: View {
             .padding(.horizontal, 20)
         }
     }
-    struct SeasonReward {
-        let idx: Int
-        let honor: TitleItem
-        let subtitle: String
-    }
     
-    private func rewardListItemView(reward: SeasonReward) -> some View {
+    private func rewardListItemView(title: TitleItem) -> some View {
         VStack(spacing: 8) {
-            Image(.rank1) // TODO: 이미지 & 텍스트 변경
-                .resizable()
-                .scaledToFit()
-                .frame(30)
+            switch title.displayType {
+            case .image(let imageName):
+                Image(imageName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(26)
+                    .frame(30)
+            case .text(let text):
+                Text(text)
+                    .styledFont(.heading2)
+                    .foregroundStyle(.gray500)
+            }
             
             HonorIconView(
-                honorTitle: reward.honor.name,
-                grade: reward.honor.grade,
+                honorTitle: title.name,
+                grade: title.grade,
                 imageSize: 20,
                 spacing: 8,
                 font: .init(size: 15, weight: .bold, lineHeight: 20, tracking: 0),
                 fgColor: .black
             )
-            
-            Text(reward.subtitle)
-                .styledFont(.regular, size: 13, lineHeight: 16)
-                .foregroundStyle(.gray400)
         }
         .frame(maxWidth: .infinity)
-        .padding(12)
-        .background(Color.white)
-        .cornerRadius(16)
-        
+        .padding(20)
+        .roundedBackground(cornerRadius: 16)
     }
+    
     private var networkErrorView: some View {
         ErrorView(
             systemImageName: "wifi.exclamationmark",
@@ -102,12 +112,16 @@ struct RankingRewardView: View {
             emoticon: "🥲"
         ) {
             Task {
-                // TODO: 재시도 로직
+                await viewModel.getRewards(pointType: viewModel.pointType)
             }
         }
     }
 }
 
 #Preview {
-    RankingRewardView()
+    RankingRewardView(
+        titleRepository: TitleRepository(
+            network: TitleNetwork()
+        )
+    )
 }

--- a/ILSANG/Sources/Views/Ranking/RankingRewardViewModel.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingRewardViewModel.swift
@@ -1,0 +1,58 @@
+//
+//  RankingRewardViewModel.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 9/16/25.
+//
+
+import Foundation
+
+class RankingRewardViewModel: ObservableObject {
+    enum ViewStatus {
+        case error
+        case loading
+        case loaded
+    }
+    
+    enum AreaType {
+        case metro
+        case commercial
+    }
+    @Published var viewStatus: ViewStatus = .loading
+    @Published var pointType: PointType = .metro
+    @Published private var rewards: [PointType: [TitleItem]] = [:]
+    var currentRewards: [TitleItem] {
+        rewards[pointType, default: []]
+    }
+    private let titleRepository: TitleRepositoryInterface
+    
+    init(
+        titleRepository: TitleRepositoryInterface
+    ) {
+        self.titleRepository = titleRepository
+    }
+    
+    @MainActor
+    func loadRewardsIfNeeded(pointType: PointType) async {
+        if let rewards = rewards[pointType], !rewards.isEmpty {
+            return
+        }
+        
+        await getRewards(pointType: pointType)
+    }
+    
+    @MainActor
+    func getRewards(pointType: PointType) async {
+        viewStatus = .loading
+        
+        let res = await titleRepository.getSeasonTitles(type: pointType)
+        
+        switch res {
+        case .success(let reward):
+            self.rewards[pointType, default: []] = reward.map { $0.toItem() }
+            viewStatus = .loaded
+        case .failure:
+            viewStatus = .error
+        }
+    }
+}

--- a/ILSANG/Sources/Views/Ranking/RankingView.swift
+++ b/ILSANG/Sources/Views/Ranking/RankingView.swift
@@ -198,7 +198,9 @@ extension RankingView {
                     }
                     
                     NavigationLink {
-                        RankingRewardView()
+                        RankingRewardView(
+                            titleRepository: dependencies.titleRepository
+                        )
                     } label: {
                         seasonBannerButtonView(title: "시즌 보상")
                     }


### PR DESCRIPTION
#### close #453 

### ✏️ 개요
시즌 보상 조회 API를 연결합니다.

### 💻 작업 사항
- 시즌 보상 조회 API 연결
- 등수에 따라 텍스트/이미지 표시

### 📱결과 화면(optional)
<img width="393" alt="image" src="https://github.com/user-attachments/assets/39d4b79c-43d0-42db-a7ee-3e8d341a44e5" />