### PR TITLE
[Feat/#458] 일상존 미설정 팝업: 오늘 그만보기 기능으로 변경, 취소 버튼 라이팅 수정

### DIFF
--- a/ILSANG/Sources/Manager/IllsangZoneManager.swift
+++ b/ILSANG/Sources/Manager/IllsangZoneManager.swift
@@ -5,8 +5,8 @@
 //  Created by Lee Jinhee on 9/2/25.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 @MainActor
 class IllsangZoneManager: ObservableObject {
@@ -14,43 +14,43 @@ class IllsangZoneManager: ObservableObject {
     @Published var currentZoneName: String?
     @Published var shouldShowWarning: Bool = false
     
-    @Published var currentSeason: Season?
-    private let dontShowKey = "DontShowIllsangZoneWarning"
-    private let seasonKey = "IllsangZoneSeason"
+    private let dontShowDateKey = "DontShowIllsangZoneWarningDate"
     
     private let areaNameService: AreaNameProvider
     private var cancellables = Set<AnyCancellable>() // 구독 저장
-
-    init(areaNameService: AreaNameProvider, seasonManager: SeasonManager) {
+    
+    init(areaNameService: AreaNameProvider) {
         self.areaNameService = areaNameService
         
-        // 시즌 변경 시 currentSeason 업데이트
-        seasonManager.$currentSeason
+        UserService.shared.$currentUser
+            .compactMap { $0?.commercialAreaCode }
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] newSeason in
-                self?.currentSeason = newSeason
+            .sink { [weak self] zoneCode in
+                self?.currentZoneCode = zoneCode
+                Task {
+                    self?.currentZoneName = await areaNameService.getAreaName(for: zoneCode)
+                }
+            }
+            .store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: .NSCalendarDayChanged)
+            .sink { [weak self] _ in
                 self?.updateWarningStatus()
             }
             .store(in: &cancellables)
         
-        loadCurrentZone()
-//        updateWarningStatus()
+        updateWarningStatus()
+        Log("🛠️ IllsangZoneManager: init")
     }
     
-    func loadCurrentZone() {
-        if let zoneCode = UserService.shared.currentUser?.commercialAreaCode {
-            self.currentZoneCode = zoneCode
-            Task {
-                self.currentZoneName = await areaNameService.getAreaName(for: zoneCode)
-            }
-        }
+    deinit {
+        Log("🛠️ IllsangZoneManager: deinit")
     }
     
     func setZone(_ area: CommercialArea) {
         self.currentZoneCode = area.code
         self.currentZoneName = area.areaName
-        // TODO: 서버에 저장 로직
     }
     
     func canChangeZone() -> Bool {
@@ -62,21 +62,29 @@ class IllsangZoneManager: ObservableObject {
     }
     
     func updateWarningStatus() {
-        let savedSeason = UserDefaults.standard.integer(forKey: seasonKey)
-        let dontShow = UserDefaults.standard.bool(forKey: dontShowKey)
-        
-        if let seasonNumber = currentSeason?.id {
-            shouldShowWarning = (savedSeason != seasonNumber) || !dontShow
+        // 일상존이 선택되지 않은 경우
+        if currentZoneCode == nil {
+            // 오늘 dontShow 저장 여부 확인
+            if let dontShowDate = UserDefaults.standard.object(forKey: dontShowDateKey) as? Date {
+                let calendar = Calendar.current
+                Log(calendar)
+                Log(dontShowDate)
+                // 오늘 날짜와 같으면 경고 안 띄움
+                if calendar.isDateInToday(dontShowDate) {
+                    shouldShowWarning = false
+                    return
+                }
+            }
+            shouldShowWarning = true
         } else {
-            shouldShowWarning = !dontShow
+            // 일상존 선택된 상태
+            shouldShowWarning = false
         }
     }
     
     func saveDontShowPreference() {
-        UserDefaults.standard.set(true, forKey: dontShowKey)
-        if let seasonNumber = currentSeason?.id {
-            UserDefaults.standard.set(seasonNumber, forKey: seasonKey)
-        }
+        // 오늘 날짜 저장
+        UserDefaults.standard.set(Date(), forKey: dontShowDateKey)
         shouldShowWarning = false
     }
 }

--- a/ILSANG/Sources/Service/UserService.swift
+++ b/ILSANG/Sources/Service/UserService.swift
@@ -5,8 +5,9 @@
 //  Created by Lee Jinhee on 7/10/24.
 //
 
-import SwiftUI
 import AuthenticationServices
+import Combine
+import SwiftUI
 
 final class UserService: ObservableObject {
     let userRepository: UserRepositoryInterface = UserRepository(network: UserNetwork())
@@ -20,8 +21,18 @@ final class UserService: ObservableObject {
     @Published var currentUser: UserItem?
     
     static let shared = UserService()
+    private var cancellables = Set<AnyCancellable>() // 구독 저장
     
-    private init() { }
+    private init() {
+        // 날짜 변경 감지
+        NotificationCenter.default.publisher(for: .NSCalendarDayChanged)
+            .sink { [weak self] _ in
+                Task {
+                    await self?.fetchUserInfo()
+                }
+            }
+            .store(in: &cancellables)
+    }
     
     // MARK: - 로그인
     /// 첫 애플 로그인하는 경우

--- a/ILSANG/Sources/Views/Area/AreaSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/AreaSelectionView.swift
@@ -54,10 +54,10 @@ struct AreaSelectionView: View {
         } label: {
             Text(area.areaName)
                 .styledFont(.subTitle1)
-                .frame(width: 103, height: 54)
+                .frame(width: 124, height: 54)
                 .foregroundStyle(isSelected ? .white : .gray500)
                 .background(isSelected ? .primary300 : .clear)
-                .animation(.default, value: selectedMetroIdx)
+                .animation(.easeOut(duration: 0.2), value: selectedMetroIdx)
         }
     }
     
@@ -109,7 +109,7 @@ struct AreaSelectionView: View {
                         )
                 )
                 .padding(.trailing, 20)
-                .animation(.default, value: selectedCommercialArea)
+                .animation(.easeOut(duration: 0.2), value: selectedCommercialArea)
         }
     }
     

--- a/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/IllsangZoneSelectionView.swift
@@ -25,7 +25,6 @@ struct IllsangZoneSelectionView: View {
                     dismiss()
                 }
                 .padding(.bottom, 8)
-                .padding(.horizontal, -20)
                 
                 AreaSelectionView(
                     areas: $viewModel.areas,
@@ -35,12 +34,12 @@ struct IllsangZoneSelectionView: View {
                         viewModel.selectedArea = area
                     }
                 )
+                .padding(.trailing, 20)
             }
             .task {
                 await viewModel.loadAreas()
             }
             .navigationBarBackButtonHidden()
-            .padding(.horizontal, 20)
             .safeAreaInset(edge: .bottom, alignment: .center) {
                 if viewModel.selectedArea != nil {
                     PrimaryButton(title: "내 일상존 선택하기") {

--- a/ILSANG/Sources/Views/Area/MyRegionAreaSelectionView.swift
+++ b/ILSANG/Sources/Views/Area/MyRegionAreaSelectionView.swift
@@ -21,11 +21,10 @@ struct MyRegionAreaSelectionView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                NavigationTitleView(title: "내 지역") {
+                NavigationTitleView(title: "지역 선택") {
                     dismiss()
                 }
                 .padding(.bottom, 8)
-                .padding(.horizontal, -20)
                 
                 AreaSelectionView(
                     areas: $viewModel.areas,
@@ -35,15 +34,15 @@ struct MyRegionAreaSelectionView: View {
                         viewModel.selectedArea = area
                     }
                 )
+                .padding(.trailing, 20)
             }
             .task {
                 await viewModel.loadAreas()
             }
             .navigationBarBackButtonHidden()
-            .padding(.horizontal, 20)
             .safeAreaInset(edge: .bottom, alignment: .center) {
                 if viewModel.selectedArea != nil {
-                    PrimaryButton(title: "내 지역 선택하기") {
+                    PrimaryButton(title: "지역 선택하기") {
                         if let selectedArea = viewModel.selectedArea {
                             onSuccess?(selectedArea)
                         }
@@ -51,7 +50,6 @@ struct MyRegionAreaSelectionView: View {
                     }
                     .padding(.horizontal, 20)
                 }
-                
             }
         }
     }

--- a/ILSANG/Sources/Views/Home/Banner/BannerDetailView.swift
+++ b/ILSANG/Sources/Views/Home/Banner/BannerDetailView.swift
@@ -260,8 +260,7 @@ enum BannerQuestStatus: String, Equatable, SelectableTabItem {
         areaRepository: AreaRepository(network: AreaNetwork()),
         favoriteService: FavoriteService(favoriteNetwork: FavoriteNetwork()),
         illsangZoneManager: IllsangZoneManager(
-            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
-            seasonManager: SeasonManager(seasonNetwork: SeasonNetwork())
+            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork()))
         ),
         questSubmissionNotifier: QuestSubmissionNotifier()
     )

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -105,8 +105,6 @@ struct HomeView: View {
             Group {
                 if let _ = dependencies.honorAcquisitionManager.currentHonor {
                     HonorPopupContainerView()
-                } else if let alert = vm.alertType {
-                    alertView(alert)
                 }
             }
         )
@@ -378,16 +376,6 @@ struct HomeView: View {
                 }
                 .scrollIndicators(.never)
         )
-    }
-    
-    @ViewBuilder
-    private func alertView(_ alertType: AlertType) -> some View {
-        if alertType ==  AlertType.myRegionChangeSuccess {
-            SettingAlertView(
-                alertType: alertType,
-                onConfirm: { vm.alertType = nil }
-            )
-        }
     }
     
     private var networkErrorView: some View {

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -163,6 +163,7 @@ struct HomeView: View {
             Text("내 일상존: ")
                 .styledFont(.caption2)
                 .foregroundStyle(.gray400)
+            // TODO: 로딩중or시즌없을경우 선택 안되도록 수정..
             Button {
                 questRouter.handleIllsangZoneButtonTap()
             } label: {
@@ -401,8 +402,7 @@ struct HomeView: View {
         questSubmissionNotifier: QuestSubmissionNotifier(),
         sharedState: SharedState(),
         illsangZoneManager: IllsangZoneManager(
-            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork())),
-            seasonManager: SeasonManager(seasonNetwork: SeasonNetwork())
+            areaNameService: AreaNameService(areaRepository: AreaRepository(network: AreaNetwork()))
         )
     )
 }

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -40,9 +40,7 @@ final class HomeViewModel: ObservableObject {
     
     @Published var showSelectMyRegionView: Bool = false
     @Published var selectedBanner: BannerViewModelItem? = nil
-    
-    @Published var alertType: AlertType? = nil
-    
+        
     var errorCnt = 0
     @Published var showMainBanners: Bool = true
     @Published var showLargestRewardQuest: Bool = true
@@ -376,7 +374,6 @@ final class HomeViewModel: ObservableObject {
     // 내 지역 선택 완료 시
     func handleMyRegionSelection(_ area: CommercialArea) {
         sharedState.selectedCommercialArea = area
-        self.alertType = .myRegionChangeSuccess
     }
     
     /// 즐겨찾기 상태를 UI에 즉시 반영하고,  서버 반영은 디바운싱 처리

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
@@ -159,9 +159,6 @@ extension FavoriteListView {
         illsangZoneManager: IllsangZoneManager(
             areaNameService: AreaNameService(
                 areaRepository: AreaRepository(network: AreaNetwork())
-            ),
-            seasonManager: SeasonManager(
-                seasonNetwork: SeasonNetwork()
             )
         )
     )

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -258,9 +258,6 @@ extension QuestView {
         illsangZoneManager: IllsangZoneManager(
             areaNameService: AreaNameService(
                 areaRepository: AreaRepository(network: AreaNetwork())
-            ),
-            seasonManager: SeasonManager(
-                seasonNetwork: SeasonNetwork()
             )
         )
     )

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -58,13 +58,6 @@ struct QuestView: View {
         }
         .withQuestNavigation(questRouter: questRouter)
         .withUserNavigation(userRouter: userRouter)
-        .overlay(
-            Group {
-                if let alert = vm.alertType {
-                    alertView(alert)
-                }
-            }
-        )
         .navigationDestination(isPresented: $vm.showSelectMyRegionView) {
             MyRegionAreaSelectionView(areaRepository: dependencies.areaRepository) { area in
                 vm.handleMyRegionSelection(area)
@@ -234,18 +227,6 @@ extension QuestView {
     
     private var filterPickerEventView: some View {
         PickerView(state: vm.eventFilterState, width: 150)
-    }
-    
-    @ViewBuilder
-    private func alertView(_ alertType: AlertType) -> some View {
-        if alertType == .myRegionChangeSuccess {
-            SettingAlertView(
-                alertType: alertType,
-                onConfirm: {
-                    vm.alertType = nil
-                }
-            )
-        }
     }
     
     private var questListEmptyView: some View {

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -21,7 +21,6 @@ class QuestViewModel: ObservableObject {
     @Published var selectedHeader: QuestStatus = .default
     
     @Published var showSelectMyRegionView: Bool = false
-    @Published var alertType: AlertType? = nil
     
     // 필터
      var questFilterState: StaticFilterPickerState<QuestFilterType>
@@ -356,7 +355,6 @@ class QuestViewModel: ObservableObject {
     
     func handleMyRegionSelection(_ area: CommercialArea) {
         sharedState.selectedCommercialArea = area
-        self.alertType = .myRegionChangeSuccess
     }
     
     /// 즐겨찾기 상태를 UI에 즉시 반영하고,  서버 반영은 디바운싱 처리

--- a/ILSANG/Sources/Views/Router/AppDependencies.swift
+++ b/ILSANG/Sources/Views/Router/AppDependencies.swift
@@ -72,7 +72,7 @@ class AppDependencies: ObservableObject {
         // Services
         self.areaNameService = AreaNameService(areaRepository: areaRepository)
         self.seasonManager = SeasonManager(seasonNetwork: seasonNetwork)
-        self.illsangZoneManager = IllsangZoneManager(areaNameService: areaNameService, seasonManager: seasonManager)
+        self.illsangZoneManager = IllsangZoneManager(areaNameService: areaNameService)
         self.imageChallengeSubmitService = ImageChallengeSubmitService(imageNetwork: imageNetwork, challengeNetwork: challengeNetwork)
         self.favoriteService = FavoriteService(favoriteNetwork: favoriteNetwork)
         self.honorAcquisitionManager = HonorAcquisitionManager(titleRepository: titleRepository)

--- a/ILSANG/Sources/Views/Setting/Component/SettingAlertView.swift
+++ b/ILSANG/Sources/Views/Setting/Component/SettingAlertView.swift
@@ -155,8 +155,6 @@ enum AlertType: AlertPresentable {
     case Withdrawal
     case Report
     case ChallengeDelete
-
-    case myRegionChangeSuccess
     
     var title: String {
         switch self {
@@ -172,7 +170,6 @@ enum AlertType: AlertPresentable {
             "신고하시겠습니까?"
         case .ChallengeDelete:
             "챌린지를 삭제 할까요?"
-        case .myRegionChangeSuccess: "내 지역이 설정되었습니다"
         }
     }
     
@@ -190,7 +187,6 @@ enum AlertType: AlertPresentable {
             "확인 후 빠른 시일 내 조치하도록 하겠습니다"
         case .ChallengeDelete:
             "삭제하면 복구가 불가합니다"
-        case .myRegionChangeSuccess: "퀘스트를 수행하러 가 볼까요?"
         }
     }
     
@@ -200,8 +196,6 @@ enum AlertType: AlertPresentable {
             "취소"
         case .Logout:
             "아니요"
-        default:
-            ""
         }
     }
     


### PR DESCRIPTION
#### close #458 

### ✏️ 개요
일상존 미설정 팝업 라이팅과 기능을 수정합니다.

### 💻 작업 사항
- 일상존 미설정 팝업: 취소 버튼 라이팅 수정 (취소 > 나중에 선택하기)
- 일상존 미설정 팝업: 기능 변경 (다시보지 않기 > 오늘 그만보기)
- 날짜 변경 감지 시 사용자 정보 갱신 (시즌 변경 시 일상존 변경 감지)

### 📱결과 화면(optional)
날짜 변경시 유저정보 갱신 (하단)
<img width="882" height="239" alt="image" src="https://github.com/user-attachments/assets/9701a72f-2df3-42d1-b8f7-78d96a50baa2" />