### PR TITLE
[Design/#497] 댓글 & 대댓글 UI 구현

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -208,6 +208,8 @@
 		60943FE62C0A38FB00C8A714 /* ApprovalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */; };
 		609A76D92CFC50C7009F4567 /* QuestImageWithTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */; };
 		609A76DB2CFC5E90009F4567 /* RewardTagRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609A76DA2CFC5E90009F4567 /* RewardTagRow.swift */; };
+		60A18CC02EDAEE1200B5D908 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A18CBF2EDAEE1200B5D908 /* CommentView.swift */; };
+		60A18CC22EDAEFD600B5D908 /* CommentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A18CC12EDAEFD600B5D908 /* CommentItem.swift */; };
 		60A2ADF32DAE62BD007AC375 /* SettingItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A2ADF22DAE62BD007AC375 /* SettingItemView.swift */; };
 		60A2ADF52DAE66BD007AC375 /* SettingToggleItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A2ADF42DAE66BD007AC375 /* SettingToggleItemView.swift */; };
 		60A2ADF82DAE6B68007AC375 /* FAQView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A2ADF72DAE6B68007AC375 /* FAQView.swift */; };
@@ -248,6 +250,7 @@
 		60C6B4DC2C2D042700926C0E /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DB2C2D042700926C0E /* Image.swift */; };
 		60C6B4DF2C2D053600926C0E /* SubmitRouterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */; };
 		60C7A1682EC0DFA900E86291 /* LoadMoreIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7A1672EC0DFA900E86291 /* LoadMoreIndicatorView.swift */; };
+		60D165592EDB0044008BF396 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D165582EDB0044008BF396 /* ProfileView.swift */; };
 		60D5EB582E783EBC00C5B78F /* QuestCouponView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D5EB572E783EBC00C5B78F /* QuestCouponView.swift */; };
 		60D5EB5A2E78668E00C5B78F /* RankingRewardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D5EB592E78668E00C5B78F /* RankingRewardViewModel.swift */; };
 		60D897122E536D2C006A8480 /* MissionHistoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D897112E536D2C006A8480 /* MissionHistoryResponse.swift */; };
@@ -562,6 +565,8 @@
 		60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalViewModel.swift; sourceTree = "<group>"; };
 		609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestImageWithTagView.swift; sourceTree = "<group>"; };
 		609A76DA2CFC5E90009F4567 /* RewardTagRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardTagRow.swift; sourceTree = "<group>"; };
+		60A18CBF2EDAEE1200B5D908 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
+		60A18CC12EDAEFD600B5D908 /* CommentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentItem.swift; sourceTree = "<group>"; };
 		60A2ADF22DAE62BD007AC375 /* SettingItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingItemView.swift; sourceTree = "<group>"; };
 		60A2ADF42DAE66BD007AC375 /* SettingToggleItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingToggleItemView.swift; sourceTree = "<group>"; };
 		60A2ADF72DAE6B68007AC375 /* FAQView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FAQView.swift; sourceTree = "<group>"; };
@@ -601,6 +606,7 @@
 		60C6B4DB2C2D042700926C0E /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterViewModel.swift; sourceTree = "<group>"; };
 		60C7A1672EC0DFA900E86291 /* LoadMoreIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadMoreIndicatorView.swift; sourceTree = "<group>"; };
+		60D165582EDB0044008BF396 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		60D5EB572E783EBC00C5B78F /* QuestCouponView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestCouponView.swift; sourceTree = "<group>"; };
 		60D5EB592E78668E00C5B78F /* RankingRewardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingRewardViewModel.swift; sourceTree = "<group>"; };
 		60D897112E536D2C006A8480 /* MissionHistoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryResponse.swift; sourceTree = "<group>"; };
@@ -1085,6 +1091,7 @@
 			isa = PBXGroup;
 			children = (
 				606C3F102E6AA8B80050C4D6 /* CouponItem.swift */,
+				60A18CC12EDAEFD600B5D908 /* CommentItem.swift */,
 				606C3F0E2E6AA8B30050C4D6 /* UserCouponItem.swift */,
 				60DA1D1F2E6CC77F00AE314E /* TitleItem.swift */,
 				60E401AF2E72CD7A00BB0B6C /* UserItem.swift */,
