### PR TITLE
[Feat/#474]  미션 히스토리 정보 추가 표시 및 미션 유형별 조회

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -225,6 +225,11 @@
 		60ADF9D22D5DDC5B00556958 /* QuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9D12D5DDC5B00556958 /* QuizView.swift */; };
 		60ADF9D42D5DDD2000556958 /* QuestEngageInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9D32D5DDD2000556958 /* QuestEngageInfoView.swift */; };
 		60ADF9D62D5DDD4400556958 /* EngageSubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ADF9D52D5DDD4400556958 /* EngageSubscriptionView.swift */; };
+		60B392E02EABEC94005C4A88 /* UserMissionHistoryDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B392DF2EABEC94005C4A88 /* UserMissionHistoryDetailResponse.swift */; };
+		60B392E22EABEE86005C4A88 /* UserMissionHistoryDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B392E12EABEE86005C4A88 /* UserMissionHistoryDetail.swift */; };
+		60B392E42EABEFD2005C4A88 /* UserMissionHistoryDetail+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B392E32EABEFD2005C4A88 /* UserMissionHistoryDetail+Mapping.swift */; };
+		60B392E62EABF1C0005C4A88 /* UserMissionHistoryDetail+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B392E52EABF1C0005C4A88 /* UserMissionHistoryDetail+UIMapper.swift */; };
+		60B392E82EABF1EA005C4A88 /* UserMissionHistoryDetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B392E72EABF1EA005C4A88 /* UserMissionHistoryDetailItem.swift */; };
 		60B8B9E72BF9EEF1005F6DE3 /* ILSANGApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */; };
 		60B8B9E92BF9EEF1005F6DE3 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */; };
 		60B8B9EB2BF9EEF3005F6DE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60B8B9EA2BF9EEF3005F6DE3 /* Assets.xcassets */; };
@@ -287,12 +292,12 @@
 		60E401B62E72D25700BB0B6C /* LegendRankResponse+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */; };
 		60E401B82E72D33000BB0B6C /* LegendRank+UIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */; };
 		60E401BA2E74477A00BB0B6C /* QuestSubmissionNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E401B92E74477A00BB0B6C /* QuestSubmissionNotifier.swift */; };
+		60F352F22E8FEDEA00307BDC /* RenderDebugContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352F12E8FEDEA00307BDC /* RenderDebugContainer.swift */; };
 		60F352F42E91644E00307BDC /* ISO8601DateFormatter++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352F32E91644E00307BDC /* ISO8601DateFormatter++.swift */; };
 		60F352F62E91666900307BDC /* ChallengeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352F52E91666900307BDC /* ChallengeResponse.swift */; };
 		60F352F82E91667700307BDC /* QuizResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352F72E91667700307BDC /* QuizResponse.swift */; };
 		60F352FA2E9166F000307BDC /* Season.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352F92E9166F000307BDC /* Season.swift */; };
 		60F352FC2E91679400307BDC /* SeasonResponse+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352FB2E91679400307BDC /* SeasonResponse+Mapping.swift */; };
-		60F352F22E8FEDEA00307BDC /* RenderDebugContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F352F12E8FEDEA00307BDC /* RenderDebugContainer.swift */; };
 		60FB50CD2D15CEAE00C55E82 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FB50CC2D15CEAE00C55E82 /* HomeView.swift */; };
 		60FF5EC32E4937A6007A5B40 /* MyRegionAreaSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */; };
 		60FF5EC52E4949F8007A5B40 /* RegionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */; };
@@ -566,6 +571,11 @@
 		60ADF9D12D5DDC5B00556958 /* QuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizView.swift; sourceTree = "<group>"; };
 		60ADF9D32D5DDD2000556958 /* QuestEngageInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestEngageInfoView.swift; sourceTree = "<group>"; };
 		60ADF9D52D5DDD4400556958 /* EngageSubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngageSubscriptionView.swift; sourceTree = "<group>"; };
+		60B392DF2EABEC94005C4A88 /* UserMissionHistoryDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMissionHistoryDetailResponse.swift; sourceTree = "<group>"; };
+		60B392E12EABEE86005C4A88 /* UserMissionHistoryDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMissionHistoryDetail.swift; sourceTree = "<group>"; };
+		60B392E32EABEFD2005C4A88 /* UserMissionHistoryDetail+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserMissionHistoryDetail+Mapping.swift"; sourceTree = "<group>"; };
+		60B392E52EABF1C0005C4A88 /* UserMissionHistoryDetail+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserMissionHistoryDetail+UIMapper.swift"; sourceTree = "<group>"; };
+		60B392E72EABF1EA005C4A88 /* UserMissionHistoryDetailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMissionHistoryDetailItem.swift; sourceTree = "<group>"; };
 		60B8B9E32BF9EEF1005F6DE3 /* ILLSANG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ILLSANG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60B8B9E62BF9EEF1005F6DE3 /* ILSANGApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANGApp.swift; sourceTree = "<group>"; };
 		60B8B9E82BF9EEF1005F6DE3 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = "<group>"; };
@@ -632,12 +642,12 @@
 		60E401B52E72D25700BB0B6C /* LegendRankResponse+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRankResponse+Mapping.swift"; sourceTree = "<group>"; };
 		60E401B72E72D33000BB0B6C /* LegendRank+UIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegendRank+UIMapper.swift"; sourceTree = "<group>"; };
 		60E401B92E74477A00BB0B6C /* QuestSubmissionNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSubmissionNotifier.swift; sourceTree = "<group>"; };
+		60F352F12E8FEDEA00307BDC /* RenderDebugContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderDebugContainer.swift; sourceTree = "<group>"; };
 		60F352F32E91644E00307BDC /* ISO8601DateFormatter++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ISO8601DateFormatter++.swift"; sourceTree = "<group>"; };
 		60F352F52E91666900307BDC /* ChallengeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeResponse.swift; sourceTree = "<group>"; };
 		60F352F72E91667700307BDC /* QuizResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResponse.swift; sourceTree = "<group>"; };
 		60F352F92E9166F000307BDC /* Season.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Season.swift; sourceTree = "<group>"; };
 		60F352FB2E91679400307BDC /* SeasonResponse+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SeasonResponse+Mapping.swift"; sourceTree = "<group>"; };
-		60F352F12E8FEDEA00307BDC /* RenderDebugContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderDebugContainer.swift; sourceTree = "<group>"; };
 		60FB50CC2D15CEAE00C55E82 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		60FF5EC22E4937A6007A5B40 /* MyRegionAreaSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRegionAreaSelectionView.swift; sourceTree = "<group>"; };
 		60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionPickerView.swift; sourceTree = "<group>"; };
@@ -998,6 +1008,7 @@
 			children = (
 				60E401AB2E72CC6000BB0B6C /* User.swift */,
 				6091976C2E5F8E9B00F1D81B /* UserMissionHistory.swift */,
+				60B392E12EABEE86005C4A88 /* UserMissionHistoryDetail.swift */,
 				606C3EC92E60E9C20050C4D6 /* PointCommercial.swift */,
 				606C3ECB2E60EA220050C4D6 /* PointSummary.swift */,
 			);
@@ -1009,6 +1020,7 @@
 			children = (
 				60E401AD2E72CC7900BB0B6C /* User+Mapping.swift */,
 				609197702E5F8F4E00F1D81B /* UserMissionHistory+Mapping.swift */,
+				60B392E32EABEFD2005C4A88 /* UserMissionHistoryDetail+Mapping.swift */,
 				606C3ECF2E60EDC50050C4D6 /* PointCommercial+Mapping.swift */,
 				606C3ED22E60EDE10050C4D6 /* PointSummary+Mapping.swift */,
 			);
@@ -1073,6 +1085,7 @@
 				60E401B12E72CDD400BB0B6C /* LegendRankItem.swift */,
 				60D897282E537653006A8480 /* ApprovalMissionHistoryItem.swift */,
 				609197722E5F8FAC00F1D81B /* UserMissionHistoryItem.swift */,
+				60B392E72EABF1EA005C4A88 /* UserMissionHistoryDetailItem.swift */,
 				607FCBE62BFD12B100BB2D04 /* QuestItem.swift */,
 				609197602E5DEB5600F1D81B /* BannerItem.swift */,
 				609197502E5C295100F1D81B /* UserRankItem.swift */,
