### PR TITLE
[Ref/#462] 인증화면: 화면 렌더링 최적화 - Equatable 적용 및 컴포넌트 분리

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		60E401B62E72D25700BB0B6C /* LegendRankResponse+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */; };
 		60E401B82E72D33000BB0B6C /* LegendRank+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */; };
 		60E401BA2E74477A00BB0B6C /* QuestSubmissionNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B92E74477A00BB0B6C /* QuestSubmissionNotifier.swift */; };
+		60F352F22E8FEDEA00307BDC /* RenderDebugContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352F12E8FEDEA00307BDC /* RenderDebugContainer.swift */; };
 		60FB50CD2D15CEAE00C55E82 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FB50CC2D15CEAE00C55E82 /* HomeView.swift */; };
 		60FF5EC32E4937A6007A5B40 /* MyRegionAreaSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */; };
 		60FF5EC52E4949F8007A5B40 /* RegionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */; };
@@ -626,6 +627,7 @@
 		60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRankResponse+Mapping.swift"; sourceTree = "<group>"; };
 		60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRank+UIMapper.swift"; sourceTree = "<group>"; };
 		60E401B92E74477A00BB0B6C /* QuestSubmissionNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSubmissionNotifier.swift; sourceTree = "<group>"; };
+		60F352F12E8FEDEA00307BDC /* RenderDebugContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderDebugContainer.swift; sourceTree = "<group>"; };
 		60FB50CC2D15CEAE00C55E82 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRegionAreaSelectionView.swift; sourceTree = "<group>"; };
 		60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionPickerView.swift; sourceTree = "<group>"; };
@@ -1585,6 +1587,7 @@
 				60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */,
 				60054F9F2D931AA300E7C5A6 /* PDFKitView.swift */,
 				606C3EE22E674AF50050C4D6 /* IllsangZoneAlertView.swift */,
+				60F352F12E8FEDEA00307BDC /* RenderDebugContainer.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1906,6 +1909,7 @@
 				609197732E5F8FAC00F1D81B /* UserMissionHistoryViewModelItem.swift in Sources */,
 				60FF5EC52E4949F8007A5B40 /* RegionPickerView.swift in Sources */,
 				609197692E5E06FB00F1D81B /* AreaResponse+Mapping.swift in Sources */,
+				60F352F22E8FEDEA00307BDC /* RenderDebugContainer.swift in Sources */,
 				60DA1D162E6CC49E00AE314E /* Title.swift in Sources */,
 				A19628622C0763F90037C53A /* ProfileEditView.swift in Sources */,
 				601BCF1C2D7C150700138387 /* OtherUserChallengeDetailView.swift in Sources */,

--- a/ILSANG/Sources/Domain/Entity/Title/UserTitle.swift
+++ b/ILSANG/Sources/Domain/Entity/Title/UserTitle.swift
@@ -7,9 +7,16 @@
 
 import Foundation
 
