### PR TITLE
[Design/#499] 인증 화면: 퀘스트 컴포넌트 추가

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		60C6B4DF2C2D053600926C0E /* SubmitRouterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */; };
 		60C7A1682EC0DFA900E86291 /* LoadMoreIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7A1672EC0DFA900E86291 /* LoadMoreIndicatorView.swift */; };
 		60D165592EDB0044008BF396 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D165582EDB0044008BF396 /* ProfileView.swift */; };
+		60D1655B2EDB614F008BF396 /* ApprovalQuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D1655A2EDB614F008BF396 /* ApprovalQuestView.swift */; };
 		60D5EB582E783EBC00C5B78F /* QuestCouponView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D5EB572E783EBC00C5B78F /* QuestCouponView.swift */; };
 		60D5EB5A2E78668E00C5B78F /* RankingRewardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D5EB592E78668E00C5B78F /* RankingRewardViewModel.swift */; };
 		60D897122E536D2C006A8480 /* MissionHistoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D897112E536D2C006A8480 /* MissionHistoryResponse.swift */; };
@@ -607,6 +608,7 @@
 		60C6B4DE2C2D053600926C0E /* SubmitRouterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitRouterViewModel.swift; sourceTree = "<group>"; };
 		60C7A1672EC0DFA900E86291 /* LoadMoreIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadMoreIndicatorView.swift; sourceTree = "<group>"; };
 		60D165582EDB0044008BF396 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		60D1655A2EDB614F008BF396 /* ApprovalQuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalQuestView.swift; sourceTree = "<group>"; };
 		60D5EB572E783EBC00C5B78F /* QuestCouponView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestCouponView.swift; sourceTree = "<group>"; };
 		60D5EB592E78668E00C5B78F /* RankingRewardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingRewardViewModel.swift; sourceTree = "<group>"; };
 		60D897112E536D2C006A8480 /* MissionHistoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryResponse.swift; sourceTree = "<group>"; };
@@ -1263,6 +1265,7 @@
 			children = (
 				60A18CBF2EDAEE1200B5D908 /* CommentView.swift */,
 				60D165582EDB0044008BF396 /* ProfileView.swift */,
+				60D1655A2EDB614F008BF396 /* ApprovalQuestView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -2159,6 +2162,7 @@
 				609197462E5C272E00F1D81B /* CommercialAreaRankResponse.swift in Sources */,
 				60E401B82E72D33000BB0B6C /* LegendRank+UIMapper.swift in Sources */,
 				604687AC2D213B890056E394 /* SelectableTabHeader.swift in Sources */,
+				60D1655B2EDB614F008BF396 /* ApprovalQuestView.swift in Sources */,
 				60E401B42E72CED500BB0B6C /* User+UIMapper.swift in Sources */,
 				607FCBDD2BFA686700BB2D04 /* MyPageView.swift in Sources */,
 				60D897232E537421006A8480 /* MIssionHistory+UIMapper.swift in Sources */,

--- a/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
+++ b/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
@@ -1,0 +1,112 @@
+//
+//  ApprovalQuestView.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 11/30/25.
+//
+
+import SwiftUI
+
+struct ApprovalQuestView: View {
+    @Environment(\.layout) var layout
+    let questType: QuestType
+    let repeatType: RepeatType?
+    let questTitle: String
+    let writerName: String
+    let approvalSource: ApprovalSource
+    let status: ApprovalQuestStatus
+    let action: () -> Void
+    
+    enum ApprovalQuestStatus: Equatable {
+        case able, expired, completed
+        
+        func getButtonTitle(source: ApprovalSource) -> String {
+            switch self {
+            case .able:
+                switch source {
+                case .tab: "나도 하기"
+                case .detail: "바로가기"
+                }
+            case .expired: "기간 만료"
+            case .completed: "수행 완료"
+            }
+        }
+    }
+    
+    var actionDisable: Bool {
+        if case .able = status { false } else { true }
+    }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 8) {
+                MissionTagGroupView(questType: questType, repeatType: repeatType, missionType: .photo)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(questTitle)
+                        .styledFont(.bold, size: 15, lineHeight: 20)
+                        .foregroundStyle(.black)
+                    Text(writerName)
+                        .styledFont(.regular, size: 11, lineHeight: 16)
+                        .foregroundStyle(.gray400)
+                }
+            }
+            
+            Spacer(minLength: 0)
+            
+            Button {
+                action()
+            } label: {
+                HStack(spacing: 0) {
+                    Text(status.getButtonTitle(source: approvalSource))
+                        .styledFont(.tabBold)
+                    
+                    Image(.arrowUnder)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(20)
+                        .rotationEffect(.degrees(-90))
+                }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 8)
+            }
+            .foregroundStyle(actionDisable ? .gray300 : .gray500)
+            .roundedBackground(cornerRadius: 12, bgColor: .background)
+            .disabled(actionDisable)
+        }
+        .padding(.horizontal, approvalSource == .tab ? 16 : layout.horizontalPadding)
+        .padding(.vertical, 16)
+        .background(
+            ZStack {
+                if case .detail = approvalSource {
+                    VStack(spacing: 0) {
+                        Rectangle()
+                            .fill(.gray100)
+                            .frame(height: 1)
+                        Spacer()
+                        Rectangle()
+                            .fill(.gray100)
+                            .frame(height: 1)
+                    }
+                    .background(.white)
+                } else {
+                    RoundedRectangle(cornerRadius: approvalSource == .tab ? 12 : 0)
+                        .fill(.white)
+                        .strokeBorder(.gray100, style: .init(lineWidth: 1))
+                }
+            }
+        )
+    }
+}
+#Preview {
+    let action = { print("tapped") }
+    ScrollView {
+        ApprovalQuestView(questType: .normal, repeatType: nil, questTitle: "일반 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action )
+        ApprovalQuestView(questType: .repeat, repeatType: .daily, questTitle: "일간 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action)
+        ApprovalQuestView(questType: .repeat, repeatType: .weekly, questTitle: "주간 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action)
+        ApprovalQuestView(questType: .repeat, repeatType: .monthly, questTitle: "월간 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action)
+        ApprovalQuestView(questType: .event, repeatType: nil, questTitle: "이벤트 퀘스트 참여완료", writerName: "작성자이름", approvalSource: .tab, status: .completed, action: action)
+        ApprovalQuestView(questType: .event, repeatType: nil, questTitle: "이벤트 퀘스트 기간만료", writerName: "작성자이름", approvalSource: .tab, status: .expired, action: action)
+        ApprovalQuestView(questType: .repeat, repeatType: .daily, questTitle: "인증예시 퀘스트", writerName: "작성자이름", approvalSource: .detail(missionId: 2), status: .able, action: action)
+    }
+    .padding(20)
+}


### PR DESCRIPTION
#### close #499 

### ✏️ 개요
인증화면에 퀘스트 컴포넌트를 추가하여 퀘스트 정보를 보여줍니다.
해당 퀘스트 컴포넌트를 작업합니다.

### 💻 작업 사항
- 인증 화면: 퀘스트 컴포넌트 추가

### 📱결과 화면(optional)
<img width="294" height="556" alt="image" src="https://github.com/user-attachments/assets/21bfd3ea-dd99-4f95-a71d-341034a05a4a" />