### PR TITLE
[Feat/#476] 기여도 2배 표시

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		603CF4F52D79A90100A2D19E /* SubmitCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603CF4F42D79A90100A2D19E /* SubmitCompleteView.swift */; };
 		603F040B2C2416D2008A2332 /* ImageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F040A2C2416D2008A2332 /* ImageNetwork.swift */; };
 		603F04132C26ADC6008A2332 /* CommonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603F04122C26ADC6008A2332 /* CommonResponse.swift */; };
+		6040AA3A2EAFA34500CBDF9C /* DoublePointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6040AA392EAFA34500CBDF9C /* DoublePointView.swift */; };
 		6044B71D2C32B6A4002C13A0 /* UIImage++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B71C2C32B6A4002C13A0 /* UIImage++.swift */; };
 		6044B7332C33F754002C13A0 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B7322C33F754002C13A0 /* ErrorView.swift */; };
 		6044B7352C3442E6002C13A0 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6044B7342C3442E6002C13A0 /* NetworkError.swift */; };
@@ -401,6 +402,7 @@
 		603CF4F42D79A90100A2D19E /* SubmitCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitCompleteView.swift; sourceTree = "<group>"; };
 		603F040A2C2416D2008A2332 /* ImageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNetwork.swift; sourceTree = "<group>"; };
 		603F04122C26ADC6008A2332 /* CommonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResponse.swift; sourceTree = "<group>"; };
+		6040AA392EAFA34500CBDF9C /* DoublePointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoublePointView.swift; sourceTree = "<group>"; };
 		6044B71C2C32B6A4002C13A0 /* UIImage++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage++.swift"; sourceTree = "<group>"; };
 		6044B7322C33F754002C13A0 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		6044B7342C3442E6002C13A0 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -1609,6 +1611,7 @@
 				A19628742C08648C0037C53A /* NavigationTitleView.swift */,
 				6044B7322C33F754002C13A0 /* ErrorView.swift */,
 				606132772CD68FE300830948 /* TagView.swift */,
+				6040AA392EAFA34500CBDF9C /* DoublePointView.swift */,
 				609197192E59AD7200F1D81B /* ChevronCircleView.swift */,
 				604687A92D1FDA090056E394 /* CarouselAutoSlideView.swift */,
 				60FF5EC42E4949F8007A5B40 /* RegionPickerView.swift */,
@@ -2083,6 +2086,7 @@
 				606C3ED72E61ACCF0050C4D6 /* PointSummaryItem.swift in Sources */,
 				60C0F4242CCE9B2F00DB19AB /* UIDevice++.swift in Sources */,
 				60D897492E576302006A8480 /* Mission.swift in Sources */,
+				6040AA3A2EAFA34500CBDF9C /* DoublePointView.swift in Sources */,
 				A1F770642C2AABCE00DB24A0 /* MyPageViewModel.swift in Sources */,
 				606132782CD68FE300830948 /* TagView.swift in Sources */,
 				60DA1D1C2E6CC6C200AE314E /* UserTitleResponse+Mapping.swift in Sources */,

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Fg_Badge_Green.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Fg_Badge_Green.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x15",
+          "green" : "0x5E",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/DoublePoint_Left.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/DoublePoint_Left.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x13",
+          "green" : "0x7D",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/DoublePoint_Right.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/Badge/Gradient/DoublePoint_Right.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.082",
-          "green" : "0.369",
-          "red" : "0.000"
+          "blue" : "0x25",
+          "green" : "0xC5",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/ILSANG/Sources/Domain/Entity/Quest.swift
+++ b/ILSANG/Sources/Domain/Entity/Quest.swift
@@ -22,4 +22,5 @@ struct Quest {
     let userRank: Int?
     let favoriteYn: Bool?
     let lastCompleteDate: Date?
+    let commercialAreaCode: String?
 }

--- a/ILSANG/Sources/Domain/Entity/User/UserMissionHistoryDetail.swift
+++ b/ILSANG/Sources/Domain/Entity/User/UserMissionHistoryDetail.swift
@@ -17,6 +17,7 @@ struct UserMissionHistoryDetail {
     let repeatType: RepeatType?
     let writerName: String
     let commercialGainPoint, metroGainPoint, contributionGainPoint: Int
+    let contributionDoublePointYn: Bool
     let quizList: [MissionHistoryQuiz]?
 }
 
@@ -36,6 +37,7 @@ extension UserMissionHistoryDetail {
         commercialGainPoint: 10,
         metroGainPoint: 10,
         contributionGainPoint: 10,
+        contributionDoublePointYn: true,
         quizList: []
     )
 }