-struct UserTitle {
+struct UserTitle: Equatable {
     let titleHistoryId: Int?
     let name: String
     let grade: HonorGrade
     let createdAt: Date?
+    
+    static func == (lhs: UserTitle, rhs: UserTitle) -> Bool {
+        lhs.titleHistoryId == rhs.titleHistoryId &&
+        lhs.name == rhs.name &&
+        lhs.grade == rhs.grade &&
+        lhs.createdAt == rhs.createdAt
+    }
 }

--- a/ILSANG/Sources/Global/View/RenderDebugContainer.swift
+++ b/ILSANG/Sources/Global/View/RenderDebugContainer.swift
@@ -1,0 +1,26 @@
+//
+//  RenderDebugContainer.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 10/3/25.
+//
+
+import SwiftUI
+
+struct RenderDebugContainer<Content: View>: View {
+    let content: () -> Content
+    
+    var body: some View {
+        let backgroundColor = Color(
+            red: .random(in: 0.3...1),
+            green: .random(in: 0.3...1),
+            blue: .random(in: 0.3...1)
+        )
+        
+        ZStack {
+            backgroundColor.ignoresSafeArea()
+            content()
+                .padding(4)
+        }
+    }
+}

--- a/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
@@ -10,128 +10,84 @@ import SwiftUI
 
 /// 18 버전 미만 > 시트로 이미지 확대 표시
 /// 18 버전 이상 > 네비게이션 이동(zoom 효과)
-struct ApprovalItemContentView: View {
-    @Namespace var namespace
+struct ApprovalItemContentView: View, Equatable {
+    static func == (lhs: ApprovalItemContentView, rhs: ApprovalItemContentView) -> Bool {
+        lhs.id == rhs.id
+    }
     
+    @Namespace var namespace
     @State var showMagView: Bool = false
     @State var showSheetView: Bool = false
-    let item: ApprovalMissionHistoryItem
     
+    let id: Int
+    let title: String
+    let image: UIImage?
+    let nickname: String
+    let userTitle: UserTitle?
+    let profileImage: UIImage?
+    let displayDate: String
+    let commercialAreaName: String?
     let width: CGFloat
     let height: CGFloat
     
     let onOtherUserTapped: () -> Void
-
+    
     var body: some View {
-        NavigationStack {
-            VStack(alignment: .leading, spacing: 16) {
-                Button {
-                    onOtherUserTapped()
-                } label: {
-                    profileView(nickname: item.nickname, honor: item.userTitle)
-                }
-                
-                Text(item.title)
-                    .styledFont(.title1)
-                    .foregroundStyle(.black)
-                
-                if #available(iOS 18.0, *) {
-                    Image(uiImage: item.image ?? .logo)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: width, height: height)
-                        .clipped()
-                        .contentShape(RoundedRectangle(cornerRadius: 12))
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .matchedTransitionSource(id: item.id, in: namespace)
-                        .onTapGesture {
-                            showMagView.toggle()
-                        }
-                } else {
-                    Image(uiImage: item.image ?? .logo)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: width, height: height)
-                        .clipped()
-                        .contentShape(RoundedRectangle(cornerRadius: 12))
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .onTapGesture {
-                            showSheetView.toggle()
-                        }
-                }
-                
-                HStack(spacing: 4) {
-                    Text(item.displayDate)
-                        .font(.system(size: 12, weight: .regular))
-                    Spacer(minLength: 0)
-                    if let commercialAreaName = item.commercialAreaName, !commercialAreaName.isEmpty {
-                        Image(.illsangRegion)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(18)
-                        Text(commercialAreaName)
-                            .styledFont(.badge1)
-                    }
-                }
-                .foregroundStyle(.gray500)
-                
-                HStack(spacing: 16) {
-                    emojiView(imageName: .thumbsUp, count: item.likeCount, alignment: .top)
-                    emojiView(imageName: .thumbsDown, count: item.hateCount, alignment: .bottom)
-                }
+        VStack(alignment: .leading, spacing: 16) {
+            Button {
+                onOtherUserTapped()
+            } label: {
+                ProfileView(profileImage: profileImage, nickname: nickname, honor: userTitle)
             }
-            .sheet(isPresented: $showSheetView, content: {
-                ImageFullScreenView(image: item.image ?? .logo) {
-                    showSheetView.toggle()
-                }
-            })
-            .sheet(isPresented: $showMagView) {
-                if #available(iOS 18.0, *) {
-                    ImageFullScreenView(image: item.image ?? .logo) {
+            
+            Text(title)
+                .styledFont(.title1)
+                .foregroundStyle(.black)
+            
+            if #available(iOS 18.0, *) {
+                Image(uiImage: image ?? .logo)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: width, height: height)
+                    .clipped()
+                    .contentShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .matchedTransitionSource(id: id, in: namespace)
+                    .onTapGesture {
                         showMagView.toggle()
                     }
-                    .navigationTransition(.zoom(sourceID: item.id, in: namespace))
-                } else {
-                    ImageFullScreenView(image: item.image ?? .logo) {
-                        showMagView.toggle()
+            } else {
+                Image(uiImage: image ?? .logo)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: width, height: height)
+                    .clipped()
+                    .contentShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .onTapGesture {
+                        showSheetView.toggle()
                     }
+            }
+            
+            MetadataView(displayDate: displayDate, commercialAreaName: commercialAreaName)
+        }
+        .sheet(isPresented: $showSheetView) {
+            ImageFullScreenView(image: image ?? .logo) {
+                showSheetView.toggle()
+            }
+        }
+        .sheet(isPresented: $showMagView) {
+            if #available(iOS 18.0, *) {
+                ImageFullScreenView(image: image ?? .logo) {
+                    showMagView.toggle()
+                }
+                .navigationTransition(.zoom(sourceID: id, in: namespace))
+            } else {
+                ImageFullScreenView(image: image ?? .logo) {
+                    showMagView.toggle()
                 }
             }
         }
-    }
-    
-    private func profileView(nickname: String, honor: UserTitle?) -> some View {
-        HStack(spacing: 10) {
-            Image(uiImage: item.profileImage ?? .profileCircle)
-                .resizable()
-                .frame(width: 35, height: 35)
-                .clipShape(.circle)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(nickname)
-                    .font(.system(size: 14, weight: .semibold))
-                if let honor {
-                    HonorIconView(honorTitle: honor.name, grade: honor.grade, imageSize: 20, spacing: 4, font: .badge1, fgColor: .gray500)
-                }
-            }
-        }
-        .foregroundStyle(.gray500)
-    }
-    
-    private func emojiView(imageName: UIImage, count: Int, alignment: Alignment) -> some View {
-        HStack(spacing: 4) {
-            Image(uiImage: imageName)
-                .resizable()
-                .renderingMode(.template)
-                .scaledToFit()
-                .frame(width: 21, height: 21)
-                .foregroundStyle(.gray200)
-                .frame(width: 24, height: 24, alignment: alignment)
-            Text(String(count))
-                .monospacedDigit()
-                .font(.system(size: 15, weight: .bold))
-                .foregroundStyle(.gray300)
-        }
-        .frame(height: 24)
     }
 }
 