@@ -1373,6 +1386,7 @@
 			children = (
 				60D897112E536D2C006A8480 /* MissionHistoryResponse.swift */,
 				6091976E2E5F8EC500F1D81B /* UserMissionHistoryResponse.swift */,
+				60B392DF2EABEC94005C4A88 /* UserMissionHistoryDetailResponse.swift */,
 				60D897362E57502B006A8480 /* BaseQuestResponse.swift */,
 				60D897302E57428D006A8480 /* QuestDetailResponse.swift */,
 				60D897402E575056006A8480 /* LargeRewardQuestResponse.swift */,
@@ -1468,6 +1482,7 @@
 			children = (
 				60D897222E537421006A8480 /* MIssionHistory+UIMapper.swift */,
 				609197742E5F8FF900F1D81B /* UserMissionHistory+UIMapper.swift */,
+				60B392E52EABF1C0005C4A88 /* UserMissionHistoryDetail+UIMapper.swift */,
 				60D897522E578003006A8480 /* Quest+UIMapper.swift */,
 				609197542E5C364600F1D81B /* Rank+UIMapper.swift */,
 				609197622E5DEC0F00F1D81B /* Banner+UIMapper.swift */,
@@ -1944,6 +1959,7 @@
 				605DA0D32C0711E900CC9450 /* CameraViewModel.swift in Sources */,
 				6060B2EA2C08947B0083944D /* Image++.swift in Sources */,
 				606C3F072E69FDB20050C4D6 /* UserCoupon.swift in Sources */,
+				60B392E82EABF1EA005C4A88 /* UserMissionHistoryDetailItem.swift in Sources */,
 				606C3EF72E69F0980050C4D6 /* CouponListItem.swift in Sources */,
 				605445C82DD36D5E0005742D /* MyPageHonorManageViewModel.swift in Sources */,
 				60D897532E578003006A8480 /* Quest+UIMapper.swift in Sources */,
@@ -1953,6 +1969,7 @@
 				606C3EC22E60E9290050C4D6 /* PointResponse.swift in Sources */,
 				609197632E5DEC0F00F1D81B /* Banner+UIMapper.swift in Sources */,
 				6091974F2E5C292F00F1D81B /* AreaRankItem.swift in Sources */,
+				60B392E22EABEE86005C4A88 /* UserMissionHistoryDetail.swift in Sources */,
 				60D897202E5372BE006A8480 /* MissionHistoryResponse+Mapping.swift in Sources */,
 				606C3EE52E674B360050C4D6 /* UserRouter.swift in Sources */,
 				607FCBE42BFD124900BB2D04 /* QuestItemView.swift in Sources */,
@@ -1974,6 +1991,7 @@
 				60FF5ECB2E4BB4A6007A5B40 /* SeasonNetwork.swift in Sources */,
 				609197752E5F8FF900F1D81B /* UserMissionHistory+UIMapper.swift in Sources */,
 				60246FA82D91E57E007C05B3 /* AnalyticsService.swift in Sources */,
+				60B392E02EABEC94005C4A88 /* UserMissionHistoryDetailResponse.swift in Sources */,
 				609197362E5C25F400F1D81B /* UserRank.swift in Sources */,
 				A1868C442C09B6C50020BF16 /* UserMissionHistoryDetailView.swift in Sources */,
 				600657DC2DBCCBAA0022D117 /* MyPageInfoCardBottomView.swift in Sources */,
@@ -2042,6 +2060,7 @@
 				607FCC332C01AA7300BB2D04 /* SubmitAlertView.swift in Sources */,
 				6091973E2E5C26C000F1D81B /* MetroAreaResponse+Mapping.swift in Sources */,
 				606C3EE32E674AF50050C4D6 /* IllsangZoneAlertView.swift in Sources */,
+				60B392E62EABF1C0005C4A88 /* UserMissionHistoryDetail+UIMapper.swift in Sources */,
 				609197672E5E069600F1D81B /* Area.swift in Sources */,
 				60ADF9C22D59D47100556958 /* FontWithLineHeight.swift in Sources */,
 				606C3F0B2E69FDF00050C4D6 /* CouponResponse+Mapping.swift in Sources */,
@@ -2117,6 +2136,7 @@
 				60DA1D122E6CC2DB00AE314E /* TitleRepository.swift in Sources */,
 				609197282E59EC7100F1D81B /* RewardResponse+Mapping.swift in Sources */,
 				60E401AA2E72CA6B00BB0B6C /* LegendRank.swift in Sources */,
+				60B392E42EABEFD2005C4A88 /* UserMissionHistoryDetail+Mapping.swift in Sources */,
 				60E401AE2E72CC7900BB0B6C /* User+Mapping.swift in Sources */,
 				606C3F112E6AA8B80050C4D6 /* CouponItem.swift in Sources */,
 				6091972A2E5A226600F1D81B /* RankingDetailView.swift in Sources */,

--- a/ILSANG/Sources/Domain/Entity/User/UserMissionHistory.swift
+++ b/ILSANG/Sources/Domain/Entity/User/UserMissionHistory.swift
@@ -12,4 +12,7 @@ struct UserMissionHistory {
     let questImageId: String?
     let viewCount: Int
     let likeCount: Int
+    let questType: QuestType
+    let repeatType: RepeatType?
+    let missionType: MissionType
 }

--- a/ILSANG/Sources/Domain/Entity/User/UserMissionHistoryDetail.swift
+++ b/ILSANG/Sources/Domain/Entity/User/UserMissionHistoryDetail.swift
@@ -1,0 +1,48 @@
+//
+//  UserMissionHistoryDetail.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 10/25/25.
+//
+
+
+struct UserMissionHistoryDetail {
+    let missionHistoryId: Int
+    let title: String
+    let submitImageId, questImageId: String?
+    let likeCount: Int
+    let createdAt, commercialAreaCode: String
+    let questType: QuestType
+    let missionType: MissionType
+    let repeatType: RepeatType?
+    let writerName: String
+    let commercialGainPoint, metroGainPoint, contributionGainPoint: Int
+    let quizList: [MissionHistoryQuiz]?
+}
+
+extension UserMissionHistoryDetail {
+    static let mockData = UserMissionHistoryDetail(
+        missionHistoryId: 1,
+        title: "타이틀",
+        submitImageId: "",
+        questImageId: "",
+        likeCount: 0,
+        createdAt: "",
+        commercialAreaCode: "",
+        questType: .event,
+        missionType: .photo,
+        repeatType: nil,
+        writerName: "",
+        commercialGainPoint: 10,
+        metroGainPoint: 10,
+        contributionGainPoint: 10,
+        quizList: []
+    )
+}
+
+struct MissionHistoryQuiz {
+    let id: Int
+    let question: String
+    let answers: [String]
+    let userAnswer: String
+}

--- a/ILSANG/Sources/Domain/Enum/MissionType.swift
+++ b/ILSANG/Sources/Domain/Enum/MissionType.swift
@@ -8,8 +8,11 @@
 
 import UIKit
 
-enum MissionType: Equatable, Hashable {
+enum MissionType: Equatable, Hashable, SelectableTabItem {
     case quiz(QuizType), photo
+    
+    var id: String { self.description }
+    static var allCases: [MissionType] = [.photo, .quiz(.ox), .quiz(.text)]
     
     init?(rawValue: String) {
         if let quizType = QuizType(rawValue: rawValue) {
@@ -27,6 +30,24 @@ enum MissionType: Equatable, Hashable {
             quizType.description
         case .photo:
             "사진인증"
+        }
+    }
+    
+    var headerText: String {
+        self.description
+    }
+    
+    var parameterText: String {
+        switch self {
+        case .quiz(let quizType):
+            switch quizType {
+            case .text:
+                "WORDS"
+            case .ox:
+                "OX"
+            }
+        case .photo:
+            "PHOTO"
         }
     }
 }

--- a/ILSANG/Sources/Domain/Enum/RepeatType.swift
+++ b/ILSANG/Sources/Domain/Enum/RepeatType.swift
@@ -12,7 +12,7 @@ enum RepeatType: String, Hashable, CustomStringConvertible, CaseIterable {
     case weekly
     case monthly
     
-    init?(param: String) {
+    init?(param: String) { // FIXME: rawValue 활용
         self.init(rawValue: param.lowercased())
     }
     

--- a/ILSANG/Sources/Domain/Mapper/User/UserMissionHistory+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/User/UserMissionHistory+Mapping.swift
@@ -8,14 +8,21 @@
 
 extension UserMissionHistoryResponse {
     func toDomain() -> UserMissionHistory {
-        UserMissionHistory(
+        guard let missionType = MissionType(rawValue: missionType) else {
+            fatalError("MissionType 초기화 실패")
+        }
+        
+        return UserMissionHistory(
             missionHistoryId: missionHistoryId,
             title: title,
             createdAt: createdAt,
             submitImageId: submitImageId,
             questImageId: questImageId,
             viewCount: viewCount,
-            likeCount: likeCount
+            likeCount: likeCount,
+            questType: QuestType(rawValue: questType),
+            repeatType: repeatFrequency.flatMap { RepeatType(param: $0) },
+            missionType: missionType
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/User/UserMissionHistoryDetail+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/User/UserMissionHistoryDetail+Mapping.swift
@@ -1,0 +1,45 @@
+//
+//  UserMissionHistoryDetail+Mapping.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 10/25/25.
+//
+
+import Foundation
+
+extension UserMissionHistoryDetailResponse: DomainConvertible {
+    func toDomain() -> UserMissionHistoryDetail {
+        guard let missionType = MissionType(rawValue: missionType) else {
+            fatalError("MissionType 초기화 실패")
+        }
+        
+        return UserMissionHistoryDetail(
+            missionHistoryId: missionHistoryId,
+            title: title,
+            submitImageId: submitImageId,
+            questImageId: questImageId,
+            likeCount: likeCount,
+            createdAt: createdAt,
+            commercialAreaCode: commercialAreaCode,
+            questType: QuestType(rawValue: questType),
+            missionType: missionType,
+            repeatType: repeatFrequency.flatMap { RepeatType(param: $0) },
+            writerName: writerName,
+            commercialGainPoint: commercialGainPoint,
+            metroGainPoint: metroGainPoint,
+            contributionGainPoint: contributionGainPoint,
+            quizList: quizList?.map { $0.toDomain() }
+        )
+    }
+}
+
+extension MissionHistoryQuizResponse: DomainConvertible {
+    func toDomain() -> MissionHistoryQuiz {
+        MissionHistoryQuiz(
+            id: id,
+            question: question,
+            answers: answers.map { $0.answer },
+            userAnswer: userAnswer
+        )
+    }
+}

--- a/ILSANG/Sources/Domain/Repository/MissionHistoryRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/MissionHistoryRepository.swift
@@ -10,7 +10,8 @@ import Foundation
 protocol MissionHistoryRepositoryInterface {
     func getRandomMissionHistories(page: Int, size: Int) async -> Result<(data: [MissionHistory], total: Int), Error>
     func getMissionHistories(missionId: Int, page: Int, size: Int) async -> Result<(data: [MissionHistory], total: Int), Error>
-    func getMissionHistories(page: Int, size: Int, userId: String?) async -> Result<(data: [UserMissionHistory], total: Int), Error>
+    func getMissionHistories(page: Int, size: Int, userId: String?, missionType: MissionType, filterType: MissionHistoryFilterType) async -> Result<(data: [UserMissionHistory], total: Int), Error>
+    func getMissionHistoryDetail(missionHistoryId: Int) async -> Result<UserMissionHistoryDetail, Error>
     func deleteMissionHistory(missionHistoryId: Int) async -> Bool
     func putMissionHistory(missionHistoryId: Int) async -> Result<Void, Error>
 }
@@ -45,12 +46,22 @@ final class MissionHistoryRepository: MissionHistoryRepositoryInterface {
         }
     }
     
-    func getMissionHistories(page: Int, size: Int, userId: String?) async -> Result<(data: [UserMissionHistory], total: Int), Error> {
-        let res = await network.getMissionHistories(page: page, size: size, userId: userId)
+    func getMissionHistories(page: Int, size: Int, userId: String?, missionType: MissionType, filterType: MissionHistoryFilterType) async -> Result<(data: [UserMissionHistory], total: Int), Error> {
+        let res = await network.getMissionHistories(page: page, size: size, userId: userId, missionType: missionType, orderRewardDesc: filterType.orderRewardDesc, orderCreatedAtDesc: filterType.latest)
         switch res {
         case .success(let response):
             let domainModels = response.content.map { $0.toDomain() }
             return .success((domainModels, response.totalElements))
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+    
+    func getMissionHistoryDetail(missionHistoryId: Int) async -> Result<UserMissionHistoryDetail, Error> {
+        let res = await network.getMissionHistoryDetail(missionHistoryId: missionHistoryId)
+        switch res {
+        case .success(let response):
+            return .success(response.toDomain())
         case .failure(let error):
             return .failure(error)
         }
@@ -105,7 +116,10 @@ final class MockMissionHistoryRepository: MissionHistoryRepositoryInterface {
             submitImageId: nil,
             questImageId: nil,
             viewCount: 0,
-            likeCount: 0
+            likeCount: 0,
+            questType: .normal,
+            repeatType: nil,
+            missionType: .photo
         )
     ]
     
@@ -117,8 +131,12 @@ final class MockMissionHistoryRepository: MissionHistoryRepositoryInterface {
         .success((data: mockMissionHistory, total: mockMissionHistory.count))
     }
     
-    func getMissionHistories(page: Int, size: Int, userId: String?) async -> Result<(data: [UserMissionHistory], total: Int), any Error> {
+    func getMissionHistories(page: Int, size: Int, userId: String?, missionType: MissionType, filterType: MissionHistoryFilterType) async -> Result<(data: [UserMissionHistory], total: Int), any Error> {
         .success((data: mockUserMissionHistory, total: mockMissionHistory.count))
+    }
+    
+    func getMissionHistoryDetail(missionHistoryId: Int) async -> Result<UserMissionHistoryDetail, Error> {
+        .success(.mockData)
     }
     
     func deleteMissionHistory(missionHistoryId: Int) async -> Bool {

--- a/ILSANG/Sources/Extension/String++.swift
+++ b/ILSANG/Sources/Extension/String++.swift
@@ -64,8 +64,25 @@ extension String {
         return formattedDate
     }
     
+    func timeAgoSinceDate() -> String {
+        let date = self.split(separator: ".")
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        
+        guard let date = dateFormatter.date(from: String(date[0])) else { return "" }
+        
+        // 날짜 포맷 설정
+        let dateFormat = "yyyy년 M월 d일"
+        
+        // 설정한 포맷으로 변환
+        dateFormatter.dateFormat = dateFormat
+        let formattedDate = dateFormatter.string(from: date)
+        
+        return formattedDate
+    }
+    
     /// 서버에서 보내주는 시간을 "2024.12.31" 형식으로 날짜 포맷 변환.
-    /// 현재와 년도가 다를 경우 "2024.12.31"로 변환.
     func timeAgoCreatedAt() -> String {
         // 날짜 문자열을 "."로 분리하여 첫 번째 부분 사용
         let dateComponents = self.split(separator: ".")
@@ -76,19 +93,9 @@ extension String {
         
         // 문자열을 Date 객체로 변환
         guard let date = dateFormatter.date(from: String(dateComponents[0])) else { return "" }
-        
-        // 현재 연도와 날짜의 연도 비교
-        let currentYear = Calendar.current.component(.year, from: Date())
-        let dateYear = Calendar.current.component(.year, from: date)
-        
-        // 날짜 포맷 설정
-        var dateFormat = "yyyy.MM.dd"
-        if currentYear != dateYear {
-            dateFormat = "yyyy.MM.dd"
-        }
-        
-        // 설정한 포맷으로 변환
-        dateFormatter.dateFormat = dateFormat
+
+        // 날짜 포맷으로 변환
+        dateFormatter.dateFormat = "yyyy.MM.dd"
         let formattedDate = dateFormatter.string(from: date)
         
         return formattedDate

--- a/ILSANG/Sources/Global/Mapper/UserMissionHistory+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/UserMissionHistory+UIMapper.swift
@@ -18,7 +18,10 @@ extension UserMissionHistory {
             questImageId: questImageId,
             questImage: nil,
             viewCount: viewCount,
-            likeCount: likeCount
+            likeCount: likeCount,
+            questType: questType,
+            repeatType: repeatType,
+            missionType: missionType
         )
     }
 }

--- a/ILSANG/Sources/Global/Mapper/UserMissionHistoryDetail+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/UserMissionHistoryDetail+UIMapper.swift
@@ -1,0 +1,29 @@
+//
+//  UserMissionHistoryDetail+UIMapper.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 10/25/25.
+//
+
+import UIKit
+
+extension UserMissionHistoryDetail {
+    func toItem(submitImage: UIImage?) -> UserMissionHistoryDetailItem {
+        UserMissionHistoryDetailItem(
+            missionHistoryId: missionHistoryId,
+            title: title,
+            createdAt: createdAt, // FIXME: 변경 date
+            submitImageId: submitImageId,
+            submitImage: submitImage,
+            likeCount: likeCount,
+            writerName: writerName,
+            questType: questType,
+            repeatType: repeatType,
+            missionType: missionType,
+            commercialGainPoint: commercialGainPoint,
+            metroGainPoint: metroGainPoint,
+            contributionGainPoint: contributionGainPoint,
+            quizList: quizList
+        )
+    }
+}

--- a/ILSANG/Sources/Global/View/FilterPicker.swift
+++ b/ILSANG/Sources/Global/View/FilterPicker.swift
@@ -175,6 +175,29 @@ enum EventQuestFilterType: String, Hashable, CustomStringConvertible, CaseIterab
     }
 }
 
+enum MissionHistoryFilterType: String, Hashable, CustomStringConvertible, CaseIterable {
+    case latest = "최신순"
+    case pointHighest = "포인트 높은 순"
+    case pointLowest = "포인트 낮은 순"
+    
+    var description: String { return self.rawValue }
+    
+    var orderRewardDesc: Bool? {
+        switch self {
+        case .pointHighest: return true
+        case .pointLowest:  return false
+        default: return nil
+        }
+    }
+    
+    var latest: Bool? {
+        switch self {
+        case .latest: return true
+        default: return nil
+        }
+    }
+}
+
 struct SeasonFilterType: Hashable, CustomStringConvertible {
     let seasonNumber: Int   // -1 = 전체
     var description: String { seasonNumber == -1 ? "전체" : "시즌 \(seasonNumber)" }

--- a/ILSANG/Sources/Global/ViewModelItem/UserMissionHistoryDetailItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/UserMissionHistoryDetailItem.swift
@@ -1,51 +1,55 @@
 //
-//  UserMissionHistoryItem.swift
+//  UserMissionHistoryDetailItem.swift
 //  ILLSANG
 //
-//  Created by Lee Jinhee on 8/28/25.
+//  Created by Lee Jinhee on 10/25/25.
 //
 
 import UIKit
 
 @Observable
-class UserMissionHistoryItem {
+class UserMissionHistoryDetailItem {
     let missionHistoryId: Int
     let title, createdAt: String
     let submitImageId: String?
     var submitImage: UIImage?
-    let questImageId: String?
-    var questImage: UIImage?
-    let viewCount: Int
     let likeCount: Int
+    let writerName: String
     let questType: QuestType?
     let repeatType: RepeatType?
     let missionType: MissionType
+    let commercialGainPoint, metroGainPoint, contributionGainPoint: Int
+    let quizList: [MissionHistoryQuiz]?
     
     init(
         missionHistoryId: Int,
         title: String,
         createdAt: String,
         submitImageId: String?,
-        submitImage: UIImage?,
-        questImageId: String?,
-        questImage: UIImage?,
-        viewCount: Int,
+        submitImage: UIImage? = nil,
         likeCount: Int,
+        writerName: String,
         questType: QuestType?,
         repeatType: RepeatType?,
-        missionType: MissionType
+        missionType: MissionType,
+        commercialGainPoint: Int,
+        metroGainPoint: Int,
+        contributionGainPoint: Int,
+        quizList: [MissionHistoryQuiz]?
     ) {
         self.missionHistoryId = missionHistoryId
         self.title = title
         self.createdAt = createdAt
         self.submitImageId = submitImageId
         self.submitImage = submitImage
-        self.questImageId = questImageId
-        self.questImage = questImage
-        self.viewCount = viewCount
         self.likeCount = likeCount
+        self.writerName = writerName
         self.questType = questType
         self.repeatType = repeatType
         self.missionType = missionType
+        self.commercialGainPoint = commercialGainPoint
+        self.metroGainPoint = metroGainPoint
+        self.contributionGainPoint = contributionGainPoint
+        self.quizList = quizList
     }
 }

--- a/ILSANG/Sources/Network/MissionHistoryNetwork.swift
+++ b/ILSANG/Sources/Network/MissionHistoryNetwork.swift
@@ -23,14 +23,28 @@ final class MissionHistoryNetwork {
     
     /// 수행한 퀘스트 이력(미션) 조회
     /// useId가 nil이면 현재 유저 정보
-    func getMissionHistories(page: Int, size: Int, userId: String?) async -> Result<ResponseWithPage<[UserMissionHistoryResponse]>, Error> {
-        var parameters: Parameters = ["page": page, "size": size]
+    func getMissionHistories(page: Int, size: Int, userId: String?, missionType: MissionType, orderRewardDesc: Bool?, orderCreatedAtDesc: Bool?) async -> Result<ResponseWithPage<[UserMissionHistoryResponse]>, Error> {
+        var parameters: Parameters = [
+            "page": page,
+            "size": size,
+            "missionType": missionType.parameterText
+        ]
         if let userId {
             parameters["userId"] = userId
+        }
+        if let orderRewardDesc {
+            parameters["orderRewardDesc"] = orderRewardDesc
+        }
+        if let orderCreatedAtDesc {
+            parameters["orderCreatedAtDesc"] = orderCreatedAtDesc
         }
         return await Network.requestData(url: url+"/history", method: .get, parameters: parameters)
     }
     
+    func getMissionHistoryDetail(missionHistoryId: Int) async -> Result<UserMissionHistoryDetailResponse, Error> {
+        let parameters: Parameters = ["missionHistoryId": missionHistoryId]
+        return await Network.requestData(url: url+"/history/detail", method: .get, parameters: parameters)
+    }
     /// 신고하기
     func putMissionHistory(missionHistoryId: Int) async -> Result<ResponseWithEmpty, Error> {
         return await Network.requestData(url: url+"/history/\(missionHistoryId)", method: .put)

--- a/ILSANG/Sources/Network/Response/UserMissionHistoryDetailResponse.swift
+++ b/ILSANG/Sources/Network/Response/UserMissionHistoryDetailResponse.swift
@@ -1,0 +1,55 @@
+//
+//  UserMissionHistoryDetailResponse.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 10/25/25.
+//
+
+struct UserMissionHistoryDetailResponse: Decodable {
+    let missionHistoryId: Int
+    let title: String
+    let submitImageId, questImageId: String?
+    let likeCount: Int
+    let createdAt, commercialAreaCode, questType, missionType, writerName: String
+    let repeatFrequency: String?
+    let commercialGainPoint, metroGainPoint, contributionGainPoint: Int
+    let quizList: [MissionHistoryQuizResponse]?
+
+//    private enum CodingKeys: String, CodingKey {
+//        case missionHistoryId, title, submitImageId, questImageId, likeCount,
+//             createdAt, commercialAreaCode, questType, missionType, writerName,repeatFrequency,
+//             commercialGainPoint, metroGainPoint, contributionGainPoint, quizList
+//    }
+//
+//    init(from decoder: Decoder) throws {
+//        let container = try decoder.container(keyedBy: CodingKeys.self)
+//        missionHistoryId = try container.decode(Int.self, forKey: .missionHistoryId)
+//        title = try container.decode(String.self, forKey: .title)
+//        submitImageId = try container.decodeIfPresent(String.self, forKey: .submitImageId)
+//        questImageId = try container.decodeIfPresent(String.self, forKey: .questImageId)
+//        likeCount = try container.decode(Int.self, forKey: .likeCount)
+//        createdAt = try container.decode(String.self, forKey: .createdAt)
+//        commercialAreaCode = try container.decode(String.self, forKey: .commercialAreaCode)
+//        questType = try container.decode(String.self, forKey: .questType)
+//        missionType = try container.decode(String.self, forKey: .missionType)
+//        writerName = try container.decode(String.self, forKey: .writerName)
+//        repeatFrequency = try container.decodeIfPresent(String.self, forKey: .repeatFrequency)
+//        commercialGainPoint = try container.decode(Int.self, forKey: .commercialGainPoint)
+//        metroGainPoint = try container.decode(Int.self, forKey: .metroGainPoint)
+//        contributionGainPoint = try container.decode(Int.self, forKey: .contributionGainPoint)
+//        quizList = try? container.decodeIfPresent([MissionHistoryQuizResponse].self, forKey: .quizList) ?? [] // null 대응
+//    }
+}
+
+struct MissionHistoryQuizResponse: Decodable {
+    let id: Int
+    let question: String
+    let answers: [MissionHistoryQuizAnswerResponse]
+    let userAnswer: String
+}
+
+struct MissionHistoryQuizAnswerResponse: Decodable {
+    let id: Int
+    let answer: String
+    let quizId: Int
+}

--- a/ILSANG/Sources/Network/Response/UserMissionHistoryResponse.swift
+++ b/ILSANG/Sources/Network/Response/UserMissionHistoryResponse.swift
@@ -14,4 +14,8 @@ struct UserMissionHistoryResponse: Decodable {
     let questImageId: String?
     let viewCount: Int
     let likeCount: Int
+    let questType: String
+    let repeatFrequency: String?
+    let missionType: String
+    let commercialAreaCode: String
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
@@ -184,12 +184,14 @@ struct ReactionView: View, Equatable {
     }
     
     let likeCount: Int
-    let hateCount: Int
+    var hateCount: Int? = nil
     
     var body: some View {
         HStack(spacing: 16) {
             emojiView(imageName: .thumbsUp, count: likeCount, alignment: .top)
-            emojiView(imageName: .thumbsDown, count: hateCount, alignment: .bottom)
+            if let hateCount {
+                emojiView(imageName: .thumbsDown, count: hateCount, alignment: .bottom)
+            }
         }
     }
     
@@ -202,9 +204,9 @@ struct ReactionView: View, Equatable {
                 .frame(width: 21, height: 21)
                 .foregroundStyle(.gray200)
                 .frame(width: 24, height: 24, alignment: alignment)
-            Text(String(count))
+            Text("\(count)")
                 .monospacedDigit()
-                .font(.system(size: 15, weight: .bold))
+                .styledFont(.heading2)
                 .foregroundStyle(.gray300)
         }
         .frame(height: 24)

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
@@ -16,7 +16,7 @@ struct UserMissionHistoryDetailView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            NavigationTitleView(title: "챌린지 정보", isSeparatorHidden: false) {
+            NavigationTitleView(title: "챌린지 정보", isSeparatorHidden: true) {
                 dismiss()
             }
             .overlay(alignment: .trailing) {
@@ -24,15 +24,36 @@ struct UserMissionHistoryDetailView: View {
             }
             .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
             
-            if let missionImage = missionHistory.submitImage {
-                ChallengeImageView(missionImage: missionImage, challengeData: missionHistory)
-            } else if missionHistory.submitImage == nil {
-                ChallengeImageView(missionImage: nil, challengeData: missionHistory)
-            } else {
-                ErrorView(title: "챌린지 정보를 불러오지 못했어요", subTitle: "챌린지 정보를 불러오는 데 실패했어요.\n인터넷 연결 상태 확인 후 다시 시도해주세요.") {
-                    Task {
-                        if let submitImageId = missionHistory.submitImageId {
-                            missionHistory.submitImage = await vm.getImage(imageId: submitImageId)
+            ScrollView {
+                VStack(spacing: 0) {
+                    if let detailItem = vm.selectedMissionHistoryDetail {
+                        switch missionHistory.missionType {
+                        case .quiz(let quizType):
+                            
+                            UserMissionHistoryInfoView(missionHistory: detailItem)
+                            if let quiz = detailItem.quizList?.first {
+                                UserMissionHistoryInfoSectionView(
+                                    quizType: quizType,
+                                    question: quiz.question,
+                                    answer: quiz.answers.joined(separator: " "),
+                                    userAnswer: quiz.userAnswer,
+                                    metroPoint: detailItem.metroGainPoint,
+                                    commercialPoint: detailItem.commercialGainPoint,
+                                    contributionPoint: detailItem.contributionGainPoint,
+                                    writer: detailItem.writerName,
+                                    createdAt: detailItem.createdAt.timeAgoCreatedAt()
+                                )
+                            }
+                        case .photo:
+                            SubmittedImageView(image: detailItem.submitImage)
+                            UserMissionHistoryInfoView(missionHistory: detailItem)
+                            UserMissionHistoryInfoSectionView(
+                                metroPoint: detailItem.metroGainPoint,
+                                commercialPoint: detailItem.commercialGainPoint,
+                                contributionPoint: detailItem.contributionGainPoint,
+                                writer: detailItem.writerName,
+                                createdAt: detailItem.createdAt.timeAgoCreatedAt()
+                            )
                         }
                     }
                 }
@@ -41,9 +62,10 @@ struct UserMissionHistoryDetailView: View {
         .background(Color.background)
         .navigationBarBackButtonHidden()
         .task {
-            if let questImageId = missionHistory.questImageId, missionHistory.questImage == nil {
-                self.missionHistory.questImage = await vm.getImage(imageId: questImageId)
-            }
+            await vm.fetchMissionHistoryDetail(
+                id: missionHistory.missionHistoryId,
+                submitImage: missionHistory.submitImage
+            )
         }
         .overlay {
             if vm.challengeDelete {
@@ -65,10 +87,23 @@ struct UserMissionHistoryDetailView: View {
         }
     }
     
+    
+    private var errorView: some View {
+        ErrorView(title: "챌린지 정보를 불러오지 못했어요", subTitle: "챌린지 정보를 불러오는 데 실패했어요.\n인터넷 연결 상태 확인 후 다시 시도해주세요.") {
+            Task {
+                if let submitImageId = missionHistory.submitImageId {
+                    missionHistory.submitImage = await vm.getImage(imageId: submitImageId)
+                }
+            }
+        }
+    }
+    
     private var trailingButton: some View {
         Menu {
-            ShareLink(item: photo, preview: SharePreview(photo.caption, image: photo.image)) {
-                Label("공유하기", image: "share")
+            if missionHistory.missionType == .photo {
+                ShareLink(item: photo, preview: SharePreview(photo.caption, image: photo.image)) {
+                    Label("공유하기", image: "share")
+                }
             }
             Button {
                 vm.challengeDelete.toggle()
@@ -92,91 +127,228 @@ struct UserMissionHistoryDetailView: View {
     
     private var dailyShareUIImage: UIImage {
         let renderer = ImageRenderer(
-            content: ChallengeImageView(missionImage: missionHistory.submitImage ?? .logo, challengeData: missionHistory).frame(width: 440)
+            content: SubmittedImageView(image: missionHistory.submitImage ?? .logo).frame(width: 440) // FIXME: 공유 이미지 변경
         )
         renderer.scale = 3.0
         return renderer.uiImage ?? .init()
     }
 }
 
-struct ChallengeImageView: View {
-    let missionImage: UIImage?
-    let challengeData : UserMissionHistoryItem
+struct SubmittedImageView: View {
+    let image: UIImage?
     
     var body: some View {
-        if let submitImage = challengeData.submitImage {
-            Image(uiImage: submitImage)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .overlay(alignment: .bottom) {
-                    challengeInfoView /// 도전내역 정보 컴포넌트
-                }
-        } else {
-            Image(uiImage: .logoWithAlpha)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 72)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .padding(.bottom, 80)
-                .overlay(alignment: .bottom) {
-                    challengeInfoView /// 도전내역 정보 컴포넌트
-                }
-        }
-    }
-    
-    private var challengeInfoView: some View {
-        HStack(spacing: 0) {
-            if let questImage = challengeData.questImage {
-                Image(uiImage: questImage)
+        VStack(spacing: 0) {
+            if let image {
+                Image(uiImage: image)
                     .resizable()
-                    .frame(width: 48, height: 48)
-                    .background(.primary100)
-                    .clipShape(Circle())
-                    .padding(.trailing, 8)
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                Image(uiImage: .logoWithAlpha)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 72)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            
-            VStack(alignment: .leading, spacing: 4) {
-                Text(challengeData.title)
-                    .font(.system(size: 17, weight: .bold))
-                    .kerning(-0.3)
-                    .foregroundColor(.black)
-                HStack(spacing: 4) {
-                    Image(.heart)
-                        .resizable()
-                        .frame(width: 10, height: 9)
-                    Text("\(challengeData.likeCount)")
-                        .font(.system(size: 12, weight: .regular))
-                }
-                .foregroundColor(.gray500)
-            }
-            
-            Spacer(minLength: 0)
-            
-            Text("1/1")
-                .font(.system(size: 13, weight: .semibold))
-                .padding(.horizontal, 11)
-                .frame(height: 20)
-                .foregroundColor(.white)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .foregroundStyle(.gray300)
-                )
         }
-        .padding(.horizontal, 9.5)
-        .padding(.vertical, 20)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .foregroundStyle(.white)
-        )
-        .padding(20)
     }
 }
 
+struct UserMissionHistoryInfoView: View {
+    let missionHistory : UserMissionHistoryDetailItem
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(missionHistory.createdAt.timeAgoSinceDate() + " 에 포인트 획득 완료!")
+                .styledFont(.tabBold)
+                .foregroundColor(.primaryPurple)
+            
+            Text(missionHistory.title.forceCharWrapping)
+                .styledFont(.title1)
+                .foregroundColor(.black)
+            
+            MissionTagGroupView(
+                questType: missionHistory.questType,
+                repeatType: missionHistory.repeatType,
+                missionType: missionHistory.missionType
+            )
+            
+            if missionHistory.missionType == .photo {
+                ReactionView(likeCount: missionHistory.likeCount)
+                    .padding(.top, 12)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(.white)
+    }
+}
 
-//#Preview {
-//    ChallengeDetailView(
-//        vm: MissionHistoryViewModel(),
-//        idx: 0
-//    )
-//}
+struct UserMissionHistoryInfoSectionView: View {
+    var quizType: QuizType? = nil
+    var question: String? = nil
+    var answer: String? = nil
+    var userAnswer: String? = nil
+    let metroPoint: Int
+    let commercialPoint: Int
+    let contributionPoint: Int
+    let writer: String
+    let createdAt: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let quizType {
+                quizView(quizType)
+            }
+            
+            UserMissionHistoryInfoSection(
+                title: "획득한 포인트",
+                content:
+                    VStack(spacing: 8) {
+                        reward(title: "일상지역", metroPoint)
+                        reward(title: "일상존", commercialPoint)
+                        reward(title: "기여도", contributionPoint)
+                    }
+            )
+            
+            UserMissionHistoryInfoSection(
+                title: "작성자 정보",
+                content:
+                    Text(writer)
+                    .styledFont(.subTitle2)
+                    .foregroundColor(.black)
+            )
+            
+            UserMissionHistoryInfoSection(
+                title: "퀘스트 수행 날짜",
+                content:
+                    Text(createdAt)
+                    .styledFont(.subTitle2)
+                    .foregroundColor(.black)
+            )
+        }
+        .padding(20)
+        .padding(.bottom, 72)
+        .background(Color.background)
+    }
+    
+    private func quizView(_ type: QuizType) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            QuizQuestionView(question: question ?? "")
+            
+            switch type {
+            case .text:
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("내 정답")
+                        .styledFont(.heading2)
+                        .foregroundColor(.primaryPurple)
+                    Text(userAnswer?.forceCharWrapping ?? "")
+                        .styledFont(.subTitle2)
+                        .foregroundColor(.black)
+                        .multilineTextAlignment(.leading)
+                }
+            case .ox:
+                HStack(spacing: 10) {
+                    OXSelectionLabel(label: "O", isSelected: answer == "O")
+                    OXSelectionLabel(label: "X", isSelected: answer == "X")
+                }
+            }
+            
+            Text("정답: \(answer ?? "")")
+                .styledFont(.caption1)
+                .foregroundColor(.primary500)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 20)
+        .padding(.horizontal, 16)
+        .roundedBackground(cornerRadius: 12)
+    }
+
+    private func reward(title: String, _ point: Int) -> some View {
+        HStack {
+            Text(title)
+                .styledFont(.subTitle2)
+                .foregroundColor(.gray500)
+            Spacer()
+            Text("+\(point)P")
+                .styledFont(.title2)
+                .foregroundColor(.primaryPurple)
+        }
+    }
+}
+
+struct UserMissionHistoryInfoSection<Content: View>: View {
+    let title: String
+    let content: Content
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .styledFont(.tabBold)
+                .foregroundColor(.gray500)
+            
+            content
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .roundedBackground(cornerRadius: 12)
+        .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
+    }
+}
+
+struct MissionTagGroupView: View {
+    let questType: QuestType?
+    let repeatType: RepeatType?
+    let missionType: MissionType
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            if let tagConfig = tagConfig(for: questType) {
+                TagView(
+                    title: tagConfig.title,
+                    image: tagConfig.image,
+                    tagStyle: tagConfig.style
+                )
+            }
+            
+            TagView(
+                title: missionType.description,
+                tagStyle: .approvalType
+            )
+        }
+    }
+    
+    private func tagConfig(for type: QuestType?) -> TagConfig? {
+        switch type {
+        case .normal:
+            return nil
+        case .repeat:
+            if let repeatType {
+                return TagConfig(
+                    style: .repeat(repeatType),
+                    image: nil,
+                    offset: (0, 0),
+                    title: repeatType.description
+                )
+            } else {
+                return nil
+            }
+        case .event:
+            return TagConfig(
+                style: .eventWithIcon,
+                image: .event,
+                offset: (0, 0),
+                title: "한정"
+            )
+        case .none:
+            return nil
+        }
+    }
+}
+
+#Preview {
+    SubmittedImageView(
+        image: .img0
+    )
+}

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryItemView.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryItemView.swift
@@ -8,51 +8,162 @@
 import SwiftUI
 
 struct UserMissionHistoryItemView: View {
-    let challenge: UserMissionHistoryItem
+    let missionHistory: UserMissionHistoryItem
+    
+    private let height = 172.0
+    private let gradationHeight = 85.0
     
     var body: some View {
-        ZStack {
-            Group {
-                if let image = challenge.submitImage {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                } else {
-                    Image(uiImage: .logoWithAlpha)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 100)
-                }
-            }
-            .scaledToFill()
-            .frame(height: 172)
-            .frame(maxWidth: .infinity)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .frame(height: 85)
-                    .foregroundStyle(
-                        .linearGradient(
-                            colors: [.clear, .black.opacity(0.8)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .opacity(challenge.submitImage == nil ? 0.3 : 1)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            
-            VStack(alignment: .leading, spacing: 6) {
+        switch missionHistory.missionType {
+        case .quiz:
+            content(hasImageBackground: false)
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .roundedBackground(cornerRadius: 12)
+        case .photo:
+            VStack(alignment: .leading, spacing: 4) {
                 Spacer()
-                Text(challenge.title)
-                    .font(.system(size: 23, weight: .bold))
-                    .foregroundColor(.white)
-                
-                Text(challenge.createdAt.timeAgoCreatedAt())
-                    .font(.system(size: 13, weight: .regular))
-                    .foregroundColor(.gray200)
+                content(hasImageBackground: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(20)
+            .frame(height: height)
+            .background(
+                Group {
+                    if let image = missionHistory.submitImage {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                    } else {
+                        Image(uiImage: .logoWithAlpha)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 100)
+                    }
+                }
+                    .scaledToFill()
+                    .frame(height: height)
+                    .frame(maxWidth: .infinity)
+                    .overlay(alignment: .bottom) {
+                        Rectangle()
+                            .frame(height: gradationHeight)
+                            .foregroundStyle(
+                                .linearGradient(
+                                    colors: [.clear, .black],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                )
+                            )
+                            .opacity(missionHistory.submitImage == nil ? 0.2 : 0.6)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            )
+        }
+    }
+    
+    private func content(hasImageBackground: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(missionHistory.title)
+                .styledFont(.heading1)
+                .foregroundColor(hasImageBackground ? .white : .black)
+            
+            MissionTagGroupView(
+                questType: missionHistory.questType,
+                repeatType: missionHistory.repeatType,
+                missionType: missionHistory.missionType
+            )
+            
+            Text(missionHistory.createdAt.timeAgoCreatedAt())
+                .styledFont(.caption1)
+                .foregroundColor(hasImageBackground ? .gray200 : .gray400)
         }
     }
 }
+
+#Preview {
+    let normal = UserMissionHistoryItem(
+        missionHistoryId: 0,
+        title: "일반 미션",
+        createdAt: "2025-12-31T12:12:12",
+        submitImageId: "",
+        submitImage: .img0,
+        questImageId: "",
+        questImage: .img0,
+        viewCount: 0,
+        likeCount: 0,
+        questType: .normal,
+        repeatType: nil,
+        missionType: .quiz(.ox)
+    )
+    let daily = UserMissionHistoryItem(
+        missionHistoryId: 0,
+        title: "daily 미션",
+        createdAt: "2025-12-31T12:12:12",
+        submitImageId: "",
+        submitImage: .img0,
+        questImageId: "",
+        questImage: .img0,
+        viewCount: 0,
+        likeCount: 0,
+        questType: .repeat,
+        repeatType: .daily,
+        missionType: .photo
+    )
+    
+    let weekly = UserMissionHistoryItem(
+        missionHistoryId: 0,
+        title: "weekly 미션 타이틀",
+        createdAt: "2025-12-31T12:12:12",
+        submitImageId: "",
+        submitImage: .img0,
+        questImageId: "",
+        questImage: .img0,
+        viewCount: 0,
+        likeCount: 0,
+        questType: .repeat,
+        repeatType: .weekly,
+        missionType: .photo
+    )
+    
+    let monthly = UserMissionHistoryItem(
+        missionHistoryId: 0,
+        title: "monthly 미션",
+        createdAt: "2025-12-31T12:12:12",
+        submitImageId: "",
+        submitImage: .img0,
+        questImageId: "",
+        questImage: .img0,
+        viewCount: 0,
+        likeCount: 0,
+        questType: .repeat,
+        repeatType: .monthly,
+        missionType: .photo
+    )
+    
+    let event = UserMissionHistoryItem(
+        missionHistoryId: 0,
+        title: "event 미션",
+        createdAt: "2025-12-31T12:12:12",
+        submitImageId: "",
+        submitImage: .img0,
+        questImageId: "",
+        questImage: .img0,
+        viewCount: 0,
+        likeCount: 0,
+        questType: .event,
+        repeatType: nil,
+        missionType: .photo
+    )
+    
+    ScrollView {
+        UserMissionHistoryItemView(missionHistory: normal)
+        UserMissionHistoryItemView(missionHistory: daily)
+        UserMissionHistoryItemView(missionHistory: weekly)
+        UserMissionHistoryItemView(missionHistory: monthly)
+        UserMissionHistoryItemView(missionHistory: event)
+        UserMissionHistoryItemView(missionHistory: event)
+    }
+    .padding()
+    .background(Color.background)
+}
+

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryList.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryList.swift
@@ -12,9 +12,11 @@ struct UserMissionHistoryList: View {
     
     var body: some View {
         LazyVStack(spacing: 9) {
-            ForEach(vm.missionHistories, id: \.missionHistoryId) { missionHistory in
-                NavigationLink(destination: UserMissionHistoryDetailView(vm: vm, missionHistory: missionHistory)) {
-                    UserMissionHistoryItemView(challenge: missionHistory)
+            ForEach(vm.currentMissionHistories, id: \.missionHistoryId) { missionHistory in
+                NavigationLink(
+                    destination: UserMissionHistoryDetailView(vm: vm, missionHistory: missionHistory)
+                ) {
+                    UserMissionHistoryItemView(missionHistory: missionHistory)
                 }
             }
             
@@ -22,7 +24,7 @@ struct UserMissionHistoryList: View {
                 ProgressView()
                     .padding(.top, 12)
                     .task {
-                        await vm.challengePaginationManager.loadData(isRefreshing: false)
+                        await vm.paginationManager(for: vm.selectedMissionType).loadData(isRefreshing: false)
                     }
             }
         }

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryView.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryView.swift
@@ -20,9 +20,11 @@ struct UserMissionHistoryView: View {
         .background(Color.background)
         .navigationBarBackButtonHidden(true)
         .task {
-            if vm.missionHistories.isEmpty {
-                await vm.challengePaginationManager.loadData(isRefreshing: true)
-            }
+            await vm.loadDataIfNeeded()
+        }
+        .onChange(of: vm.selectedMissionType) { _, _ in
+            vm.closeFilterPicker()
+            Task { await vm.loadCurrentData() }
         }
     }
     
@@ -35,31 +37,49 @@ struct UserMissionHistoryView: View {
     
     @ViewBuilder
     private var content: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("수행한 챌린지")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundColor(.gray400)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.top, 20)
-                .padding(.leading, 20)
+        VStack(alignment: .leading, spacing: 0) {
+            SelectableTabHeader(
+                selectedItem: $vm.selectedMissionType,
+                items: MissionType.allCases,
+                horizontalPadding: 0,
+                height: 44,
+                hasBottomLine: true
+            )
             
-            if vm.missionHistories.isEmpty {
-                ErrorView(
-                    title: "아직 수행한 퀘스트가 없어요!",
-                    subTitle: "내 지역의 퀘스트를\n수행해 보세요",
-                    buttonTitle: "퀘스트 바로가기"
-                ) {
-                    sharedState.selectedTab = .home
-                    dismiss()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("수행한 퀘스트")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.gray400)
+                        .frame(height: 40)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 20)
+                    
+                    if vm.currentMissionHistories.isEmpty {
+                        ErrorView(
+                            title: "아직 수행한 퀘스트가 없어요!",
+                            subTitle: "내 지역의 퀘스트를\n수행해 보세요",
+                            buttonTitle: "퀘스트 바로가기"
+                        ) {
+                            sharedState.selectedTab = .home
+                            dismiss()
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 600, maxHeight: .infinity, alignment: .center)
+                    } else {
+                        UserMissionHistoryList(vm: vm)
+                            .padding(.top, 24)
+                            .padding(.horizontal, 20)
+                    }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-            } else {
-                ScrollView {
-                    UserMissionHistoryList(vm: vm)
-                        .padding(.top, 20)
-                        .padding(.horizontal, 20)
+                .overlay(alignment: .topTrailing) {
+                    PickerView(state: vm.filterState, width: 150)
+                        .padding(.trailing, 20)
                 }
+                .zIndex(1)
+                .padding(.top, 20)
+                .padding(.bottom, 72)
             }
+            .scrollDisabled(vm.currentMissionHistories.isEmpty)
         }
     }
 }
@@ -67,9 +87,8 @@ struct UserMissionHistoryView: View {
 #Preview {
     UserMissionHistoryView(
         vm: UserMissionHistoryViewModel(
-            missionHistoryRepository: MissionHistoryRepository(
-                network: MissionHistoryNetwork()
-            )
+            missionHistoryRepository: MockMissionHistoryRepository()
         )
     )
+    .environmentObject(SharedState())
 }

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryViewModel.swift
@@ -8,43 +8,96 @@
 
 import SwiftUI
 
+@MainActor
 final class UserMissionHistoryViewModel: ObservableObject {
-    @Published var missionHistories: [UserMissionHistoryItem] = []
-    
+    @Published var missionHistories: [MissionType: [UserMissionHistoryItem]] = [:]
+    @Published var selectedMissionHistoryDetail: UserMissionHistoryDetailItem?
+    @Published var selectedMissionType: MissionType = .photo
     @Published var challengeDelete = false
     
-    var hasMorePage: Bool {
-        challengePaginationManager.canLoadMoreData()
+    var currentMissionHistories: [UserMissionHistoryItem] {
+        switch selectedMissionType {
+        case .photo:
+            return missionHistories[.photo, default: []]
+        case .quiz(.ox):
+            return missionHistories[.quiz(.ox), default: []]
+        case .quiz(.text):
+            return missionHistories[.quiz(.text), default: []]
+        }
     }
+    
+    var isCurrentListEmpty: Bool {
+        currentMissionHistories.isEmpty
+    }
+    
+    var hasMorePage: Bool {
+        self.paginationManager(for: selectedMissionType).canLoadMoreData()
+    }
+    
+    var filterState: StaticFilterPickerState<MissionHistoryFilterType>
     
     private let missionHistoryRepository: MissionHistoryRepositoryInterface
     
     init(missionHistoryRepository: MissionHistoryRepositoryInterface, challengeDelete: Bool = false) {
         self.missionHistoryRepository = missionHistoryRepository
-        challengePaginationManager.loadPageData = { [weak self] page in
+        filterState = StaticFilterPickerState<MissionHistoryFilterType>(initialValue: .latest)
+        filterState.onSelectionChange = { [weak self] _ in
+            guard let self = self else { return }
+            Task {
+                await self.paginationManager(for: self.selectedMissionType).loadData(isRefreshing: true)
+            }
+        }
+        
+        self.photoPaginationManager.loadPageData = { [weak self] page in
             guard let self = self else { return ([], 0) }
-            return await loadChallengeListWithImage(page: page, size: 10)
+            return await loadPhotoMissionHistory(page: page, size: 10)
+        }
+        self.oxPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await loadQuizMissionHistory(page: page, size: 10, quizType: .ox, filterType: self.filterState.selectedValue)
+        }
+        self.textPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await loadQuizMissionHistory(page: page, size: 10, quizType: .text, filterType: self.filterState.selectedValue)
         }
     }
     
-    var challengePaginationManager = PaginationManager<UserMissionHistoryItem>(
-        size: 10,
-        threshold: 7
-    )
+    private var photoPaginationManager = PaginationManager<UserMissionHistoryItem>(size: 10, threshold: 7)
+    private var oxPaginationManager = PaginationManager<UserMissionHistoryItem>(size: 10, threshold: 7)
+    private var textPaginationManager = PaginationManager<UserMissionHistoryItem>(size: 10, threshold: 7)
     
-    @discardableResult @MainActor
-    func loadChallengeListWithImage(page: Int, size: Int) async -> ([UserMissionHistoryItem], Int) {
-        let getChallengeList = await fetchChallenges(page: page, size: size)
-        let newChallengeList = getChallengeList.data
+    func loadDataIfNeeded() async {
+        if isCurrentListEmpty {
+            await loadInitialData()
+        }
+    }
+    
+    func loadInitialData() async {
+        async let photoLoad: () = photoPaginationManager.loadData(isRefreshing: true)
+        //        async let oxLoad: () = oxPaginationManager.loadData(isRefreshing: true)
+        //        async let textLoad: () = textPaginationManager.loadData(isRefreshing: true)
+        _ = await (photoLoad/*, oxLoad, textLoad*/)
+    }
+    
+    func loadCurrentData() async {
+        if isCurrentListEmpty {
+            await self.paginationManager(for: self.selectedMissionType).loadData(isRefreshing: true)
+        }
+    }
+    
+    @discardableResult
+    private func loadPhotoMissionHistory(page: Int, size: Int) async -> ([UserMissionHistoryItem], Int) {
+        let response = await fetchMissionHistories(page: page, size: size, missionType: .photo, filterType: filterState.selectedValue)
+        let newItems = response.data
         
         if page == 0 {
-            self.missionHistories = newChallengeList
+            self.missionHistories[.photo, default: []] = newItems
         } else {
-            self.missionHistories += newChallengeList
+            self.missionHistories[.photo, default: []] += newItems
         }
         
         await withTaskGroup(of: (Int, UIImage?).self) { group in
-            for (index, challenge) in newChallengeList.enumerated() {
+            for (index, challenge) in newItems.enumerated() {
                 group.addTask {
                     let imageId = challenge.submitImageId
                     var image: UIImage? = nil
@@ -58,19 +111,37 @@ final class UserMissionHistoryViewModel: ObservableObject {
             for await (index, image) in group {
                 if let image = image {
                     if page == 0 {
-                        self.missionHistories[index].submitImage = image
+                        self.missionHistories[.photo, default: []][index].submitImage = image
                     } else {
-                        self.missionHistories[missionHistories.count - newChallengeList.count + index].submitImage = image
+                        let startIndex = (self.missionHistories[.photo]?.count ?? 0) - newItems.count
+                        let targetIndex = startIndex + index
+                        if self.missionHistories[.photo, default: []].indices.contains(targetIndex) {
+                            self.missionHistories[.photo, default: []][targetIndex].submitImage = image
+                        }
                     }
                 }
             }
         }
         
-        return (missionHistories, getChallengeList.total)
+        return (missionHistories[.photo, default: []], response.total)
     }
     
-    private func fetchChallenges(page: Int, size: Int) async -> (data: [UserMissionHistoryItem], total: Int) {
-        let response = await missionHistoryRepository.getMissionHistories(page: page, size: size, userId: nil)
+    @discardableResult
+    private func loadQuizMissionHistory(page: Int, size: Int, quizType: QuizType, filterType: MissionHistoryFilterType) async -> ([UserMissionHistoryItem], Int) {
+        let response = await fetchMissionHistories(page: page, size: size, missionType: .quiz(quizType), filterType: filterType)
+        let newItems = response.data
+        
+        if page == 0 {
+            self.missionHistories[.quiz(quizType), default: []] = newItems
+        } else {
+            self.missionHistories[.quiz(quizType), default: []] += newItems
+        }
+        
+        return (missionHistories[.quiz(quizType), default: []], response.total)
+    }
+    
+    private func fetchMissionHistories(page: Int, size: Int, missionType: MissionType, filterType: MissionHistoryFilterType) async -> (data: [UserMissionHistoryItem], total: Int) {
+        let response = await missionHistoryRepository.getMissionHistories(page: page, size: size, userId: nil, missionType: missionType, filterType: filterType)
         
         switch response {
         case .success(let res):
@@ -82,7 +153,17 @@ final class UserMissionHistoryViewModel: ObservableObject {
         }
     }
     
-    
+    func fetchMissionHistoryDetail(id: Int, submitImage: UIImage?) async {
+        let response = await missionHistoryRepository.getMissionHistoryDetail(missionHistoryId: id)
+        switch response {
+        case .success(let res):
+            self.selectedMissionHistoryDetail = res.toItem( submitImage: submitImage)
+        case .failure(let error):
+            self.selectedMissionHistoryDetail = nil
+            Log("챌린지 상세 조회 실패: \(error)")
+        }
+    }
+     
     func deleteMissionHistory(id: Int) async -> Bool {
         return await missionHistoryRepository.deleteMissionHistory(missionHistoryId: id)
     }
@@ -91,5 +172,15 @@ final class UserMissionHistoryViewModel: ObservableObject {
         await ImageCacheService.shared.loadImageAsync(imageId: imageId)
     }
     
+    func paginationManager(for type: MissionType) -> PaginationManager<UserMissionHistoryItem> {
+        switch type {
+        case .photo: return photoPaginationManager
+        case .quiz(.ox): return oxPaginationManager
+        case .quiz(.text): return textPaginationManager
+        }
+    }
     
+    func closeFilterPicker() {
+        self.filterState.pickerStatus  = .close
+    }
 }

--- a/ILSANG/Sources/Views/Profile/OtherUserChallengeDetailView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserChallengeDetailView.swift
@@ -8,18 +8,77 @@
 import SwiftUI
 
 struct OtherUserChallengeDetailView: View {
+    @ObservedObject var vm: OtherUserProfileViewModel
+    
+    let missionHistory: UserMissionHistoryItem
     @Environment(\.dismiss) var dismiss
-    let challenge: UserMissionHistoryItem
     
     var body: some View {
-        VStack {
-            NavigationTitleView(title: "챌린지 정보", isSeparatorHidden: false) {
+        VStack(spacing: 0) {
+            NavigationTitleView(title: "챌린지 정보", isSeparatorHidden: true) {
                 dismiss()
             }
-            .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
+            .overlay(alignment: .trailing) {
+                if missionHistory.missionType == .photo {
+                    trailingButton /// 공유 & 삭제 버튼
+                }
+            }
+            .padding(.bottom, 8)
             
-            ChallengeImageView(missionImage: challenge.submitImage ?? .logo, challengeData: challenge)
+            ScrollView {
+                VStack(spacing: 0) {
+                    if let detailItem = vm.selectedMissionHistoryDetail {
+                        if missionHistory.missionType == .photo {
+                            SubmittedImageView(image: missionHistory.submitImage)
+                        }
+                        
+                        UserMissionHistoryInfoView(missionHistory: detailItem)
+                        
+                        UserMissionHistoryInfoSectionView(
+                            metroPoint: detailItem.metroGainPoint,
+                            commercialPoint: detailItem.commercialGainPoint,
+                            contributionPoint: detailItem.contributionGainPoint,
+                            writer: detailItem.writerName,
+                            createdAt: detailItem.createdAt.timeAgoCreatedAt()
+                        )
+                    }
+                }
+            }
+            .background(Color.background)
+            .task {
+                await vm.fetchMissionHistoryDetail(
+                    id: missionHistory.missionHistoryId,
+                    submitImage: missionHistory.submitImage
+                )
+            }
         }
         .navigationBarBackButtonHidden()
+    }
+    
+    private var trailingButton: some View {
+        Menu {
+            ShareLink(item: photo, preview: SharePreview(photo.caption, image: photo.image)) {
+                Label("공유하기", image: "share")
+            }
+        } label: {
+            Image(.moreVertical)
+                .resizable()
+                .frame(width: 30, height: 30)
+                .foregroundStyle(.gray500)
+        }
+        .padding(.trailing, 12)
+    }
+    
+    // MARK: - 챌린지 이미지 공유하기
+    private var photo: TransferableUIImage {
+        return .init(uiimage: dailyShareUIImage, caption: "일상 챌린지 공유하기")
+    }
+    
+    private var dailyShareUIImage: UIImage {
+        let renderer = ImageRenderer(
+            content: SubmittedImageView(image: missionHistory.submitImage ?? .logo).frame(width: 440) // FIXME: 공유 이미지 변경
+        )
+        renderer.scale = 3.0
+        return renderer.uiImage ?? .init()
     }
 }

--- a/ILSANG/Sources/Views/Profile/OtherUserChallengeList.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserChallengeList.swift
@@ -11,33 +11,42 @@ struct OtherUserChallengeList: View {
     @ObservedObject var vm: OtherUserProfileViewModel
     
     var body: some View {
-        if vm.challengeList.isEmpty {
-            ErrorView(
-                title: "완료된 퀘스트가 없어요",
-                subTitle: "사용자가 아직 퀘스트를\n수행하지 않았어요",
-                showButton: false
-            )
-            .frame(minHeight: 353)
-        } else {
-            LazyVStack(spacing: 9) {
-                ForEach(vm.challengeList, id: \.missionHistoryId) { challenge in
-                    NavigationLink {
-                        OtherUserChallengeDetailView(challenge: challenge)
-                    } label: {
-                        UserMissionHistoryItemView(challenge: challenge)
+        switch vm.missionHistoryViewStatus {
+        case .error:
+            EmptyView() // TODO: 변경
+        case .loading: // page 0을 불러올 때만 프로그레스뷰 표시
+            ProgressView().frame(maxWidth: .infinity, minHeight: 300)
+        case .loaded:
+            if vm.currentMissionHistories.isEmpty {
+                ErrorView(
+                    title: "완료된 퀘스트가 없어요",
+                    subTitle: "사용자가 아직 퀘스트를\n수행하지 않았어요",
+                    showButton: false
+                )
+                .frame(minHeight: 353)
+            } else {
+                LazyVStack(spacing: 9) {
+                    ForEach(vm.currentMissionHistories, id: \.missionHistoryId) { missionHistory in
+                        NavigationLink {
+                            OtherUserChallengeDetailView(vm: vm, missionHistory: missionHistory)
+                        } label: {
+                            UserMissionHistoryItemView(missionHistory: missionHistory)
+                        }
+                    }
+                    
+                    if vm.hasMorePage {
+                        ProgressView()
+                            .padding(.top, 12)
+                            .task {
+                                await vm.photoPaginationManager.loadData(isRefreshing: false)
+                            }
                     }
                 }
-                
-                if vm.hasMorePage() {
-                    ProgressView()
-                        .padding(.top, 12)
-                        .task {
-                            await vm.challengePaginationManager.loadData(isRefreshing: false)
-                        }
-                }
+                .padding(.bottom, 72)
+                .frame(minHeight: 300, alignment: .top)
             }
-            .padding(.bottom, 72)
         }
+        
     }
 }
 

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileView.swift
@@ -40,6 +40,10 @@ struct OtherUserProfileView: View {
         .task {
             await vm.loadDataIfNeeded()
         }
+        .onChange(of: vm.selectedMissionType) { _, _ in
+            // TODO: scroll to top
+            Task { await vm.loadCurrentData() }
+        }
     }
     
     private var header: some View {
@@ -87,10 +91,10 @@ struct OtherUserProfileView: View {
                         fgColor: .gray500
                     )
                 }
-                                    
+                
                 HStack(alignment: .center, spacing: 6) {
                     ProgressBar(progress: vm.progress)
-
+                    
                     Text("\(vm.points.reduce(0) { $0 + $1.value })P")
                         .styledFont(.bold, size: 13, lineHeight: 13, tracking: 0)
                         .foregroundStyle(.primaryPurple)
@@ -104,9 +108,11 @@ struct OtherUserProfileView: View {
     
     @ViewBuilder
     private var illsangZoneSection: some View {
-        if let pointCommercial = vm.pointCommercial, let topCommercialArea = pointCommercial.topCommercialArea {
+        if let pointCommercial = vm.pointCommercial,
+           let topCommercialArea = pointCommercial.topCommercialArea,
+           let nickname = vm.userData?.nickname {
             TitleWithContentView(
-                title: "내 일상존",
+                title: "\(nickname)님의 일상존",
                 style: .my,
                 content:
                     Group {
@@ -123,10 +129,12 @@ struct OtherUserProfileView: View {
         }
     }
     
-    @ViewBuilder
     private var pointSection: some View {
-        TitleWithContentView(
-            title: "내 포인트",
+        let nickname = vm.userData?.nickname ?? ""
+        let titleText = nickname.isEmpty ? "포인트" : "\(nickname)님의 포인트"
+        
+        return TitleWithContentView(
+            title: titleText,
             style: .my,
             content:
                 UserPointView(
@@ -139,17 +147,28 @@ struct OtherUserProfileView: View {
                 .padding(.horizontal, 20)
         )
     }
-        
+    
     private var challengeSection: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            Text("수행한 챌린지")
-                .styledFont(.medium, size: 14, lineHeight: 16)
-                .foregroundColor(.gray400)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            
-            OtherUserChallengeList(vm: vm)
-        }
-        .padding(.horizontal, 20)
+        let nickname = vm.userData?.nickname ?? ""
+        let titleText = nickname.isEmpty ? "포인트" : "\(nickname)님이 수행한 퀘스트"
+        
+        return TitleWithContentView(
+            title: titleText,
+            style: .my,
+            content:
+                VStack(alignment: .leading, spacing: 20) {
+                    SelectableTabHeader(
+                        selectedItem: $vm.selectedMissionType,
+                        items: MissionType.allCases,
+                        horizontalPadding: 0,
+                        height: 44,
+                        hasBottomLine: true
+                    )
+                    
+                    OtherUserChallengeList(vm: vm)
+                }
+                .padding(.horizontal, 20)
+        )
     }
 }
 

--- a/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserProfileViewModel.swift
@@ -11,7 +11,8 @@ import Combine
 @MainActor
 final class OtherUserProfileViewModel: ObservableObject {
     let userId: String
-
+    
+    @Published var missionHistoryViewStatus: ViewStatus = .loading
     @Published var userData: User?
     @Published var userTotalPoint: Int?
     @Published var userProfileImage: UIImage?
@@ -24,19 +25,36 @@ final class OtherUserProfileViewModel: ObservableObject {
     @Published var pointCommercial: PointCommercialItem? // 내 일상존
     @Published var completedQuestCount: Int = 0
     @Published var points: [PointType: Int] = [:]
-    @Published var challengeList: [UserMissionHistoryItem] = []
-    
     @Published var seasonFilterState: DynamicFilterPickerState<SeasonFilterType>
-
-    var challengePaginationManager = PaginationManager<UserMissionHistoryItem>(
-        size: 10,
-        threshold: 7)
+    
+    @Published var selectedMissionType: MissionType = .photo
+    @Published private var missionHistories: [MissionType: [UserMissionHistoryItem]] = [:]
+    @Published var selectedMissionHistoryDetail: UserMissionHistoryDetailItem?
+    
+    var photoPaginationManager = PaginationManager<UserMissionHistoryItem>(size: 10, threshold: 7)
+    var oxPaginationManager = PaginationManager<UserMissionHistoryItem>(size: 10, threshold: 7)
+    var textPaginationManager = PaginationManager<UserMissionHistoryItem>(size: 10, threshold: 7)
     
     private let userRepository: UserRepositoryInterface
     private let missionHistoryRepository: MissionHistoryRepository
     private let areaNameService: AreaNameProvider
     private let seasonManager: SeasonManager
     private var cancellables = Set<AnyCancellable>()
+    
+    var currentMissionHistories: [UserMissionHistoryItem] {
+        switch selectedMissionType {
+        case .photo:
+            return missionHistories[.photo, default: []]
+        case .quiz(.ox):
+            return missionHistories[.quiz(.ox), default: []]
+        case .quiz(.text):
+            return missionHistories[.quiz(.text), default: []]
+        }
+    }
+    
+    var hasMorePage: Bool {
+        self.paginationManager(for: selectedMissionType).canLoadMoreData()
+    }
     
     var userPoint: Int {
         points.reduce(0) { $0 + $1.value }
@@ -57,7 +75,7 @@ final class OtherUserProfileViewModel: ObservableObject {
         self.seasonManager = seasonManager
         
         selectedSeasonNumber = seasonManager.currentSeason?.seasonNumber ?? -1 // 현재시즌으로 초기화
-
+        
         // 초기값을 -1로 통일
         seasonFilterState = DynamicFilterPickerState(
             initialValue: SeasonFilterType(seasonNumber: -1),
@@ -67,14 +85,22 @@ final class OtherUserProfileViewModel: ObservableObject {
             guard let self = self else { return }
             // 선택된 시즌 번호 업데이트
             self.selectedSeasonNumber = selectedValue.seasonNumber
-             Task { await self.fetchPointAndQuestCount() }
+            Task { await self.fetchPointAndQuestCount() }
         }
         
         updateSeasonsFromServer(seasonManager.seasons.map { $0.seasonNumber })
         
-        challengePaginationManager.loadPageData = { [weak self] page in
+        self.photoPaginationManager.loadPageData = { [weak self] page in
             guard let self = self else { return ([], 0) }
-            return await loadChallengeListWithImage(page: page, size: 10)
+            return await loadPhotoMissionHistory(page: page, size: 10)
+        }
+        self.oxPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await loadQuizMissionHistory(page: page, size: 10, quizType: .ox)
+        }
+        self.textPaginationManager.loadPageData = { [weak self] page in
+            guard let self = self else { return ([], 0) }
+            return await loadQuizMissionHistory(page: page, size: 10, quizType: .text)
         }
     }
     
@@ -90,17 +116,26 @@ final class OtherUserProfileViewModel: ObservableObject {
         async let user: () = fetchUser(userId: userId)
         async let commercial: () = fetchUserPointCommercial()
         async let pointAndQuest: () = fetchPointAndQuestCount()
-        async let history: () =  challengePaginationManager.loadData(isRefreshing: true)
+        async let history: () =  photoPaginationManager.loadData(isRefreshing: true)
         _ = await (user, commercial, pointAndQuest, history)
     }
     
+    func loadCurrentData() async {
+        if currentMissionHistories.isEmpty {
+            await self.paginationManager(for: self.selectedMissionType).loadData(isRefreshing: true)
+        }
+    }
+    
     @discardableResult
-    func loadChallengeListWithImage(page: Int, size: Int) async -> ([UserMissionHistoryItem], Int) {
-        let getChallengeList = await fetchChallenges(page: page, size: size)
-        let newChallengeList = getChallengeList.data
+    func loadPhotoMissionHistory(page: Int, size: Int) async -> ([UserMissionHistoryItem], Int) {
+        if page == 0 {
+            missionHistoryViewStatus = .loading
+        }
+        let response = await fetchMissionHistories(page: page, size: size, missionType: .photo)
+        let newItems = response.data
         
         await withTaskGroup(of: (Int, UIImage?).self) { group in
-            for (index, challenge) in newChallengeList.enumerated() {
+            for (index, challenge) in newItems.enumerated() {
                 group.addTask {
                     let imageId = challenge.submitImageId
                     guard let imageId else { return (index, nil) }
@@ -108,25 +143,44 @@ final class OtherUserProfileViewModel: ObservableObject {
                     return (index, image)
                 }
             }
-
+            
             for await (index, image) in group {
                 if let image {
-                    newChallengeList[index].submitImage = image
+                    newItems[index].submitImage = image
                 }
             }
         }
         
         if page == 0 {
-            self.challengeList = newChallengeList
+            self.missionHistories[.photo, default: []] = newItems
+            missionHistoryViewStatus = .loaded
         } else {
-            self.challengeList += newChallengeList
+            self.missionHistories[.photo, default: []] += newItems
         }
         
-        return (challengeList, getChallengeList.total)
+        return (missionHistories[.photo, default: []], response.total)
     }
     
-    private func fetchChallenges(page: Int, size: Int) async -> (data: [UserMissionHistoryItem], total: Int) {
-        let response = await missionHistoryRepository.getMissionHistories(page: page, size: size, userId: userId)
+    @discardableResult /*@MainActor*/
+    private func loadQuizMissionHistory(page: Int, size: Int, quizType: QuizType) async -> ([UserMissionHistoryItem], Int) {
+        if page == 0 {
+            missionHistoryViewStatus = .loading
+        }
+        let response = await fetchMissionHistories(page: page, size: size, missionType: .quiz(quizType))
+        let newItems = response.data
+        
+        if page == 0 {
+            self.missionHistories[.quiz(quizType), default: []] = newItems
+            missionHistoryViewStatus = .loaded
+        } else {
+            self.missionHistories[.quiz(quizType), default: []]  += newItems
+        }
+        
+        return (missionHistories[.quiz(quizType), default: []] , response.total)
+    }
+    
+    private func fetchMissionHistories(page: Int, size: Int, missionType: MissionType) async -> (data: [UserMissionHistoryItem], total: Int) {
+        let response = await missionHistoryRepository.getMissionHistories(page: page, size: size, userId: userId, missionType: missionType, filterType: .latest)
         
         switch response {
         case .success(let res):
@@ -187,14 +241,20 @@ final class OtherUserProfileViewModel: ObservableObject {
         }
     }
     
+    func fetchMissionHistoryDetail(id: Int, submitImage: UIImage?) async {
+        let response = await missionHistoryRepository.getMissionHistoryDetail(missionHistoryId: id)
+        switch response {
+        case .success(let res):
+            self.selectedMissionHistoryDetail = res.toItem(submitImage: submitImage)
+        case .failure(let error):
+            self.selectedMissionHistoryDetail = nil
+            Log("챌린지 상세 조회 실패: \(error)")
+        }
+    }
+    
     func getImage(imageId: String) async -> UIImage? {
         await ImageCacheService.shared.loadImageAsync(imageId: imageId)
     }
-    
-    func hasMorePage() -> Bool {
-        challengePaginationManager.canLoadMoreData()
-    }
-    
     
     func updateSeasonsFromServer(_ seasonNumbers: [Int]) {
         let newOptions = [SeasonFilterType(seasonNumber: -1)] + seasonNumbers.map { SeasonFilterType(seasonNumber: $0) }
@@ -202,6 +262,14 @@ final class OtherUserProfileViewModel: ObservableObject {
         // 값이 실제로 바뀌었을 때만 업데이트
         if seasonFilterState.options != newOptions {
             seasonFilterState.updateOptions(newOptions)
+        }
+    }
+    
+    private func paginationManager(for type: MissionType) -> PaginationManager<UserMissionHistoryItem> {
+        switch type {
+        case .photo: return photoPaginationManager
+        case .quiz(.ox): return oxPaginationManager
+        case .quiz(.text): return textPaginationManager
         }
     }
 }

--- a/ILSANG/Sources/Views/Quest/QuestEngage/QuizView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestEngage/QuizView.swift
@@ -26,29 +26,19 @@ struct QuizView: View, KeyboardReadable {
     
     private func oxQuizView(question: String, selection: String) -> some View {
         VStack(alignment: .leading, spacing: 24) {
-            quizTitleView(question)
+            QuizQuestionView(question: question)
             
             HStack(spacing: 10) {
                 Button {
                     selectedAnswer = "O"
                 } label: {
-                    Text("O")
-                        .styledFont(.title1)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 65)
-                        .foregroundStyle(selection == "O" ? .white : .black)
-                        .roundedBackground(cornerRadius: 12, bgColor: selection == "O" ? .primaryPurple : .gray100)
+                    OXSelectionLabel(label: "O", isSelected: selectedAnswer == "O")
                 }
                 
                 Button {
                     selectedAnswer = "X"
                 } label: {
-                    Text("X")
-                        .styledFont(.title1)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 65)
-                        .foregroundStyle(selection == "X" ? .white : .black)
-                        .roundedBackground(cornerRadius: 12, bgColor: selection == "X" ? .primaryPurple : .gray100)
+                    OXSelectionLabel(label: "X", isSelected: selectedAnswer == "X")
                 }
             }
         }
@@ -59,7 +49,7 @@ struct QuizView: View, KeyboardReadable {
     
     private func textQuizView(question: String, hint: String?, userAnswer: String) -> some View {
         VStack(alignment: .leading, spacing: 24) {
-            quizTitleView(question)
+            QuizQuestionView(question: question)
             
             if let hint {
                 VStack(alignment: .leading, spacing: 4) {
@@ -99,8 +89,30 @@ struct QuizView: View, KeyboardReadable {
         .padding(.horizontal, 20)
         .roundedBackground(cornerRadius: 12)
     }
+}
+
+/// OX 선택 상태를 정적으로 표시하는 라벨
+struct OXSelectionLabel: View {
+    let label: String
+    let isSelected: Bool
     
-    private func quizTitleView(_ question: String) -> some View {
+    var body: some View {
+        Text(label)
+            .styledFont(.title1)
+            .frame(maxWidth: .infinity)
+            .frame(height: 65)
+            .foregroundStyle(isSelected ? .white : .black)
+            .roundedBackground(
+                cornerRadius: 12,
+                bgColor: isSelected ? .primaryPurple : .gray100
+            )
+    }
+}
+
+struct QuizQuestionView: View {
+    let question: String
+    
+    var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
                 Text("Q")

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -59,8 +59,7 @@ struct BaseQuestItemView<Trailing: View>: View {
             .padding(.vertical, 20)
             .padding(.leading, 20)
             .padding(.trailing, trailingPadding)
-            .background(.white)
-            .cornerRadius(12)
+            .roundedBackground(cornerRadius: 12)
             .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
             .padding(.horizontal, 20)
         }


### PR DESCRIPTION
#### relate #474 

### ✏️ 개요
미션 히스토리 목록에 정보를 더 표기하며, 미션 유형별로 조회할 수 있게 한다.
미션 히스토리 상세 화면의 정보를 강화한다.

### 💻 작업 사항
- 미션 히스토리 목록 아이템 - 퀘스트타입, 미션타입 추가 표시
- 미션 히스토리 목록 - 조회 필터 강화 (미션유형별, 최신순&포인트순)
- 미션 히스토리 상세 화면 - 퀘스트 유형, 미션 유형, 퀴즈 정보 추가 표시
- 다른 유저의 미션 히스토리 목록 - 로딩 상태에 따라 프로그레스뷰 표시

### 📱결과 화면(optional)

### 본인 미션 히스토리
| 미션 히스토리 목록(사진인증) | 미션 히스토리 목록(OX인증) | 미션 히스토리 상세(사진인증) | 미션 히스토리 상세(OX인증) |
|--------|--------|--------|--------|
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/7e7b6897-049f-441b-be5e-0b0265651771" /> |  <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/c9ab4b51-052b-438f-82ab-2e54425c6ef2" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/84ef3177-2286-433f-a8bd-fad0b4aa2037" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/83000773-c199-4769-8b5f-6a80012480c7" /> | 

### 다른 유저 미션 히스토리

| 미션 히스토리 목록(사진인증) | 미션 히스토리 상세(사진인증) | 미션 히스토리 상세(OX인증) |
|--------|--------|--------|
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/9e58a1e3-8b06-4588-b2f3-851872cb15c8" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/c2ee0d3e-ee07-48cf-a03a-ac3be21c8ae5" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/e90a33dc-da95-4236-a5f9-27766c57e871" /> |
