### PR TITLE
[Feat/#477] 반복퀘스트 진행중 상태 추가

### DIFF
--- a/ILSANG/Sources/Domain/Entity/Quest.swift
+++ b/ILSANG/Sources/Domain/Entity/Quest.swift
@@ -21,4 +21,5 @@ struct Quest {
     let mainImageId: String?
     let userRank: Int?
     let favoriteYn: Bool?
+    let lastCompleteDate: Date?
 }

--- a/ILSANG/Sources/Domain/Mapper/BannerQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/BannerQuestResponse+Mapping.swift
@@ -9,10 +9,7 @@ import Foundation
 
 extension BannerQuestResponse: DomainConvertible {
     func toDomain() -> Quest {
-        let formatter = ISO8601DateFormatter()
-        let date = formatter.date(from: expireDate) ?? Date()
-        
-        return Quest(
+        Quest(
             id: questId,
             title: title,
             writer: writerName,
@@ -21,11 +18,12 @@ extension BannerQuestResponse: DomainConvertible {
             rewards: rewards.map { $0.toDomain() },
             missions: [],
             coupons: [],
-            expireDate: date,
+            expireDate: expireDate.toISO8601Date(),
             imageId: imageId,
             mainImageId: mainImageId,
             userRank: nil,
-            favoriteYn: nil
+            favoriteYn: nil,
+            lastCompleteDate: lastCompleteDate?.toISO8601Date()
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/BaseQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/BaseQuestResponse+Mapping.swift
@@ -9,23 +9,21 @@ import Foundation
 
 extension BaseQuestResponse: DomainConvertible {
     func toDomain() -> Quest {
-        let formatter = ISO8601DateFormatter()
-        let date = formatter.date(from: expireDate) ?? Date()
-        
-        return Quest(
+        Quest(
             id: questId,
             title: title,
             writer: writerName,
             questType: self.questType.flatMap { QuestType(rawValue: $0) },
-            repeatFrequency: self.repeatFrequency.flatMap { RepeatType(rawValue: $0) },
+            repeatFrequency: self.repeatFrequency.flatMap { RepeatType(param: $0) },
             rewards: rewards.map { $0.toDomain() },
             missions: [],
             coupons: [],
-            expireDate: date,
+            expireDate: expireDate.toISO8601Date(),
             imageId: imageId,
             mainImageId: mainImageId,
             userRank: nil,
-            favoriteYn: favoriteYn
+            favoriteYn: favoriteYn,
+            lastCompleteDate: lastCompleteDate?.toISO8601Date()
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/LargeRewardQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/LargeRewardQuestResponse+Mapping.swift
@@ -9,10 +9,7 @@ import Foundation
 
 extension LargeRewardQuestResponse: DomainConvertible {
     func toDomain() -> Quest {
-        let formatter = ISO8601DateFormatter()
-        let date = formatter.date(from: expireDate) ?? Date()
-        
-        return Quest(
+        Quest(
             id: questId,
             title: title,
             writer: writerName,
@@ -21,11 +18,12 @@ extension LargeRewardQuestResponse: DomainConvertible {
             rewards: rewards.map { $0.toDomain() },
             missions: [],
             coupons: [],
-            expireDate: date,
+            expireDate: expireDate.toISO8601Date(),
             imageId: imageId,
             mainImageId: mainImageId,
             userRank: nil,
-            favoriteYn: nil
+            favoriteYn: nil,
+            lastCompleteDate: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
@@ -9,10 +9,7 @@ import Foundation
 
 extension PopularQuestResponse: DomainConvertible {
     func toDomain() -> Quest {
-        let formatter = ISO8601DateFormatter()
-        let date = formatter.date(from: expireDate) ?? Date()
-        
-        return Quest(
+        Quest(
             id: questId,
             title: title,
             writer: writerName,
@@ -21,11 +18,12 @@ extension PopularQuestResponse: DomainConvertible {
             rewards: nil,
             missions: [],
             coupons: [],
-            expireDate: date,
+            expireDate: expireDate.toISO8601Date(),
             imageId: imageId,
             mainImageId: mainImageId,
             userRank: nil,
-            favoriteYn: nil
+            favoriteYn: nil,
+            lastCompleteDate: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/QuestDetailResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/QuestDetailResponse+Mapping.swift
@@ -9,10 +9,7 @@ import Foundation
 
 extension QuestDetailResponse: DomainConvertible {
     func toDomain() -> Quest {
-        let formatter = ISO8601DateFormatter()
-        let date = formatter.date(from: expireDate) ?? Date()
-        
-        return Quest(
+        Quest(
             id: id,
             title: title,
             writer: writerName,
@@ -21,11 +18,12 @@ extension QuestDetailResponse: DomainConvertible {
             rewards: rewards.map { $0.toDomain() },
             missions: missions.map { $0.toDomain() },
             coupons: coupons.map { $0.toDomain() },
-            expireDate: date,
+            expireDate: expireDate.toISO8601Date(),
             imageId: imageId,
             mainImageId: mainImageId,
             userRank: userRank,
-            favoriteYn: favoriteYn
+            favoriteYn: favoriteYn,
+            lastCompleteDate: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/RecommendQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/RecommendQuestResponse+Mapping.swift
@@ -21,7 +21,8 @@ extension RecommendQuestResponse: DomainConvertible {
             imageId: imageId,
             mainImageId: mainImageId,
             userRank: nil,
-            favoriteYn: nil
+            favoriteYn: nil,
+            lastCompleteDate: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Repository/QuestRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/QuestRepository.swift
@@ -87,7 +87,8 @@ final class MockQuestRepository: QuestRepositoryInterface {
             imageId: "IMQU/2025082308223895",
             mainImageId: "IMQU/2025082308223895",
             userRank: nil,
-            favoriteYn: false
+            favoriteYn: false,
+            lastCompleteDate: nil
         )
     ]
     private let mockRepeatQuests: [Quest] = [
@@ -104,7 +105,8 @@ final class MockQuestRepository: QuestRepositoryInterface {
             imageId: "IMQU/2025082308223895",
             mainImageId: "IMQU/2025082308223895",
             userRank: nil,
-            favoriteYn: false
+            favoriteYn: false,
+            lastCompleteDate: .now.addingTimeInterval(-10000)
         )
     ]
     
@@ -122,7 +124,8 @@ final class MockQuestRepository: QuestRepositoryInterface {
             imageId: "",
             mainImageId: "",
             userRank: nil,
-            favoriteYn: false
+            favoriteYn: false,
+            lastCompleteDate: nil
         )
     ]
     

--- a/ILSANG/Sources/Global/Builder/QuestItemBuilder.swift
+++ b/ILSANG/Sources/Global/Builder/QuestItemBuilder.swift
@@ -24,6 +24,7 @@ final class QuestItemBuilder {
     // private var challengeImages: [UIImage] = []
     private var userRank: Int = 0
     private var favoriteYn: Bool = false
+    private var lastCompleteDate: Date = .now.addingTimeInterval(-20000)
     
     func setId(_ id: Int) -> Self {
         self.id = id
@@ -137,7 +138,8 @@ final class QuestItemBuilder {
             mainImageId: mainImageId,
             mainImage: mainImage,
             userRank: userRank,
-            favoriteYn: favoriteYn
+            favoriteYn: favoriteYn,
+            lastCompleteDate: lastCompleteDate
         )
     }
 }

--- a/ILSANG/Sources/Global/Mapper/Quest+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/Quest+UIMapper.swift
@@ -22,7 +22,8 @@ extension Quest {
             mainImageId: mainImageId,
             mainImage: nil,
             userRank: userRank,
-            favoriteYn: favoriteYn ?? false
+            favoriteYn: favoriteYn ?? false,
+            lastCompleteDate: lastCompleteDate
         )
     }
 }

--- a/ILSANG/Sources/Global/ViewModelItem/QuestItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/QuestItem.swift
@@ -40,6 +40,7 @@ class QuestItem: Hashable, Identifiable {
     var mainImage: UIImage?
     let userRank: Int?
     var favoriteYn: Bool
+    var lastCompleteDate: Date?
     
     init(
         id: Int,
@@ -56,7 +57,8 @@ class QuestItem: Hashable, Identifiable {
         mainImageId: String?,
         mainImage: UIImage?,
         userRank: Int?,
-        favoriteYn: Bool
+        favoriteYn: Bool,
+        lastCompleteDate: Date?
     ) {
         self.id = id
         self.title = title
@@ -73,6 +75,7 @@ class QuestItem: Hashable, Identifiable {
         self.mainImage = mainImage
         self.userRank = userRank
         self.favoriteYn = favoriteYn
+        self.lastCompleteDate = lastCompleteDate
     }
     
     var missionType: MissionType { missions.first?.type ?? .photo }
@@ -83,6 +86,89 @@ class QuestItem: Hashable, Identifiable {
     
     func totalRewardPoint() -> Int {
         self.rewards?.reduce(0) { $0 + $1.point } ?? 0
+    }
+    
+    /// 반복 퀘스트가 현재 잠금 상태인지 여부
+    var isRepeatDisabled: Bool {
+        guard questType == .repeat,
+              let repeatType,
+              let lastCompleteDate
+        else { return false }
+        
+        return Date() < nextAvailableDate(for: repeatType, from: lastCompleteDate)
+    }
+    
+    var nextAvailableDate: Date? {
+        guard questType == .repeat,
+              let repeatType,
+              let lastCompleteDate
+        else { return .now }
+        return nextAvailableDate(for: repeatType, from: lastCompleteDate)
+    }
+    
+    /// 반복 퀘스트 재시작까지 남은 시간 텍스트
+    var repeatStatusText: String? {
+        guard isRepeatDisabled,
+              let repeatType,
+              let lastCompleteDate
+        else {
+            return nil
+        }
+
+        let next = nextAvailableDate(for: repeatType, from: lastCompleteDate)
+        let remaining = next.timeIntervalSinceNow
+
+        // 만약 다음 반복 주기가 퀘스트 종료일 이후라면 종료 문구 표시
+        if let expireDate, next >= expireDate {
+            let remainingToExpire = expireDate.timeIntervalSinceNow
+            if remainingToExpire <= 0 {
+                return "퀘스트 종료"
+            } else if remainingToExpire > 24 * 3600 {
+                let days = ceil(remainingToExpire / (24 * 3600))
+                return "\(Int(days))일 후 퀘스트 종료"
+            } else {
+                let hours = ceil(remainingToExpire / 3600)
+                return "\(Int(hours))시간 후 퀘스트 종료"
+            }
+        }
+
+        // 기본: 반복 가능까지 남은 시간
+        if remaining > 24 * 3600 {
+            let days = ceil(remaining / (24 * 3600))
+            return "\(Int(days))일 후 다시 시작"
+        } else {
+            let hours = ceil(remaining / 3600)
+            return "\(Int(hours))시간 후 다시 시작"
+        }
+    }
+
+    /// repeatType에 따른 다음 재시작 가능 날짜 계산
+    private func nextAvailableDate(for type: RepeatType, from date: Date) -> Date {
+        let calendar = Calendar.current
+
+        switch type {
+        case .daily:
+            // 다음날 00:00
+            if let nextDay = calendar.date(byAdding: .day, value: 1, to: date) {
+                return calendar.startOfDay(for: nextDay)
+            }
+
+        case .weekly:
+            // 다음 주 월요일 00:00
+            let nextWeek = calendar.date(byAdding: .weekOfYear, value: 1, to: date) ?? date
+            var components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: nextWeek)
+            components.weekday = 2 // 월요일 (1=일요일, 2=월요일)
+            return calendar.date(from: components).flatMap { calendar.startOfDay(for: $0) } ?? date
+
+        case .monthly:
+            // 다음달 1일 00:00
+            let nextMonth = calendar.date(byAdding: .month, value: 1, to: date) ?? date
+            var components = calendar.dateComponents([.year, .month], from: nextMonth)
+            components.day = 1
+            return calendar.date(from: components).flatMap { calendar.startOfDay(for: $0) } ?? date
+        }
+
+        return date
     }
     
     func updateChallengeImages() async {

--- a/ILSANG/Sources/Network/QuestNetwork.swift
+++ b/ILSANG/Sources/Network/QuestNetwork.swift
@@ -32,7 +32,6 @@ final class QuestNetwork {
     func getRepeatQuests(commercialAreaCode: String, repeatFrequency: RepeatType, orderRewardDesc: Bool?, page: Int, size: Int) async -> Result<ResponseWithPage<[BaseQuestResponse]>, Error> {
         var parameters: Parameters = [
             "questType": "REPEAT",
-            "completedYn": false,
             "commercialAreaCode": commercialAreaCode,
             "repeatFrequency": repeatFrequency.toParam(),
             "page": page,
@@ -78,7 +77,6 @@ final class QuestNetwork {
     /// 즐겨찾기 퀘스트 조회
     func getFavoriteQuests(commercialAreaCode: String, page: Int, size: Int) async -> Result<ResponseWithPage<[BaseQuestResponse]>, Error> {
         let parameters: Parameters = [
-            "completedYn": false,
             "favoriteYn": true,
             "commercialAreaCode": commercialAreaCode,
             "page": page,

--- a/ILSANG/Sources/Network/Response/BannerQuestResponse.swift
+++ b/ILSANG/Sources/Network/Response/BannerQuestResponse.swift
@@ -16,4 +16,5 @@ struct BannerQuestResponse: Decodable {
     let rewards: [RewardResponse]
     let questType: String
     let repeatFrequency: String?
+    let lastCompleteDate: String?
 }

--- a/ILSANG/Sources/Network/Response/BaseQuestResponse.swift
+++ b/ILSANG/Sources/Network/Response/BaseQuestResponse.swift
@@ -17,5 +17,6 @@ struct BaseQuestResponse: Decodable {
     let expireDate: String // "2025-08-21T11:53:17.556Z",
     let favoriteYn: Bool
     let rewards: [RewardResponse]
+    let lastCompleteDate: String?
 }
 

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailInfoView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailInfoView.swift
@@ -45,6 +45,17 @@ struct QuestDetailInfoView: View {
                     .styledFont(.title2)
                     .lineLimit(2)
                 
+                if let repeatStatusText = quest.repeatStatusText {
+                    Text(repeatStatusText)
+                        .styledFont(.caption2)
+                        .foregroundStyle(.black)
+                        .padding(.vertical, 2)
+                        .padding(.horizontal, 8)
+                        .background(
+                            Capsule().fill(.gray300)
+                        )
+                }
+                
                 if quest.questType == .event, let date = quest.expireDate {
                     Text(date.toDisplayFormat(.short)+"까지")
                         .styledFont(.caption2)

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailView.swift
@@ -108,7 +108,10 @@ struct QuestDetailView: View {
             .background(Color.white)
         }
         .safeAreaInset(edge: .bottom) {
-            PrimaryButton(title: "퀘스트 인증하기") {
+            PrimaryButton(
+                title: "퀘스트 인증하기",
+                buttonAble: vm.approvalButtonAble
+            ) {
                 questApproveAction()
             }
             .padding(.bottom, 4)

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
@@ -15,7 +15,6 @@ class QuestDetailViewModel: ObservableObject {
 
     var approvalDescription: String = "퀘스트를 수행하고\n인증 후, 포인트를 적립받으세요"
     var approvalButtonAble: Bool {
-        // FIXME: 조건 점검하기
         if quest.questType == .repeat { // 반복 퀘스트인 경우
             return !quest.isRepeatDisabled
         } else {

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailViewModel.swift
@@ -14,7 +14,14 @@ class QuestDetailViewModel: ObservableObject {
     private var onFavorite: ((QuestItem) -> Void)?
 
     var approvalDescription: String = "퀘스트를 수행하고\n인증 후, 포인트를 적립받으세요"
-    
+    var approvalButtonAble: Bool {
+        // FIXME: 조건 점검하기
+        if quest.questType == .repeat { // 반복 퀘스트인 경우
+            return !quest.isRepeatDisabled
+        } else {
+            return true // 일반 퀘스트는 항상 활성화
+        }
+    }
     private let questRepository: QuestRepositoryInterface
     
     init(quest: QuestItem, questRepository: QuestRepositoryInterface, onFavorite: @escaping (QuestItem) -> Void) {

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -48,6 +48,18 @@ struct BaseQuestItemView<Trailing: View>: View {
                         .foregroundColor(.gray400)
                         .padding(.bottom, 8)
                     RewardTagRow(rewards: quest.rewards ?? [])
+                    
+                    if let repeatStatusText = quest.repeatStatusText {
+                        Text(repeatStatusText)
+                            .styledFont(.caption2)
+                            .foregroundStyle(.black)
+                            .padding(.vertical, 2)
+                            .padding(.horizontal, 8)
+                            .background(
+                                Capsule().fill(.gray300)
+                            )
+                            .padding(.top, 8)
+                    }
                 }
                 Spacer(minLength: 0)
                 
@@ -59,7 +71,10 @@ struct BaseQuestItemView<Trailing: View>: View {
             .padding(.vertical, 20)
             .padding(.leading, 20)
             .padding(.trailing, trailingPadding)
-            .roundedBackground(cornerRadius: 12)
+            .roundedBackground(
+                cornerRadius: 12,
+                bgColor: (quest.isRepeatDisabled ? Color.gray200 : Color.white)
+            )
             .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
             .padding(.horizontal, 20)
         }

--- a/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
+++ b/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
@@ -58,6 +58,7 @@ class QuestRouter: ObservableObject {
                 if let imageId = questDetail.imageId {
                     questDetail.image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
                 }
+                questDetail.lastCompleteDate = quest.lastCompleteDate // 마지막 수행일 업데이트
                 self.selectedQuest = questDetail
                 
                 // 일상존 체크 후 시트 표시


### PR DESCRIPTION
#### close #477 

### ✏️ 개요
반복퀘스트의 진행중 상태를 추가합니다.

### 💻 작업 사항
- 배너 상세에 `다시시작 카운트, 종료 카운트` 표시
- 퀘스트 탭에 `다시시작 카운트, 종료 카운트` 표시
- 즐겨찾기 화면에 배너 상세에 `다시시작 카운트, 종료 카운트` 표시
- 퀘스트 상세 화면에 `다시시작 카운트, 종료 카운트` 표시

### 📱결과 화면(optional)
| 퀘스트 화면 | 즐겨찾기 화면 | 퀘스트 상세 화면 |
|--------|--------|--------|
| <img width="1170" height="2532" alt="IMG_5402" src="https://github.com/user-attachments/assets/3f45db35-d758-430e-96e0-e20c4aef588b" /> | <img width="1170" height="2532" alt="IMG_5403" src="https://github.com/user-attachments/assets/e738c020-86c7-4e44-a267-9db9e81259c9" /> | <img width="1170" height="2532" alt="IMG_5404" src="https://github.com/user-attachments/assets/42c1ac5e-0759-44b1-ac9a-2e2d9d371d90" /> | 