--- a/ILSANG/Sources/Domain/Mapper/BannerQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/BannerQuestResponse+Mapping.swift
@@ -23,7 +23,8 @@ extension BannerQuestResponse: DomainConvertible {
             mainImageId: mainImageId,
             userRank: nil,
             favoriteYn: nil,
-            lastCompleteDate: lastCompleteDate?.toISO8601Date()
+            lastCompleteDate: lastCompleteDate?.toISO8601Date(),
+            commercialAreaCode: commercialAreaCode
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/BaseQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/BaseQuestResponse+Mapping.swift
@@ -23,7 +23,8 @@ extension BaseQuestResponse: DomainConvertible {
             mainImageId: mainImageId,
             userRank: nil,
             favoriteYn: favoriteYn,
-            lastCompleteDate: lastCompleteDate?.toISO8601Date()
+            lastCompleteDate: lastCompleteDate?.toISO8601Date(),
+            commercialAreaCode: commercialAreaCode,
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/LargeRewardQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/LargeRewardQuestResponse+Mapping.swift
@@ -23,7 +23,8 @@ extension LargeRewardQuestResponse: DomainConvertible {
             mainImageId: mainImageId,
             userRank: nil,
             favoriteYn: nil,
-            lastCompleteDate: nil
+            lastCompleteDate: nil,
+            commercialAreaCode: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/PopularQuestResponse+Mapping.swift
@@ -23,7 +23,8 @@ extension PopularQuestResponse: DomainConvertible {
             mainImageId: mainImageId,
             userRank: nil,
             favoriteYn: nil,
-            lastCompleteDate: nil
+            lastCompleteDate: nil,
+            commercialAreaCode: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/QuestDetailResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/QuestDetailResponse+Mapping.swift
@@ -23,7 +23,8 @@ extension QuestDetailResponse: DomainConvertible {
             mainImageId: mainImageId,
             userRank: userRank,
             favoriteYn: favoriteYn,
-            lastCompleteDate: nil
+            lastCompleteDate: nil,
+            commercialAreaCode: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/RecommendQuestResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/RecommendQuestResponse+Mapping.swift
@@ -22,7 +22,8 @@ extension RecommendQuestResponse: DomainConvertible {
             mainImageId: mainImageId,
             userRank: nil,
             favoriteYn: nil,
-            lastCompleteDate: nil
+            lastCompleteDate: nil,
+            commercialAreaCode: nil
         )
     }
 }

--- a/ILSANG/Sources/Domain/Mapper/User/UserMissionHistoryDetail+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/User/UserMissionHistoryDetail+Mapping.swift
@@ -28,6 +28,7 @@ extension UserMissionHistoryDetailResponse: DomainConvertible {
             commercialGainPoint: commercialGainPoint,
             metroGainPoint: metroGainPoint,
             contributionGainPoint: contributionGainPoint,
+            contributionDoublePointYn: contributionDoublePointYn,
             quizList: quizList?.map { $0.toDomain() }
         )
     }

--- a/ILSANG/Sources/Domain/Repository/QuestRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/QuestRepository.swift
@@ -88,7 +88,8 @@ final class MockQuestRepository: QuestRepositoryInterface {
             mainImageId: "IMQU/2025082308223895",
             userRank: nil,
             favoriteYn: false,
-            lastCompleteDate: nil
+            lastCompleteDate: nil,
+            commercialAreaCode: "R100"
         )
     ]
     private let mockRepeatQuests: [Quest] = [
@@ -106,7 +107,8 @@ final class MockQuestRepository: QuestRepositoryInterface {
             mainImageId: "IMQU/2025082308223895",
             userRank: nil,
             favoriteYn: false,
-            lastCompleteDate: .now.addingTimeInterval(-10000)
+            lastCompleteDate: .now.addingTimeInterval(-10000),
+            commercialAreaCode: "R100"
         )
     ]
     
@@ -125,7 +127,8 @@ final class MockQuestRepository: QuestRepositoryInterface {
             mainImageId: "",
             userRank: nil,
             favoriteYn: false,
-            lastCompleteDate: nil
+            lastCompleteDate: nil,
+            commercialAreaCode: "R100"
         )
     ]
     

--- a/ILSANG/Sources/Global/Builder/QuestItemBuilder.swift
+++ b/ILSANG/Sources/Global/Builder/QuestItemBuilder.swift
@@ -25,6 +25,8 @@ final class QuestItemBuilder {
     private var userRank: Int = 0
     private var favoriteYn: Bool = false
     private var lastCompleteDate: Date = .now.addingTimeInterval(-20000)
+    private var commercialAreaCode: String = "R100"
+    private var isMyIllsangZone: Bool = true
     
     func setId(_ id: Int) -> Self {
         self.id = id
@@ -139,7 +141,9 @@ final class QuestItemBuilder {
             mainImage: mainImage,
             userRank: userRank,
             favoriteYn: favoriteYn,
-            lastCompleteDate: lastCompleteDate
+            lastCompleteDate: lastCompleteDate,
+            commercialAreaCode: commercialAreaCode,
+            isMyIllsangZone: isMyIllsangZone
         )
     }
 }