@@ -142,8 +98,8 @@ struct ApprovalItemContentShareView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            profileView(nickname: item.nickname, honor: item.userTitle)
-
+            ProfileView(profileImage: item.profileImage, nickname: item.nickname, honor: item.userTitle)
+            
             Text(item.title)
                 .styledFont(.title1)
                 .foregroundStyle(.black)
@@ -156,43 +112,84 @@ struct ApprovalItemContentShareView: View {
                 .contentShape(RoundedRectangle(cornerRadius: 12))
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             
-            HStack(spacing: 4) {
-                Text(item.displayDate)
-                    .font(.system(size: 12, weight: .regular))
-                Spacer(minLength: 0)
-                if let commercialAreaName = item.commercialAreaName, !commercialAreaName.isEmpty {
-                    Image(.illsangRegion)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(18)
-                    Text(commercialAreaName)
-                        .styledFont(.badge1)
-                }
-            }
-            .foregroundStyle(.gray500)
+            MetadataView(displayDate: item.displayDate, commercialAreaName: item.commercialAreaName)
             
-            HStack(spacing: 16) {
-                emojiView(imageName: .thumbsUp, count: item.likeCount, alignment: .top)
-                emojiView(imageName: .thumbsDown, count: item.hateCount, alignment: .bottom)
-            }
+            ReactionView(likeCount: item.likeCount, hateCount: item.hateCount)
         }
         .background(.white)
     }
+}
+
+fileprivate struct ProfileView: View {
+    let profileImage: UIImage?
+    let nickname: String
+    let honor: UserTitle?
     
-    private func profileView(nickname: String, honor: UserTitle?) -> some View {
+    var body: some View {
         HStack(spacing: 10) {
-            Image(uiImage: item.profileImage ?? .profileCircle)
+            Image(uiImage: profileImage ?? .profileCircle)
                 .resizable()
                 .frame(width: 35, height: 35)
                 .clipShape(Circle())
-            VStack(alignment: .leading, spacing: 6) {
+            
+            VStack(alignment: .leading, spacing: 4) {
                 Text(nickname)
                     .font(.system(size: 14, weight: .semibold))
+                
                 if let honor {
-                    HonorIconView(honorTitle: honor.name, grade: honor.grade, imageSize: 20, spacing: 4, font: .badge1, fgColor: .gray500)
+                    HonorIconView(
+                        honorTitle: honor.name,
+                        grade: honor.grade,
+                        imageSize: 20,
+                        spacing: 4,
+                        font: .badge1,
+                        fgColor: .gray500
+                    )
                 }
             }
-            .foregroundStyle(.gray500)
+        }
+        .foregroundStyle(.gray500)
+    }
+}
+
+fileprivate struct MetadataView: View {
+    let displayDate: String
+    let commercialAreaName: String?
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(displayDate)
+                .font(.system(size: 12, weight: .regular))
+            
+            Spacer(minLength: 0)
+            
+            if let commercialAreaName, !commercialAreaName.isEmpty {
+                Image(.illsangRegion)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(18)
+                
+                Text(commercialAreaName)
+                    .styledFont(.badge1)
+            }
+        }
+        .foregroundStyle(.gray500)
+    }
+}
+
+struct ReactionView: View, Equatable {
+    static func == (lhs: ReactionView, rhs: ReactionView) -> Bool {
+        lhs.likeCount == rhs.likeCount &&
+        lhs.hateCount == rhs.hateCount
+    }
+    
+    let likeCount: Int
+    let hateCount: Int
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            emojiView(imageName: .thumbsUp, count: likeCount, alignment: .top)
+            emojiView(imageName: .thumbsDown, count: hateCount, alignment: .bottom)
         }
     }
     