@@ -1133,6 +1140,7 @@
 		607FCBDA2BFA681F00BB2D04 /* Approval */ = {
 			isa = PBXGroup;
 			children = (
+				60A18CBE2EDAED5C00B5D908 /* Component */,
 				607FCBD72BFA681500BB2D04 /* ApprovalView.swift */,
 				60A6B64C2E2C819E00872DE5 /* ApprovalDetailView.swift */,
 				606C87AE2C0B9B8C002D5C3E /* ApprovalItemView.swift */,
@@ -1246,6 +1254,15 @@
 				609A76D82CFC50C7009F4567 /* QuestImageWithTagView.swift */,
 				609A76DA2CFC5E90009F4567 /* RewardTagRow.swift */,
 				60D897502E577E96006A8480 /* TrailingStarView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
+		60A18CBE2EDAED5C00B5D908 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				60A18CBF2EDAEE1200B5D908 /* CommentView.swift */,
+				60D165582EDB0044008BF396 /* ProfileView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1924,6 +1941,7 @@
 				60F352F62E91666900307BDC /* ChallengeResponse.swift in Sources */,
 				6091972C2E5A228700F1D81B /* RankingRewardView.swift in Sources */,
 				601BCF202D7C2DC100138387 /* UINavigationController.swift in Sources */,
+				60D165592EDB0044008BF396 /* ProfileView.swift in Sources */,
 				A1FF916E2C250C3B00F03E4B /* UserNetwork.swift in Sources */,
 				60DA1D202E6CC77F00AE314E /* TitleItem.swift in Sources */,
 				60004AD52D3B799700CD2254 /* Constants.swift in Sources */,
@@ -1935,6 +1953,7 @@
 				60ADF9CD2D5DD3D000556958 /* RoundedBackground.swift in Sources */,
 				606C3EFF2E69FC600050C4D6 /* UserCouponResponse.swift in Sources */,
 				606C3F0F2E6AA8B30050C4D6 /* UserCouponItem.swift in Sources */,
+				60A18CC02EDAEE1200B5D908 /* CommentView.swift in Sources */,
 				A1AB3D682C1141B3001EB9D8 /* LoginButtonView.swift in Sources */,
 				604B2D262E92A4C1006A814D /* QuestItemBuilder.swift in Sources */,
 				606F18152DA3E1F800ABEA84 /* FavoriteNetwork.swift in Sources */,
@@ -2123,6 +2142,7 @@
 				600657E02DBCFEE80022D117 /* HonorView.swift in Sources */,
 				A1BB602C2BFF145100AAADD4 /* MyPageProfile.swift in Sources */,
 				607FCBE92BFE418600BB2D04 /* QuestViewModel.swift in Sources */,
+				60A18CC22EDAEFD600B5D908 /* CommentItem.swift in Sources */,
 				606694F32DDA2B140000E368 /* HonorAcquisitionPopup.swift in Sources */,
 				60DA1D0F2E6CC2B700AE314E /* TitleResponse.swift in Sources */,
 				60DA1D102E6CC2B700AE314E /* UserTitleResponse.swift in Sources */,

--- a/ILSANG/Resources/Assets.xcassets/Color/ContentBackground.colorset/Contents.json
+++ b/ILSANG/Resources/Assets.xcassets/Color/ContentBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.973",
+          "green" : "0.973",
+          "red" : "0.973"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG/Sources/Global/ViewModelItem/CommentItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/CommentItem.swift
@@ -1,0 +1,215 @@
+//
+//  CommentItem.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 11/29/25.
+//
+
+import UIKit
+
+struct CommentItem: Identifiable {
+    let id: Int
+    let userId: String
+    let nickname: String
+    let profileImageId: String?
+    var profileImage: UIImage?
+    let userTitle: UserTitle?
+    
+    let content: String
+    let date: Date
+    
+    let isWriter: Bool
+    let isReplyComment: Bool
+    let isFromCurrentUser: Bool
+    
+    let state: CommentState
+    var isUserReported: Bool
+}
+
+enum CommentState {
+    case normal
+    case deleted
+    case reported
+}
+
+extension CommentItem {
+    static let mockList: [CommentItem] = [
+        
+        // MARK: - Normal Comments (정상 댓글)
+        CommentItem(
+            id: 0,
+            userId: "u1",
+            nickname: "김이선",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "기본 댓글 기본 댓글 기본 댓글 기본 댓글 기본 댓글 기본 댓글 기본 댓글 기본 댓글 기본 댓글 기본 댓글기본댓글기본댓글댓글기본댓글기본댓글댓글기본댓글기본댓글댓글기본댓글기본댓글",
+            date: .now,
+            isWriter: false,
+            isReplyComment: false,
+            isFromCurrentUser: false,
+            state: .normal,
+            isUserReported: false
+        ),
+        CommentItem(
+            id: 1,
+            userId: "u1",
+            nickname: "김이선",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "작성자 댓글",
+            date: .now,
+            isWriter: true,
+            isReplyComment: false,
+            isFromCurrentUser: false,
+            state: .normal,
+            isUserReported: false
+        ),
+        CommentItem(
+            id: 2,
+            userId: "u1",
+            nickname: "김이선",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "현재 유저 댓글",
+            date: .now,
+            isWriter: false,
+            isReplyComment: false,
+            isFromCurrentUser: true,
+            state: .normal,
+            isUserReported: false
+        ),
+        CommentItem(
+            id: 3,
+            userId: "u1",
+            nickname: "김이선",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "현재 유저가 신고한 댓글",
+            date: .now,
+            isWriter: false,
+            isReplyComment: false,
+            isFromCurrentUser: true,
+            state: .normal,
+            isUserReported: true
+        ),
+        
+        // MARK: - Normal Replies (정상 대댓글)
+        CommentItem(
+            id: 4,
+            userId: "u2",
+            nickname: "김이선",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "기본 대댓글",
+            date: .now,
+            isWriter: false,
+            isReplyComment: true,
+            isFromCurrentUser: false,
+            state: .normal,
+            isUserReported: false
+        ),
+        CommentItem(
+            id: 5,
+            userId: "u2",
+            nickname: "김이선",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "현재 유저 대댓글",
+            date: .now,
+            isWriter: false,
+            isReplyComment: true,
+            isFromCurrentUser: true,
+            state: .normal,
+            isUserReported: false
+        ),
+        CommentItem(
+            id: 6,
+            userId: "u2",
+            nickname: "김이선",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "현재 유저 신고한 대댓글",
+            date: .now,
+            isWriter: false,
+            isReplyComment: true,
+            isFromCurrentUser: true,
+            state: .normal,
+            isUserReported: true
+        ),
+        
+        // MARK: - Deleted Comments (삭제된 댓글)
+        CommentItem(
+            id: 7,
+            userId: "u3",
+            nickname: "삭제된 댓글",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "",
+            date: .now,
+            isWriter: false,
+            isReplyComment: false,
+            isFromCurrentUser: false,
+            state: .deleted,
+            isUserReported: false
+        ),
+        
+        // MARK: - Deleted Replies (삭제된 대댓글)
+        CommentItem(
+            id: 8,
+            userId: "u3",
+            nickname: "삭제된 대댓글",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "",
+            date: .now,
+            isWriter: false,
+            isReplyComment: true,
+            isFromCurrentUser: false,
+            state: .deleted,
+            isUserReported: false
+        ),
+        
+        // MARK: - Reported Comments (신고 누적으로 블라인드된 댓글)
+        CommentItem(
+            id: 9,
+            userId: "u4",
+            nickname: "블라인드 댓글",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "",
+            date: .now,
+            isWriter: false,
+            isReplyComment: false,
+            isFromCurrentUser: false,
+            state: .reported,
+            isUserReported: false
+        ),
+        
+        // MARK: - Reported Replies (블라인드 대댓글)
+        CommentItem(
+            id: 10,
+            userId: "u4",
+            nickname: "블라인드 대댓글",
+            profileImageId: nil,
+            profileImage: nil,
+            userTitle: .none,
+            content: "",
+            date: .now,
+            isWriter: false,
+            isReplyComment: true,
+            isFromCurrentUser: false,
+            state: .reported,
+            isUserReported: false
+        )
+    ]
+}

--- a/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
@@ -120,38 +120,6 @@ struct ApprovalItemContentShareView: View {
     }
 }
 
-fileprivate struct ProfileView: View {
-    let profileImage: UIImage?
-    let nickname: String
-    let honor: UserTitle?
-    
-    var body: some View {
-        HStack(spacing: 10) {
-            Image(uiImage: profileImage ?? .profileCircle)
-                .resizable()
-                .frame(width: 35, height: 35)
-                .clipShape(Circle())
-            
-            VStack(alignment: .leading, spacing: 4) {
-                Text(nickname)
-                    .font(.system(size: 14, weight: .semibold))
-                
-                if let honor {
-                    HonorIconView(
-                        honorTitle: honor.name,
-                        grade: honor.grade,
-                        imageSize: 20,
-                        spacing: 4,
-                        font: .badge1,
-                        fgColor: .gray500
-                    )
-                }
-            }
-        }
-        .foregroundStyle(.gray500)
-    }
-}
-
 fileprivate struct MetadataView: View {
     let displayDate: String
     let commercialAreaName: String?

--- a/ILSANG/Sources/Views/Approval/Component/CommentView.swift
+++ b/ILSANG/Sources/Views/Approval/Component/CommentView.swift
@@ -1,0 +1,205 @@
+//
+//  CommentView.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 11/29/25.
+//
+
+import SwiftUI
+
+enum CommentAction {
+    case delete(id: Int)
+    case report(id: Int, isAlreadyReported: Bool)
+    case reply(id: Int)
+    case showUserProfile(userId: String)
+}
+
+
+struct CommentView: View {
+    @Binding var activeMenuCommentId: Int?
+    let comment: CommentItem
+    let onAction: (CommentAction) -> Void
+    private var isMenuActive: Bool {
+        activeMenuCommentId == comment.id
+    }
+    @Environment(\.layout) var layout
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            switch comment.state {
+            case .normal:
+                normalCommentView
+            case .deleted:
+                deletedCommentView
+            case .reported:
+                reportedCommentView
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            if isMenuActive {
+                CommentMenuOverlay(
+                    canDelete: comment.isFromCurrentUser,
+                    canReport: !comment.isFromCurrentUser,
+                    onDelete: {
+                        onAction(.delete(id: comment.id))
+                    },
+                    onReport: {
+                        onAction(.report(id: comment.id, isAlreadyReported: comment.isUserReported))
+                    }
+                )
+                .padding(.top, 40)
+            }
+        }
+        .padding(layout.horizontalPadding)
+        .padding(.leading, comment.isReplyComment ? layout.horizontalPadding : 0)
+        .background(comment.isReplyComment ? Color.contentBackground : .white)
+    }
+    
+    @ViewBuilder
+    private var normalCommentView: some View {
+        HStack {
+            Button {
+                onAction(.showUserProfile(userId: comment.userId))
+            } label: {
+                ProfileView(
+                    profileImage: comment.profileImage,
+                    nickname: comment.nickname,
+                    honor: comment.userTitle,
+                    isWriter: comment.isWriter
+                )
+            }
+            
+            Spacer(minLength: 0)
+            
+            Button {
+                withAnimation(.snappy) {
+                    if isMenuActive {
+                        activeMenuCommentId = nil
+                    } else {
+                        activeMenuCommentId = comment.id
+                    }
+                }
+            } label: {
+                Image(.moreVertical)
+            }
+            .foregroundStyle(.gray500)
+        }
+        
+        Text(comment.content.forceCharWrapping)
+            .styledFont(.caption1)
+            .multilineTextAlignment(.leading)
+            .foregroundStyle(.black)
+        
+        HStack(spacing: 0) {
+            if !comment.isReplyComment {
+                Button {
+                    onAction(.reply(id: comment.id))
+                } label: {
+                    Text("답글 달기")
+                        .styledFont(.tabBold)
+                        .foregroundStyle(.primary300)
+                }
+                Spacer(minLength: 0)
+            }
+            Text(comment.date.toDisplayFormat(.full))
+                .styledFont(.caption2)
+                .foregroundStyle(.gray500)
+        }
+    }
+    
+    private var reportedCommentView: some View {
+        Text("신고 누적으로 숨겨진 댓글입니다.")
+            .styledFont(.subTitle2)
+            .foregroundStyle(.gray500)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 40)
+    }
+    
+    private var deletedCommentView: some View {
+        Text("삭제된 댓글입니다.")
+            .styledFont(.subTitle2)
+            .foregroundStyle(.gray500)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 40)
+    }
+}
+
+fileprivate struct CommentMenuOverlay: View {
+    let canDelete: Bool
+    let canReport: Bool
+    let onDelete: () -> Void
+    let onReport: () -> Void
+    
+    var body: some View {
+        Group {
+            if canDelete {
+                Button(role: .destructive) {
+                    onDelete()
+                } label: {
+                    HStack {
+                        Text("삭제")
+                            .styledFont(.regular, size: 15, lineHeight: 15)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Image(.trash)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(15)
+                    }
+                }
+            }
+            
+            if canReport {
+                Button {
+                    onReport()
+                } label: {
+                    HStack {
+                        Text("신고")
+                            .styledFont(.regular, size: 15, lineHeight: 15)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Image(.syren)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(15)
+                    }
+                }
+            }
+        }
+        .foregroundStyle(.gray500)
+        .padding(.horizontal, 12)
+        .frame(height: 40)
+        .frame(width: 150)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.white)
+                .stroke(.gray100, style: StrokeStyle(lineWidth: 1))
+        )
+        .shadow(color: .shadow7D.opacity(0.05), radius: 20, x: 0, y: 10)
+    }
+}
+
+#Preview {
+    @Previewable @State var activeMenuCommentId: Int? = nil
+    ZStack {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(CommentItem.mockList) { item in
+                    CommentView(activeMenuCommentId: $activeMenuCommentId, comment: item, onAction: { _ in })
+                    Divider()
+                }
+            }
+        }
+        .simultaneousGesture(
+            DragGesture().onChanged { _ in
+                print("스크롤 중")
+                activeMenuCommentId = nil
+            }
+        )
+        .simultaneousGesture(
+            TapGesture().onEnded {
+                print("탭 발생")
+                activeMenuCommentId = nil
+            }
+        )
+    }
+}
+

