### PR TITLE
[Feat/#474] 미션 히스토리 상세 화면: 이미지 없을 경우 미표시

### DIFF
--- a/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
+++ b/ILSANG/Sources/Views/MyPage/UserMissionHistory/UserMissionHistoryDetailView.swift
@@ -144,12 +144,6 @@ struct SubmittedImageView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                Image(uiImage: .logoWithAlpha)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: 72)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
     }


### PR DESCRIPTION
#### relate #474 

### ✏️ 개요
미션 히스토리 상세 화면 이미지 없을 경우 미표시되도록 변경합니다.

### 💻 작업 사항
- 미션 히스토리 상세 화면: 이미지 없을 경우 미표시

### 📱결과 화면(optional)
<img width="393" alt="image" src="https://github.com/user-attachments/assets/014a7bfd-ab46-47c6-837b-79564fc55429" />