@@ -214,11 +211,40 @@ struct ApprovalItemContentShareView: View {
     }
 }
 
+
 #Preview {
-    VStack {
-        ApprovalItemContentView(item: .mockDataList[0], width: .screenWidth-40, height:  ((.screenWidth-40) / 5) * 4, onOtherUserTapped: {})
-        ApprovalItemContentShareView(item: .mockDataList[1], width: .screenWidth-40, height:  ((.screenWidth-40) / 5) * 4)
+    let item1 = ApprovalMissionHistoryItem.mockDataList[0]
+    let item2 = ApprovalMissionHistoryItem.mockDataList[1]
+    ScrollView {
+        ApprovalItemContentView(
+            id: item1.id,
+            title: item1.title,
+            image: item1.image,
+            nickname: item1.nickname,
+            userTitle: item1.userTitle,
+            profileImage: item1.profileImage,
+            displayDate: item1.displayDate,
+            commercialAreaName: item1.commercialAreaName,
+            width: .screenWidth-40,
+            height:  ((.screenWidth-40) / 5) * 4,
+            onOtherUserTapped: { }
+        )
+        
+        ApprovalItemContentView(
+            id: item2.id,
+            title: item2.title,
+            image: item2.image,
+            nickname: item2.nickname,
+            userTitle: item2.userTitle,
+            profileImage: item2.profileImage,
+            displayDate: item2.displayDate,
+            commercialAreaName: item2.commercialAreaName,
+            width: .screenWidth-40,
+            height:  ((.screenWidth-40) / 5) * 4,
+            onOtherUserTapped: { }
+        )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding()
     .background(Color.background)
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalItemView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemView.swift
@@ -7,22 +7,42 @@
 
 import SwiftUI
 
-struct ApprovalItemView: View {
+struct ApprovalItemView: View, Equatable {
+    static func == (lhs: ApprovalItemView, rhs: ApprovalItemView) -> Bool {
+        lhs.item.id == rhs.item.id
+    }
     let item: ApprovalMissionHistoryItem
-    
     let width: CGFloat
     let height: CGFloat
-    
     let padding: CGFloat
-    let onLike: () -> Void
-    let onHate: () -> Void
-    let onOtherUserTapped: () -> Void
+    let onAction: (ApprovalAction) -> Void
+    
+    enum ApprovalAction {
+        case like
+        case hate
+        case profileTapped(userId: String)
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            ApprovalItemContentView(item: item, width: width, height: height) {
-                onOtherUserTapped()
+            ApprovalItemContentView(
+                id: item.id,
+                title: item.title,
+                image: item.image,
+                nickname: item.nickname,
+                userTitle: item.userTitle,
+                profileImage: item.profileImage,
+                displayDate: item.displayDate,
+                commercialAreaName: item.commercialAreaName,
+                width: width,
+                height: height
+            ) {
+                onAction(.profileTapped(userId: item.userId))
             }
+            .equatable()
+            
+            ReactionView(likeCount: item.likeCount, hateCount: item.hateCount)
+                .equatable()
             
             HStack(spacing: 8) {
                 emojiButton(
@@ -30,20 +50,21 @@ struct ApprovalItemView: View {
                     active: item.emojis.isSelected(.hate),
                     activeFgColor: .primary300,
                     activeBgColor: .primary100,
-                    action: { onHate() }
+                    action: { onAction(.hate) }
                 )
                 emojiButton(
                     imageName: .thumbsUp,
                     active: item.emojis.isSelected(.like),
                     activeFgColor: .white,
                     activeBgColor: .primaryPurple,
-                    action: { onLike() }
+                    action: { onAction(.like) }
                 )
             }
         }
         .padding(padding)
         .background(Color.white)
         .cornerRadius(12)
+        
     }
     
     private func emojiButton(
@@ -79,8 +100,6 @@ struct ApprovalItemView: View {
         width: .screenWidth-40,
         height: 200,
         padding: 20,
-        onLike: { },
-        onHate: { },
-        onOtherUserTapped: { }
+        onAction: { _ in}
     )
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalMissionHistoryItem.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalMissionHistoryItem.swift
@@ -25,7 +25,17 @@ struct UserEmojis {
 }
 
 @Observable
-class ApprovalMissionHistoryItem: Identifiable {
+class ApprovalMissionHistoryItem: Identifiable, Equatable {
+    static func == (lhs: ApprovalMissionHistoryItem, rhs: ApprovalMissionHistoryItem) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.title == rhs.title &&
+        lhs.displayDate == rhs.displayDate &&
+        lhs.likeCount == rhs.likeCount &&
+        lhs.hateCount == rhs.hateCount &&
+        lhs.imageId == rhs.imageId &&
+        lhs.userId == rhs.userId
+    }
+    
     let id: Int
     let title: String
     let displayDate: String

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -68,12 +68,18 @@ struct ApprovalView: View {
                         width: .screenWidth - 40,
                         height: ((.screenWidth-40) / 5) * 4,
                         padding: 20,
-                        onLike: { vm.onLike(for: idx) },
-                        onHate: { vm.onHate(for: idx) },
-                        onOtherUserTapped: {
-                            userRouter.navigateToUserProfile(userId: item.userId)
+                        onAction: { action in
+                            switch action {
+                            case .like:
+                                vm.onLike(for: idx)
+                            case .hate:
+                                vm.onHate(for: idx)
+                            case .profileTapped(let userId):
+                                userRouter.navigateToUserProfile(userId: userId)
+                            }
                         }
                     )
+                    .equatable()
                     .overlay(alignment: .topTrailing) {
                         trailingButton(for: item)
                     }

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -237,9 +237,6 @@ final class ApprovalViewModel: ObservableObject {
         case .hate:
             item.hateCount = newCount(item.hateCount, isSelected: item.emojis.isSelected(.hate))
         }
-        
-        // 리스트 업데이트
-        itemList[idx] = item
     }
     
     /// 신고 확인 버튼을 눌렀을 때 호출됩니다.


### PR DESCRIPTION
#### relate #462 

### ✏️ 개요
기존 구현에서는 likeCount, hateCount 변경 및 화면 전환 시 ApprovalItemView 전체가 리렌더링됨 >> 불필요한 성능 소모 발생
정적/동적 컴포넌트를 분리하고, Equatable을 적절히 적용해 필요한 부분만 리렌더링 되도록 개선했습니다.

### 💻 작업 사항
- Equatable / .equatable() 적용
     - ApprovalItemContentView 및 하위 주요 뷰에 Equatable 프로토콜 및 .equatable() 적용
     - 불필요한 전체 뷰 body 재계산 최소화
- 정적/동적 컴포넌트 분리
     - 정적 UI(ProfileView, MetadataView, title, 이미지 등)와 동적으로 변경되는 UI(ReactionView - likeCount, hateCount) 분리
     - 카운트 변경 시 ReactionView만 리렌더링 되도록 최적화
- RenderDebugContainer 추가
     - 목적: 어떤 뷰가 다시 그려지는지 확인할 수 있도록 RenderDebugContainer 래핑 적용


### 📱결과 화면(optional)
**`좋아요 버튼 > 프로필 전환 > 공유하기 > 이미지 확대`**

#### 수정 전

https://github.com/user-attachments/assets/1a8d725f-f284-424b-8573-d01dee43e340

#### 수정 후

https://github.com/user-attachments/assets/ec6de10d-3b64-4586-ae16-a4b503ff9a1a


### Instruments - SwiftUI

#### Instruments - SwiftUI 수정 전

<img width="3018" height="1834" alt="image" src="https://github.com/user-attachments/assets/350d547c-3d7f-4c33-b116-558705536686" />

#### Instruments - SwiftUI 수정 후

<img width="3024" height="1892" alt="image" src="https://github.com/user-attachments/assets/9d92302b-334e-465f-8113-20166537fada" />

#### Instruments 요약
<img width="935" height="274" alt="스크린샷 2025-10-04 오전 6 04 41" src="https://github.com/user-attachments/assets/9525f032-71e4-47f9-8dae-775a08056ac8" />