--- a/ILSANG/Sources/Global/Mapper/Quest+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/Quest+UIMapper.swift
@@ -6,7 +6,17 @@
 //
 
 extension Quest {
-    func toQuestItem() -> QuestItem {
+    func toQuestItem(myCommercialCode: String?, questCommercialCode: String?) -> QuestItem {
+        // commercialAreaCode 우선, 없으면 questCommercialCode로 비교
+        let compareCode = commercialAreaCode ?? questCommercialCode
+        let isMyIllsangZone: Bool
+
+        if let compareCode, let myCommercialCode {
+            isMyIllsangZone = compareCode == myCommercialCode
+        } else {
+            isMyIllsangZone = false
+        }
+        
         return QuestItem(
             id: id,
             title: title,
@@ -23,7 +33,32 @@ extension Quest {
             mainImage: nil,
             userRank: userRank,
             favoriteYn: favoriteYn ?? false,
-            lastCompleteDate: lastCompleteDate
+            lastCompleteDate: lastCompleteDate,
+            commercialAreaCode: commercialAreaCode,
+            isMyIllsangZone: isMyIllsangZone
+        )
+    }
+    
+    func toQuestItem(isMyIllsangZone: Bool) -> QuestItem {
+        return QuestItem(
+            id: id,
+            title: title,
+            writer: writer,
+            questType: questType,
+            repeatType: repeatFrequency,
+            rewards: rewards,
+            missions: missions,
+            coupons: coupons.map { $0.toCoupon() },
+            expireDate: expireDate,
+            imageId: imageId,
+            image: nil,
+            mainImageId: mainImageId,
+            mainImage: nil,
+            userRank: userRank,
+            favoriteYn: favoriteYn ?? false,
+            lastCompleteDate: lastCompleteDate,
+            commercialAreaCode: commercialAreaCode,
+            isMyIllsangZone: isMyIllsangZone
         )
     }
 }

--- a/ILSANG/Sources/Global/Mapper/UserMissionHistoryDetail+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/UserMissionHistoryDetail+UIMapper.swift
@@ -23,6 +23,7 @@ extension UserMissionHistoryDetail {
             commercialGainPoint: commercialGainPoint,
             metroGainPoint: metroGainPoint,
             contributionGainPoint: contributionGainPoint,
+            contributionDoublePointYn: contributionDoublePointYn,
             quizList: quizList
         )
     }

--- a/ILSANG/Sources/Global/View/DoublePointView.swift
+++ b/ILSANG/Sources/Global/View/DoublePointView.swift
@@ -1,0 +1,45 @@
+//
+//  DoublePointView.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 10/27/25.
+//
+
+import SwiftUI
+
+struct DoublePointView: View {
+    enum Style {
+        case text
+        case background
+        
+        var gradient: LinearGradient {
+            LinearGradient(
+                colors: [.doublePointLeft, .doublePointRight],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        }
+    }
+    let style: Style
+    
+    var body: some View {
+        Text("X2")
+            .styledFont(.badge2)
+            .frame(width: 20, height: 20)
+            .foregroundStyle(
+                style == .text
+                ? AnyShapeStyle(style.gradient)
+                : AnyShapeStyle(Color.white)
+            )
+            .background(
+                style == .background
+                ? style.gradient.clipShape(Circle())
+                : nil
+            )
+    }
+}
+
+#Preview {
+    DoublePointView(style: .text)
+    DoublePointView(style: .background)
+}

--- a/ILSANG/Sources/Global/View/TagView.swift
+++ b/ILSANG/Sources/Global/View/TagView.swift
@@ -7,14 +7,27 @@
 
 import SwiftUI
 
-struct TagView: View {
+struct TagView<TrailingView: View>: View {
     let title: String
     var image: ImageResource? = nil
     let tagStyle: TagStyle
+    let trailingView: TrailingView?
+    
+    init(
+        title: String,
+        image: ImageResource? = nil,
+        tagStyle: TagStyle,
+        @ViewBuilder trailingView: () -> TrailingView = { EmptyView() }
+    ) {
+        self.title = title
+        self.image = image
+        self.tagStyle = tagStyle
+        self.trailingView = trailingView()
+    }
     
     var body: some View {
         HStack(spacing: 0) {
-            if let image = image {
+            if let image {
                 Image(image)
                     .resizable()
                     .frame(width: tagStyle.iconSize, height: tagStyle.iconSize)
@@ -23,102 +36,104 @@ struct TagView: View {
             }
             Text(title)
                 .multilineTextAlignment(.center)
+            if let trailingView {
+                trailingView
+            }
         }
         .modifier(TagViewModifier(style: tagStyle))
     }
 }
 
-extension TagView {
-    enum TagStyle {
-        case level, pointWithIcon, `repeat`(RepeatType), approvalType
-        case levelStroke, levelStrokeBig
-        case eventWithIcon
-        var font: Font {
-            switch self {
-            case .level, .levelStroke: return .system(size: 13, weight: .bold)
-            case .levelStrokeBig: return .system(size: 19, weight: .bold)
-            case .pointWithIcon: return .system(size: 12, weight: .regular)
-            case .repeat, .approvalType, .eventWithIcon: return .system(size: 10, weight: .semibold)
-            }
+enum TagStyle {
+    case level, pointWithIcon, `repeat`(RepeatType), approvalType
+    case levelStroke, levelStrokeBig
+    case eventWithIcon
+    var font: Font {
+        switch self {
+        case .level, .levelStroke: return .system(size: 13, weight: .bold)
+        case .levelStrokeBig: return .system(size: 19, weight: .bold)
+        case .pointWithIcon: return .system(size: 12, weight: .regular)
+        case .repeat, .approvalType, .eventWithIcon: return .system(size: 10, weight: .semibold)
         }
-        
-        var fgColor: Color {
-            switch self {
-            case .level: return .white
-            case .levelStroke: return .primaryPurple
-            case .levelStrokeBig: return .primaryPurple
-            case .pointWithIcon: return .primaryPurple
-            case .repeat(let type): return type.fgColor
-            case .approvalType: return .white
-            case .eventWithIcon: return .white
-            }
+    }
+    
+    var fgColor: Color {
+        switch self {
+        case .level: return .white
+        case .levelStroke: return .primaryPurple
+        case .levelStrokeBig: return .primaryPurple
+        case .pointWithIcon: return .primaryPurple
+        case .repeat(let type): return type.fgColor
+        case .approvalType: return .white
+        case .eventWithIcon: return .white
         }
-        
-        var bgColor: Color {
-            switch self {
-            case .level: return .primaryPurple
-            case .levelStroke: return .white
-            case .levelStrokeBig: return .white
-            case .pointWithIcon: return .clear
-            case .repeat: return .white
-            case .approvalType: return .gray500
-            case .eventWithIcon: return .primaryPurple
-            }
+    }
+    
+    var bgColor: Color {
+        switch self {
+        case .level: return .primaryPurple
+        case .levelStroke: return .white
+        case .levelStrokeBig: return .white
+        case .pointWithIcon: return .clear
+        case .repeat: return .white
+        case .approvalType: return .gray500
+        case .eventWithIcon: return .primaryPurple
         }
-        
-        var gradient: Gradient? {
-            switch self {
-            case .repeat(let type): return type.bgGradient
-            default: return nil
-            }
+    }
+    
+    var gradient: Gradient? {
+        switch self {
+        case .repeat(let type): return type.bgGradient
+        default: return nil
         }
-        
-        var strokeColor: Color? {
-            switch self {
-            case .pointWithIcon, .levelStroke, .levelStrokeBig: return .primaryPurple
-            default: return nil
-            }
+    }
+    
+    var strokeColor: Color? {
+        switch self {
+        case .pointWithIcon, .levelStroke, .levelStrokeBig: return .primaryPurple
+        default: return nil
         }
-        
-        var padding: EdgeInsets {
-            switch self {
-            case .level: return EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12)
-            case .levelStroke: return EdgeInsets(top: 5, leading: 12, bottom: 5, trailing: 12)
-            case .levelStrokeBig: return EdgeInsets(top: 6, leading: 21, bottom: 6, trailing: 21)
-            case .pointWithIcon: return EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8)
-            case .repeat: return EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 11)
-            case .eventWithIcon: return EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 6)
-            case .approvalType: return EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 11)
-            }
+    }
+    
+    var padding: EdgeInsets {
+        switch self {
+        case .level: return EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12)
+        case .levelStroke: return EdgeInsets(top: 5, leading: 12, bottom: 5, trailing: 12)
+        case .levelStrokeBig: return EdgeInsets(top: 6, leading: 21, bottom: 6, trailing: 21)
+        case .pointWithIcon: return EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8)
+        case .repeat: return EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 11)
+        case .eventWithIcon: return EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 6)
+        case .approvalType: return EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 11)
         }
-        
-        var height: CGFloat {
-            switch self {
-            case .level, .levelStroke, .repeat, .approvalType, .eventWithIcon:
-                20
-            case .pointWithIcon:
-                25
-            case .levelStrokeBig:
-                30
-            }
+    }
+    
+    var height: CGFloat {
+        switch self {
+        case .level, .levelStroke, .repeat, .approvalType, .eventWithIcon:
+            20
+        case .pointWithIcon:
+            25
+        case .levelStrokeBig:
+            30
         }
-        
-        var iconSize: CGFloat {
-            switch self {
-            case .eventWithIcon: 16
-            case .pointWithIcon: 18
-            default: 0
-            }
+    }
+    
+    var iconSize: CGFloat {
+        switch self {
+        case .eventWithIcon: 16
+        case .pointWithIcon: 18
+        default: 0
         }
-        
-        var cornerRadius: CGFloat {
-            return 16
-        }
+    }
+    
+    var cornerRadius: CGFloat {
+        return 16
     }
 }
 
+
 struct TagViewModifier: ViewModifier {
-    let style: TagView.TagStyle
+    let style: TagStyle
     
     func body(content: Content) -> some View {
         content

--- a/ILSANG/Sources/Global/ViewModelItem/QuestItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/QuestItem.swift
@@ -41,6 +41,8 @@ class QuestItem: Hashable, Identifiable {
     let userRank: Int?
     var favoriteYn: Bool
     var lastCompleteDate: Date?
+    var commercialAreaCode: String?
+    let isMyIllsangZone: Bool
     
     init(
         id: Int,
@@ -58,7 +60,9 @@ class QuestItem: Hashable, Identifiable {
         mainImage: UIImage?,
         userRank: Int?,
         favoriteYn: Bool,
-        lastCompleteDate: Date?
+        lastCompleteDate: Date?,
+        commercialAreaCode: String?,
+        isMyIllsangZone: Bool
     ) {
         self.id = id
         self.title = title
@@ -76,6 +80,8 @@ class QuestItem: Hashable, Identifiable {
         self.userRank = userRank
         self.favoriteYn = favoriteYn
         self.lastCompleteDate = lastCompleteDate
+        self.commercialAreaCode = commercialAreaCode
+        self.isMyIllsangZone = isMyIllsangZone
     }
     
     var missionType: MissionType { missions.first?.type ?? .photo }
@@ -85,7 +91,17 @@ class QuestItem: Hashable, Identifiable {
     var hasCouponReward: Bool { !coupons.isEmpty }
     
     func totalRewardPoint() -> Int {
-        self.rewards?.reduce(0) { $0 + $1.point } ?? 0
+        guard let rewards else { return 0 }
+        return rewards.reduce(0) { total, reward in
+            var point = reward.point
+            
+            // 내 일상존이고, contribution 포인트면 두 배로 계산
+            if isMyIllsangZone, reward.pointType == .contribution {
+                point *= 2
+            }
+            
+            return total + point
+        }
     }
     
     /// 반복 퀘스트가 현재 잠금 상태인지 여부

--- a/ILSANG/Sources/Global/ViewModelItem/UserMissionHistoryDetailItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/UserMissionHistoryDetailItem.swift
@@ -20,6 +20,7 @@ class UserMissionHistoryDetailItem {
     let missionType: MissionType
     let commercialGainPoint, metroGainPoint, contributionGainPoint: Int
     let quizList: [MissionHistoryQuiz]?
+    let contributionDoublePointYn: Bool
     
     init(
         missionHistoryId: Int,
@@ -35,6 +36,7 @@ class UserMissionHistoryDetailItem {
         commercialGainPoint: Int,
         metroGainPoint: Int,
         contributionGainPoint: Int,
+        contributionDoublePointYn: Bool,
         quizList: [MissionHistoryQuiz]?
     ) {
         self.missionHistoryId = missionHistoryId
@@ -50,6 +52,7 @@ class UserMissionHistoryDetailItem {
         self.commercialGainPoint = commercialGainPoint
         self.metroGainPoint = metroGainPoint
         self.contributionGainPoint = contributionGainPoint
+        self.contributionDoublePointYn = contributionDoublePointYn
         self.quizList = quizList
     }
 }

--- a/ILSANG/Sources/Network/Response/BannerQuestResponse.swift
+++ b/ILSANG/Sources/Network/Response/BannerQuestResponse.swift
@@ -17,4 +17,5 @@ struct BannerQuestResponse: Decodable {
     let questType: String
     let repeatFrequency: String?
     let lastCompleteDate: String?
+    let commercialAreaCode: String?
 }

--- a/ILSANG/Sources/Network/Response/BaseQuestResponse.swift
+++ b/ILSANG/Sources/Network/Response/BaseQuestResponse.swift
@@ -18,5 +18,6 @@ struct BaseQuestResponse: Decodable {
     let favoriteYn: Bool
     let rewards: [RewardResponse]
     let lastCompleteDate: String?
+    let commercialAreaCode: String?
 }
 

--- a/ILSANG/Sources/Network/Response/UserMissionHistoryDetailResponse.swift
+++ b/ILSANG/Sources/Network/Response/UserMissionHistoryDetailResponse.swift
@@ -13,32 +13,8 @@ struct UserMissionHistoryDetailResponse: Decodable {
     let createdAt, commercialAreaCode, questType, missionType, writerName: String
     let repeatFrequency: String?
     let commercialGainPoint, metroGainPoint, contributionGainPoint: Int
+    let contributionDoublePointYn: Bool
     let quizList: [MissionHistoryQuizResponse]?
-
-//    private enum CodingKeys: String, CodingKey {
-//        case missionHistoryId, title, submitImageId, questImageId, likeCount,
-//             createdAt, commercialAreaCode, questType, missionType, writerName,repeatFrequency,
-//             commercialGainPoint, metroGainPoint, contributionGainPoint, quizList
-//    }
-//
-//    init(from decoder: Decoder) throws {
-//        let container = try decoder.container(keyedBy: CodingKeys.self)
-//        missionHistoryId = try container.decode(Int.self, forKey: .missionHistoryId)
-//        title = try container.decode(String.self, forKey: .title)
-//        submitImageId = try container.decodeIfPresent(String.self, forKey: .submitImageId)
-//        questImageId = try container.decodeIfPresent(String.self, forKey: .questImageId)
-//        likeCount = try container.decode(Int.self, forKey: .likeCount)
-//        createdAt = try container.decode(String.self, forKey: .createdAt)
-//        commercialAreaCode = try container.decode(String.self, forKey: .commercialAreaCode)
-//        questType = try container.decode(String.self, forKey: .questType)
-//        missionType = try container.decode(String.self, forKey: .missionType)
-//        writerName = try container.decode(String.self, forKey: .writerName)
-//        repeatFrequency = try container.decodeIfPresent(String.self, forKey: .repeatFrequency)
-//        commercialGainPoint = try container.decode(Int.self, forKey: .commercialGainPoint)
-//        metroGainPoint = try container.decode(Int.self, forKey: .metroGainPoint)
-//        contributionGainPoint = try container.decode(Int.self, forKey: .contributionGainPoint)
-//        quizList = try? container.decodeIfPresent([MissionHistoryQuizResponse].self, forKey: .quizList) ?? [] // null 대응
-//    }
 }
 
 struct MissionHistoryQuizResponse: Decodable {

--- a/ILSANG/Sources/Views/Home/Banner/BannerDetailView.swift
+++ b/ILSANG/Sources/Views/Home/Banner/BannerDetailView.swift
@@ -31,6 +31,7 @@ struct BannerDetailView: View {
                 questRepository: questRepository,
                 areaRepository: areaRepository,
                 favoriteService: favoriteService,
+                illsangZoneManager: illsangZoneManager,
                 questSubmissionNotifier: questSubmissionNotifier
             )
         )

--- a/ILSANG/Sources/Views/Home/Banner/BannerDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Home/Banner/BannerDetailViewModel.swift
@@ -35,6 +35,7 @@ class BannerDetailViewModel: ObservableObject {
     private let questRepository: QuestRepositoryInterface
     private let areaRepository: AreaRepositoryInterface
     private let favoriteService: FavoriteService
+    private let illsangZoneManager: IllsangZoneManager
     private let questSubmissionNotifier: QuestSubmissionNotifier
     
     private var cancellables = Set<AnyCancellable>()
@@ -45,6 +46,7 @@ class BannerDetailViewModel: ObservableObject {
         questRepository: QuestRepositoryInterface,
         areaRepository: AreaRepositoryInterface,
         favoriteService: FavoriteService,
+        illsangZoneManager: IllsangZoneManager,
         questSubmissionNotifier: QuestSubmissionNotifier
     ) {
         self.banner = banner
@@ -52,6 +54,7 @@ class BannerDetailViewModel: ObservableObject {
         self.questRepository = questRepository
         self.areaRepository = areaRepository
         self.favoriteService = favoriteService
+        self.illsangZoneManager = illsangZoneManager
         self.questSubmissionNotifier = questSubmissionNotifier
         
         self.eventFilterState = StaticFilterPickerState(initialValue: .upcoming)
@@ -197,10 +200,11 @@ class BannerDetailViewModel: ObservableObject {
             page: page,
             size: size
         )
-        
+        let myCommercialCode = await MainActor.run { illsangZoneManager.currentZoneCode }
+
         switch result {
         case .success(let response):
-            return (response.content.map { $0.toQuestItem() }, response.totalElements)
+            return (response.content.map { $0.toQuestItem(myCommercialCode: myCommercialCode, questCommercialCode: nil) }, response.totalElements)
         case .failure:
             // TODO: error 화면 변경
             return ([], 0)

--- a/ILSANG/Sources/Views/Home/HomeView.swift
+++ b/ILSANG/Sources/Views/Home/HomeView.swift
@@ -47,6 +47,7 @@ struct HomeView: View {
                 rankRepository: rankRepository,
                 bannerRepository: bannerRepository,
                 favoriteService: favoriteService,
+                illsangZoneManager: illsangZoneManager,
                 questSubmissionNotifier: questSubmissionNotifier,
                 sharedState: sharedState
             )

--- a/ILSANG/Sources/Views/Home/HomeViewModel.swift
+++ b/ILSANG/Sources/Views/Home/HomeViewModel.swift
@@ -56,6 +56,7 @@ final class HomeViewModel: ObservableObject {
     private let rankRepository: RankRepositoryInterface
     private let bannerRepository: BannerRepositoryInterface
     private let favoriteService: FavoriteService
+    private let illsangZoneManager: IllsangZoneManager
     private let questSubmissionNotifier: QuestSubmissionNotifier
     private let sharedState: SharedState
     
@@ -68,6 +69,7 @@ final class HomeViewModel: ObservableObject {
         rankRepository: RankRepositoryInterface,
         bannerRepository: BannerRepositoryInterface,
         favoriteService: FavoriteService,
+        illsangZoneManager: IllsangZoneManager,
         questSubmissionNotifier: QuestSubmissionNotifier,
         sharedState: SharedState
     )  {
@@ -77,6 +79,7 @@ final class HomeViewModel: ObservableObject {
         self.rankRepository = rankRepository
         self.bannerRepository = bannerRepository
         self.favoriteService = favoriteService
+        self.illsangZoneManager = illsangZoneManager
         self.questSubmissionNotifier = questSubmissionNotifier
         self.sharedState = sharedState
         
@@ -256,10 +259,11 @@ final class HomeViewModel: ObservableObject {
     @MainActor
     func loadPopularQuestList() async throws {
         let res = await questRepository.getPopularQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: 0, size: 8)
-        
+        let myCommercialCode = await MainActor.run { illsangZoneManager.currentZoneCode }
+
         switch res {
         case .success(let response):
-            self.popularQuestList = response.content.map { $0.toQuestItem() }
+            self.popularQuestList = response.content.map { $0.toQuestItem(myCommercialCode: myCommercialCode, questCommercialCode: sharedState.selectedCommercialArea.code) }
             await cacheImages(for: &popularQuestList, getMainImage: true)
         case .failure(let error):
             throw error
@@ -269,10 +273,11 @@ final class HomeViewModel: ObservableObject {
     @MainActor
     func loadRecommendQuestList() async throws {
         let res = await questRepository.getRecommendQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: 0, size: 10)
-        
+        let myCommercialCode = await MainActor.run { illsangZoneManager.currentZoneCode }
+
         switch res {
         case .success(let response):
-            self.recommendQuestList = response.content.map { $0.toQuestItem() }
+            self.recommendQuestList = response.content.map { $0.toQuestItem(myCommercialCode: myCommercialCode, questCommercialCode: sharedState.selectedCommercialArea.code) }
             await cacheImages(for: &recommendQuestList, getWriterImage: true)
         case .failure(let error):
             throw error
@@ -282,10 +287,11 @@ final class HomeViewModel: ObservableObject {
     @MainActor
     func loadLargeRewardQuestList() async throws {
         let res = await questRepository.getLargeRewardQuests(commercialAreaCode: sharedState.selectedCommercialArea.code, page: 0, size: 3)
-        
+        let myCommercialCode = await MainActor.run { illsangZoneManager.currentZoneCode }
+
         switch res {
-        case .success(let quests):
-            self.largestRewardQuestList = quests.content.map { $0.toQuestItem() }
+        case .success(let response):
+            self.largestRewardQuestList = response.content.map { $0.toQuestItem(myCommercialCode: myCommercialCode, questCommercialCode: sharedState.selectedCommercialArea.code) }
             await cacheImages(for: &largestRewardQuestList, getWriterImage: true)
         case .failure(let error):
             throw error

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListView.swift
@@ -26,6 +26,7 @@ struct FavoriteListView: View {
             wrappedValue: FavoriteListViewModel(
                 questRepository: questRepository,
                 favoriteService: favoriteService,
+                illsangZoneManager: illsangZoneManager,
                 selectedCommercialArea: selectedCommercialArea,
                 questSubmissionNotifier: questSubmissionNotifier
             )

--- a/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
+++ b/ILSANG/Sources/Views/MyPage/Favorite/FavoriteListViewModel.swift
@@ -19,6 +19,7 @@ class FavoriteListViewModel: ObservableObject {
     
     private let questRepository: QuestRepositoryInterface
     private let favoriteService: FavoriteService
+    private let illsangZoneManager: IllsangZoneManager
     private let questSubmissionNotifier: QuestSubmissionNotifier
     
     private var refreshTask: Task<Void, Never>?
@@ -27,11 +28,13 @@ class FavoriteListViewModel: ObservableObject {
     init(
         questRepository: QuestRepositoryInterface,
         favoriteService: FavoriteService,
+        illsangZoneManager: IllsangZoneManager,
         selectedCommercialArea: CommercialArea,
         questSubmissionNotifier: QuestSubmissionNotifier
     ) {
         self.questRepository = questRepository
         self.favoriteService = favoriteService
+        self.illsangZoneManager = illsangZoneManager
         self.selectedArea = selectedCommercialArea
         self.questSubmissionNotifier = questSubmissionNotifier
         
@@ -126,9 +129,11 @@ class FavoriteListViewModel: ObservableObject {
     }
     
     private func getQuestList(areaCode: String, page: Int, size: Int) async -> (data: [QuestItem], total: Int) {
+        let myCommercialCode = await MainActor.run { illsangZoneManager.currentZoneCode }
+
         switch await questRepository.getFavoriteQuests(commercialAreaCode: areaCode, page: page, size: size) {
         case .success(let response):
-            return (response.content.map { $0.toQuestItem() }, response.totalElements)
+            return (response.content.map { $0.toQuestItem(myCommercialCode: myCommercialCode, questCommercialCode: areaCode) }, response.totalElements)
         case .failure:
             return ([], 0)
         }

--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
@@ -40,6 +40,7 @@ struct UserMissionHistoryDetailView: View {
                                     metroPoint: detailItem.metroGainPoint,
                                     commercialPoint: detailItem.commercialGainPoint,
                                     contributionPoint: detailItem.contributionGainPoint,
+                                    isMyIllsangZone: detailItem.contributionDoublePointYn,
                                     writer: detailItem.writerName,
                                     createdAt: detailItem.createdAt.timeAgoCreatedAt()
                                 )
@@ -51,6 +52,7 @@ struct UserMissionHistoryDetailView: View {
                                 metroPoint: detailItem.metroGainPoint,
                                 commercialPoint: detailItem.commercialGainPoint,
                                 contributionPoint: detailItem.contributionGainPoint,
+                                isMyIllsangZone: detailItem.contributionDoublePointYn,
                                 writer: detailItem.writerName,
                                 createdAt: detailItem.createdAt.timeAgoCreatedAt()
                             )
@@ -193,6 +195,7 @@ struct UserMissionHistoryInfoSectionView: View {
     let metroPoint: Int
     let commercialPoint: Int
     let contributionPoint: Int
+    let isMyIllsangZone: Bool
     let writer: String
     let createdAt: String
     
@@ -208,7 +211,7 @@ struct UserMissionHistoryInfoSectionView: View {
                     VStack(spacing: 8) {
                         reward(title: "일상지역", metroPoint)
                         reward(title: "일상존", commercialPoint)
-                        reward(title: "기여도", contributionPoint)
+                        reward(title: "기여도", contributionPoint, showDoublePoint: isMyIllsangZone)
                     }
             )
             
@@ -265,12 +268,15 @@ struct UserMissionHistoryInfoSectionView: View {
         .roundedBackground(cornerRadius: 12)
     }
 
-    private func reward(title: String, _ point: Int) -> some View {
-        HStack {
+    private func reward(title: String, _ point: Int, showDoublePoint: Bool = false) -> some View {
+        HStack(spacing: 0) {
             Text(title)
                 .styledFont(.subTitle2)
                 .foregroundColor(.gray500)
             Spacer()
+            if showDoublePoint {
+                DoublePointView(style: .text)
+            }
             Text("+\(point)P")
                 .styledFont(.title2)
                 .foregroundColor(.primaryPurple)

--- a/ILSANG/Sources/Views/Profile/OtherUserChallengeDetailView.swift
+++ b/ILSANG/Sources/Views/Profile/OtherUserChallengeDetailView.swift
@@ -38,8 +38,9 @@ struct OtherUserChallengeDetailView: View {
                             metroPoint: detailItem.metroGainPoint,
                             commercialPoint: detailItem.commercialGainPoint,
                             contributionPoint: detailItem.contributionGainPoint,
+                            isMyIllsangZone: detailItem.isMyIllsangZone,
                             writer: detailItem.writerName,
-                            createdAt: detailItem.createdAt.timeAgoCreatedAt()
+                            createdAt: detailItem.createdAt.timeAgoCreatedAt(),
                         )
                     }
                 }

--- a/ILSANG/Sources/Views/Quest/Component/RewardTagRow.swift
+++ b/ILSANG/Sources/Views/Quest/Component/RewardTagRow.swift
@@ -9,12 +9,28 @@ import SwiftUI
 
 struct RewardTagRow: View {
     let rewards: [Reward]
+    let isMyIllsangZone: Bool
     
     var body: some View {
         HStack(spacing: 4) {
             ForEach(Array(PointType.sorted), id: \.rawValue) { type in
                 if let reward = rewards.first(where: { $0.pointType == type }) {
-                    TagView(title: "\(reward.point)P", image: type.image, tagStyle: .pointWithIcon)
+                    if reward.pointType == .contribution && isMyIllsangZone {
+                        TagView(
+                            title: "\(reward.point)P",
+                            image: type.image,
+                            tagStyle: .pointWithIcon,
+                            trailingView: {
+                                DoublePointView(style: .text)
+                            }
+                        )
+                    } else {
+                        TagView(
+                            title: "\(reward.point)P",
+                            image: type.image,
+                            tagStyle: .pointWithIcon
+                        )
+                    }
                 }
             }
         }
@@ -23,6 +39,7 @@ struct RewardTagRow: View {
 
 
 #Preview {
-    RewardTagRow(rewards: [Reward(point: 10, pointType: .commercial), Reward(point: 10, pointType: .metro), Reward(point: 10, pointType: .contribution)])
+    RewardTagRow(rewards: [Reward(point: 10, pointType: .commercial), Reward(point: 10, pointType: .metro), Reward(point: 10, pointType: .contribution)], isMyIllsangZone: true)
+    RewardTagRow(rewards: [Reward(point: 10, pointType: .commercial), Reward(point: 10, pointType: .metro), Reward(point: 10, pointType: .contribution)], isMyIllsangZone: false)
         .padding(.horizontal, 20)
 }

--- a/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailStatView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestDetail/QuestDetailStatView.swift
@@ -18,14 +18,14 @@ struct QuestDetailStatView: View {
             HStack(spacing: 20) {
                 ForEach(PointType.sorted, id: \.rawValue) { type in
                     if let point = quest.rewards?.first(where: { $0.pointType == type }) {
-                        pointTagView(type: type, point: point.point)
+                        pointTagView(type: type, point: point.point, showDoublePoint: quest.isMyIllsangZone && type == .contribution)
                     }
                 }
             }
         }
     }
     
-    private func pointTagView(type: PointType, point: Int) -> some View {
+    private func pointTagView(type: PointType, point: Int, showDoublePoint: Bool) -> some View {
         VStack(spacing: 8) {
             Text(type.headerText)
                 .font(.system(size: 12, weight: .bold))
@@ -49,6 +49,9 @@ struct QuestDetailStatView: View {
                         .scaledToFit()
                         .frame(width: 12)
                         .frame(width: 20, height: 20)
+                    if showDoublePoint {
+                        DoublePointView(style: .background)
+                    }
                 }
                 .frame(height: 20)
             }

--- a/ILSANG/Sources/Views/Quest/QuestItemView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestItemView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TagConfig {
-    let style: TagView.TagStyle
+    let style: TagStyle
     let image: ImageResource?
     let offset: (x: CGFloat, y: CGFloat)
     let title: String
@@ -47,6 +47,10 @@ struct BaseQuestItemView<Trailing: View>: View {
                         .styledFont(.regular, size: 11, lineHeight: 16)
                         .foregroundColor(.gray400)
                         .padding(.bottom, 8)
+                    RewardTagRow(
+                        rewards: quest.rewards ?? [],
+                        isMyIllsangZone: quest.isMyIllsangZone
+                    )
                     RewardTagRow(rewards: quest.rewards ?? [])
                     
                     if let repeatStatusText = quest.repeatStatusText {
@@ -187,7 +191,7 @@ struct FavoriteQuestItemView: View {
     let quest: QuestItem
     let action: (() -> Void)
     let favoriteAction: (() -> Void)
-
+    
     var body: some View {
         BaseQuestItemView(
             quest: quest,
@@ -232,7 +236,7 @@ struct CompletedQuestItemView: View {
             quest: quest,
             tagConfig: tagConfig(for: quest.questType ?? .normal),
             imageSize: .init(width: 60, height: 60),
-            trailingPadding: 16,
+            trailingPadding: 14,
             isDisabled: true,
             trailingView:
                 VStack(spacing: 7) {

--- a/ILSANG/Sources/Views/Quest/QuestView.swift
+++ b/ILSANG/Sources/Views/Quest/QuestView.swift
@@ -26,6 +26,7 @@ struct QuestView: View {
             wrappedValue: QuestViewModel(
                 questRepository: questRepository,
                 favoriteService: favoriteService,
+                illsangZoneManager: illsangZoneManager,
                 questSubmissionNotifier: questSubmissionNotifier,
                 sharedState: sharedState
             )

--- a/ILSANG/Sources/Views/Quest/QuestViewModel.swift
+++ b/ILSANG/Sources/Views/Quest/QuestViewModel.swift
@@ -57,6 +57,7 @@ class QuestViewModel: ObservableObject {
     
     private let questRepository: QuestRepositoryInterface
     private let favoriteService: FavoriteService
+    private let illsangZoneManager: IllsangZoneManager
     private let questSubmissionNotifier: QuestSubmissionNotifier
     private let sharedState: SharedState
         
@@ -65,11 +66,13 @@ class QuestViewModel: ObservableObject {
     init(
         questRepository: QuestRepositoryInterface,
         favoriteService: FavoriteService,
+        illsangZoneManager: IllsangZoneManager,
         questSubmissionNotifier: QuestSubmissionNotifier,
         sharedState: SharedState
     ) {
         self.questRepository = questRepository
         self.favoriteService = favoriteService
+        self.illsangZoneManager = illsangZoneManager
         self.questSubmissionNotifier = questSubmissionNotifier
         self.sharedState = sharedState
         
@@ -286,19 +289,21 @@ class QuestViewModel: ObservableObject {
     }
     
     private func getQuestList(page: Int, size: Int, status: QuestStatus) async -> (data: [QuestItem], total: Int) {
+        let myCommercialCode = await MainActor.run { illsangZoneManager.currentZoneCode }
+        let selectedCommercialCode = sharedState.selectedCommercialArea.code
         let result: Result<ResponseWithPage<[Quest]>, Error>
         
         switch status {
         case .default:
             result = await questRepository.getDefaultQuests(
-                commercialAreaCode: sharedState.selectedCommercialArea.code,
+                commercialAreaCode: selectedCommercialCode,
                 orderRewardDesc: questFilterState.selectedValue.orderRewardDesc,
                 page: page,
                 size: size
             )
         case .repeat:
             result = await questRepository.getRepeatQuests(
-                commercialAreaCode: sharedState.selectedCommercialArea.code,
+                commercialAreaCode: selectedCommercialCode,
                 repeatFrequency: repeatFilterState.selectedValue,
                 orderRewardDesc: questFilterState.selectedValue.orderRewardDesc,
                 page: page,
@@ -306,7 +311,7 @@ class QuestViewModel: ObservableObject {
             )
         case .event:
             result = await questRepository.getEventQuests(
-                commercialAreaCode: sharedState.selectedCommercialArea.code,
+                commercialAreaCode: selectedCommercialCode,
                 orderRewardDesc: eventFilterState.selectedValue.orderRewardDesc,
                 orderExpiredDesc: eventFilterState.selectedValue.orderExpiredDesc,
                 page: page,
@@ -314,9 +319,10 @@ class QuestViewModel: ObservableObject {
             )
         }
         
+
         switch result {
         case .success(let response):
-            return (response.content.map { $0.toQuestItem() }, response.totalElements)
+            return (response.content.map { $0.toQuestItem(myCommercialCode: myCommercialCode, questCommercialCode: selectedCommercialCode) }, response.totalElements)
         case .failure:
             return ([], 0)
         }

--- a/ILSANG/Sources/Views/Quest/Submit/SubmitAlert/SubmitCompleteView.swift
+++ b/ILSANG/Sources/Views/Quest/Submit/SubmitAlert/SubmitCompleteView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SubmitCompleteView: View {
     let totalPoint: Int
     let rewards: [PointType: Int]
+    let isMyIllsangZone: Bool
     let action: () -> ()
     
     private let innerSpacing: CGFloat = 24
@@ -31,6 +32,7 @@ struct SubmitCompleteView: View {
             }
         }
         self.rewards = rewardDict
+        self.isMyIllsangZone = quest.isMyIllsangZone
         self.action = action
     }
     
@@ -65,7 +67,7 @@ struct SubmitCompleteView: View {
     private func rewardSummaryView(rewards: [PointType: Int]) -> some View {
         HStack(spacing: 8) {
             ForEach(PointType.sorted, id: \.self) { type in
-                pointView(icon: type.image, point: rewards[type])
+                pointView(icon: type.image, point: rewards[type], showDoublePoint: type == .contribution && isMyIllsangZone)
             }
         }
         .padding(.vertical, 8)
@@ -73,7 +75,7 @@ struct SubmitCompleteView: View {
         .roundedBackground(cornerRadius: 12, bgColor: .background)
     }
     
-    private func pointView(icon: ImageResource, point: Int?) -> some View {
+    private func pointView(icon: ImageResource, point: Int?, showDoublePoint: Bool) -> some View {
         HStack(spacing: 0) {
             Image(icon)
                 .resizable()
@@ -89,6 +91,10 @@ struct SubmitCompleteView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(height: 10)
+            }
+            
+            if showDoublePoint {
+                DoublePointView(style: .text)
             }
         }
         .frame(height: 25)

--- a/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
+++ b/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
@@ -54,7 +54,10 @@ class QuestRouter: ObservableObject {
         Task { [weak self] in
             guard let self = self else { return }
             do {
-                let questDetail = try await questRepository.getQuestDetail(questId: quest.id).get().toQuestItem()
+                let questDetail = try await questRepository
+                    .getQuestDetail(questId: quest.id)
+                    .get()
+                    .toQuestItem(isMyIllsangZone: quest.isMyIllsangZone) // 상위에서 세팅된 commercialAreaCode 재사용
                 if let imageId = questDetail.imageId {
                     questDetail.image = await ImageCacheService.shared.loadImageAsync(imageId: imageId)
                 }


### PR DESCRIPTION
#### close #476

### ✏️ 개요
퀘스트의 일상존과 사용자의 일상존이 같으면, 기여도를 2배 표시한다.


### 💻 작업 사항
- 기여도 2배 표시 - 퀘스트 상세, 포인트획득팝업, 홈-큰보상, 배너 상세, 퀘스트탭, 즐겨찾기, 미션히스토리상세

### 📱결과 화면(optional)
| 포인트획득팝업 | 퀘스트탭 | 즐겨찾기 |
|--------|--------|--------|
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/79a40e07-5b7d-4efc-932c-5c1ec51cd585" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/e00dd368-9b6e-4991-9ad6-5e36e8cf41c8" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/3ea66f26-6340-4d03-8e51-4e1b472726d1" /> | 