--- a/ILSANG/Sources/Views/Approval/Component/ProfileView.swift
+++ b/ILSANG/Sources/Views/Approval/Component/ProfileView.swift
@@ -1,0 +1,66 @@
+//
+//  ProfileView.swift
+//  ILSANG
+//
+//  Created by Lee Jinhee on 11/29/25.
+//
+
+
+import SwiftUI
+
+struct ProfileView: View {
+    let profileImage: UIImage?
+    let nickname: String
+    let honor: UserTitle?
+    var isWriter = false
+    
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(uiImage: profileImage ?? .profileCircle)
+                .resizable()
+                .frame(width: 35, height: 35)
+                .clipShape(Circle())
+            
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    Text(nickname)
+                        .styledFont(.semibold, size: 14, lineHeight: 14)
+                    if isWriter {
+                        Text("수행자")
+                            .styledFont(.badge2)
+                            .foregroundStyle(.primary500)
+                            .padding(.horizontal, 6)
+                            .frame(height: 20)
+                            .roundedBackground(cornerRadius: 20, bgColor: .primary100)
+                    }
+                }
+                
+                if let honor {
+                    HonorIconView(
+                        honorTitle: honor.name,
+                        grade: honor.grade,
+                        imageSize: 20,
+                        spacing: 4,
+                        font: .badge1,
+                        fgColor: .gray500
+                    )
+                }
+            }
+        }
+        .foregroundStyle(.gray500)
+    }
+}
+
+#Preview {
+    ProfileView(
+        profileImage: .profileCircle,
+        nickname: "일상",
+        honor: .init(
+            titleHistoryId: 1,
+            name: "김김김",
+            grade: .legend,
+            createdAt: .now
+        ),
+        isWriter: true
+    )
+}


### PR DESCRIPTION
#### close #497 

### ✏️ 개요
상태에 따른 댓글 UI 컴포넌트를 구현합니다.

### 💻 작업 사항
- 댓글 & 대댓글 UI 컴포넌트 구현
  - 미션 수행자 여부에 따른 수행자 여부 표시
  - 현재유저 여부에 따른 옵션 구성 (신고/삭제)
  - 댓글/답글에 따른 답글달기 버튼, 배경색상, 여백 구현
  - 댓글 상태에 따른 UI 표시 (기본,신고,삭제)
- 댓글 컴포넌트 액션 정의

```swift

enum CommentAction {
    case delete(id: Int)
    case report(id: Int, isAlreadyReported: Bool)
    case reply(id: Int)
    case showUserProfile(userId: String)
}
```

### 📱결과 화면(optional)
<img width="301" height="573" alt="image" src="https://github.com/user-attachments/assets/efad8c10-c9d2-45de-a9ba-45a23f33f770" />
<img width="302" height="440" alt="image" src="https://github.com/user-attachments/assets/a6ef75f0-384a-4de9-a90c-1a9e5e7fa6ab" />
