### PR TITLE
[Ref/#470] 퀘스트 화면: 완료 탭 제거

### DIFF
--- a/ILSANG/Sources/Domain/Enum/QuestStatus.swift
+++ b/ILSANG/Sources/Domain/Enum/QuestStatus.swift
@@ -11,7 +11,6 @@ enum QuestStatus: String, CaseIterable {
     case `default`
     case `repeat`
     case event
-    case completed
     
     var headerText: String {
         switch self {
@@ -21,26 +20,14 @@ enum QuestStatus: String, CaseIterable {
             "반복"
         case .event:
             "이벤트"
-        case .completed:
-            "완료"
         }
     }
     
     var emptyTitle: String {
-        switch self {
-        case .default, .repeat, .event:
-            "퀘스트를 모두 완료하셨어요!"
-        case .completed:
-            "완료된 퀘스트가 없어요"
-        }
+        "퀘스트를 모두 완료하셨어요!"
     }
     
     var emptySubTitle: String {
-        switch self {
-        case .default, .repeat, .event:
-            "상상할 수 없는 퀘스트를 준비 중이니\n다음 업데이트를 기대해 주세요!"
-        case .completed:
-            "퀘스트를 수행하러 가볼까요?"
-        }
+        "상상할 수 없는 퀘스트를 준비 중이니\n다음 업데이트를 기대해 주세요!"
     }
 }

--- a/ILSANG/Sources/Domain/Repository/QuestRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/QuestRepository.swift
@@ -11,7 +11,6 @@ protocol QuestRepositoryInterface {
     func getDefaultQuests(commercialAreaCode: String, orderRewardDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getRepeatQuests(commercialAreaCode: String, repeatFrequency: RepeatType, orderRewardDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getEventQuests(commercialAreaCode: String, orderRewardDesc: Bool?, orderExpiredDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
-    func getCompletedQuests(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getFavoriteQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getRecommendQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
     func getPopularQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error>
@@ -39,11 +38,6 @@ final class QuestRepository: QuestRepositoryInterface {
     
     func getEventQuests(commercialAreaCode: String, orderRewardDesc: Bool?, orderExpiredDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
         let res = await network.getEventQuests(commercialAreaCode: commercialAreaCode, orderRewardDesc: orderRewardDesc, orderExpiredDesc: orderExpiredDesc, page: page, size: size)
-        return ResponseMapper.mapPagedResponse(res)
-    }
-    
-    func getCompletedQuests(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
-        let res = await network.getCompletedQuests(page: page, size: size)
         return ResponseMapper.mapPagedResponse(res)
     }
     
@@ -142,10 +136,6 @@ final class MockQuestRepository: QuestRepositoryInterface {
     
     func getEventQuests(commercialAreaCode: String, orderRewardDesc: Bool?, orderExpiredDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
         .success(ResponseWithPage(size: size, content: mockEventQuests, totalPages: 1, totalElements: mockQuests.count, page: page, isLast: true))
-    }
-    
-    func getCompletedQuests(page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, Error> {
-        .success(ResponseWithPage(size: size, content: mockQuests+mockRepeatQuests+mockEventQuests, totalPages: 1, totalElements: mockQuests.count, page: page, isLast: true))
     }
     
     func getFavoriteQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[Quest]>, any Error> {

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -388,7 +388,7 @@ struct RecommendQuestItemView: View {
             Text("이벤트")
             EventQuestItemView(quest: quest, action: {}, favoriteAction: {})
             
-            Text("완료, 배너 완료")
+            Text("배너 완료")
             CompletedQuestItemView(quest: repeatQuest)
             
             Text("배너 미완료")

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -171,28 +171,16 @@ extension QuestView {
                         favoriteAction: { vm.toggleFavoriteStatus(quest: quest) }
                     )
                 }
-            case .completed: // 완료 퀘스트
-                ForEach(vm.currentQuests, id: \.id) { quest in
-                    CompletedQuestItemView(quest: quest)
-                }
-                
-                if vm.hasMorePage(status: .completed) {
-                    ProgressView()
-                        .task {
-                            await vm.completedPaginationManager.loadData(isRefreshing: false)
-                        }
-                }
             }
         }
-        .padding(.top, vm.selectedHeader != .completed ? 100 : 0)
+        .padding(.top, 100)
         .overlay(alignment: .top) {
             VStack(spacing: 16) {
-                if vm.selectedHeader != .completed {
-                    RegionPickerView(title: sharedState.selectedCommercialArea.areaName) {
-                        vm.showSelectMyRegionView = true
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                RegionPickerView(title: sharedState.selectedCommercialArea.areaName) {
+                    vm.showSelectMyRegionView = true
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                
                 Group {
                     if (vm.selectedHeader == .default) {
                         filterPickerDefaultView

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -30,8 +30,7 @@ class QuestViewModel: ObservableObject {
     @Published var defaultQuestListByFilter: [QuestFilterType: [QuestItem]] = [:]
     @Published var repeatQuestListByFilter: [RepeatType: [QuestFilterType: [QuestItem]]] = [:]
     @Published var eventQuestListByFilter: [EventQuestFilterType: [QuestItem]] = [:]
-    @Published var completedQuestList: [QuestItem] = []
-
+    
     var currentQuests: [QuestItem] {
         switch selectedHeader {
         case .default:
@@ -40,8 +39,6 @@ class QuestViewModel: ObservableObject {
             return repeatQuestListByFilter[repeatFilterState.selectedValue]?[questFilterState.selectedValue] ?? []
         case .event:
             return eventQuestListByFilter[eventFilterState.selectedValue] ?? []
-        case .completed:
-            return completedQuestList
         }
     }
     
@@ -53,7 +50,6 @@ class QuestViewModel: ObservableObject {
     let defaultPaginationManager: PaginationManager<QuestItem>
     let repeatPaginationManager: PaginationManager<QuestItem>
     let eventPaginationManager: PaginationManager<QuestItem>
-    let completedPaginationManager: PaginationManager<QuestItem>
     
     // MARK: throttle 관련
     let throttleInterval: TimeInterval = 2.0
@@ -84,7 +80,6 @@ class QuestViewModel: ObservableObject {
         self.defaultPaginationManager = PaginationManager(size: 20, threshold: 18)
         self.repeatPaginationManager = PaginationManager(size: 20, threshold: 18)
         self.eventPaginationManager = PaginationManager(size: 20, threshold: 18)
-        self.completedPaginationManager = PaginationManager(size: 20, threshold: 18)
         self.defaultPaginationManager.loadPageData = { [weak self] page in
             guard let self = self else { return ([], 0) }
             return await self.loadQuestListWithImage(page: page, size: 20, status: .default)
@@ -96,10 +91,6 @@ class QuestViewModel: ObservableObject {
         self.eventPaginationManager.loadPageData = { [weak self] page in
             guard let self = self else { return ([], 0) }
             return await self.loadQuestListWithImage(page: page, size: 20, status: .event)
-        }
-        self.completedPaginationManager.loadPageData = { [weak self] page in
-            guard let self = self else { return ([], 0) }
-            return await self.loadQuestListWithImage(page: page, size: 10, status: .completed)
         }
         
         questFilterState.onSelectionChange = { [weak self] _ in
@@ -165,8 +156,7 @@ class QuestViewModel: ObservableObject {
         async let defaultLoad: () = defaultPaginationManager.loadData(isRefreshing: true)
         async let repeatLoad: () = repeatPaginationManager.loadData(isRefreshing: true)
         async let eventLoad: () = eventPaginationManager.loadData(isRefreshing: true)
-        async let completedLoad: () = completedPaginationManager.loadData(isRefreshing: true)
-        _ = await (defaultLoad, repeatLoad, eventLoad, completedLoad)
+        _ = await (defaultLoad, repeatLoad, eventLoad)
         await changeViewStatus(.loaded)
     }
     
@@ -186,8 +176,6 @@ class QuestViewModel: ObservableObject {
             await repeatPaginationManager.loadData(isRefreshing: true)
         case .event:
             await eventPaginationManager.loadData(isRefreshing: true)
-        case .completed:
-            await completedPaginationManager.loadData(isRefreshing: true)
         }
         
         lastRefreshTime = Date()
@@ -219,8 +207,6 @@ class QuestViewModel: ObservableObject {
         case .event:
             let filter = eventFilterState.selectedValue
             existingList = eventQuestListByFilter[filter] ?? []
-        case .completed:
-            existingList = completedQuestList
         }
         
         // 중복된 항목 제거
@@ -273,8 +259,6 @@ class QuestViewModel: ObservableObject {
             mapRepeatQuestByFilter(list: mergedList, repeatType: repeatFilterState.selectedValue, filter: questFilterState.selectedValue)
         case .event:
             mapEventQuestByFilter(list: mergedList, filter: eventFilterState.selectedValue)
-        case .completed:
-            completedQuestList = mergedList
         }
         
         return (mergedList, getQuestList.total)
@@ -328,8 +312,6 @@ class QuestViewModel: ObservableObject {
                 page: page,
                 size: size
             )
-        case .completed:
-            result = await questRepository.getCompletedQuests(page: page, size: size)
         }
         
         switch result {
@@ -348,8 +330,6 @@ class QuestViewModel: ObservableObject {
             return repeatPaginationManager.canLoadMoreData()
         case .event:
             return eventPaginationManager.canLoadMoreData()
-        case .completed:
-            return completedPaginationManager.canLoadMoreData()
         }
     }
     


### PR DESCRIPTION
#### close #470 

### ✏️ 개요
완료된 퀘스트는 마이 화면에서만 확인할 수 있도록 UI를 개선합니다.
퀘스트 화면에서는 완료된 퀘스트가 표시되지 않도록 변경합니다.

### 💻 작업 사항
- 퀘스트 화면의 완료 탭 제거
- api 조회 제거

### 📱결과 화면(optional)
리뷰어의 이해를 위해 스크린샷을 추가해주세요
| AS-IS | TO-BE |
|--------|--------|
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/85337ee2-62c6-4ecc-9664-16dd7cfeadc9" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/6977a95b-e412-41fc-80eb-14f0c009f6ae" /> | 

