### PR TITLE
[Design/#505] 인증 상세 화면 추가

### DIFF
--- a/ILSANG.xcodeproj/project.pbxproj
+++ b/ILSANG.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		600657E42DBD2DF50022D117 /* MyPageHonorManageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600657E32DBD2DF50022D117 /* MyPageHonorManageView.swift */; };
 		6009EC362EE4208A000F17BD /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6009EC352EE4208A000F17BD /* ReportView.swift */; };
 		6009EC392EE4213A000F17BD /* ReportPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6009EC382EE4213A000F17BD /* ReportPopup.swift */; };
+		6009EC3B2EE42BCA000F17BD /* ApprovalDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6009EC3A2EE42BCA000F17BD /* ApprovalDetailView.swift */; };
 		600D63982E48E5BC009FE14F /* AreaResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D63972E48E5A9009FE14F /* AreaResponse.swift */; };
 		600D639C2E48E83F009FE14F /* AreaSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D639B2E48E83F009FE14F /* AreaSelectionView.swift */; };
 		600D639E2E490D14009FE14F /* IllsangZoneSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D639D2E490D14009FE14F /* IllsangZoneSelectionView.swift */; };
@@ -375,6 +376,7 @@
 		600657E32DBD2DF50022D117 /* MyPageHonorManageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHonorManageView.swift; sourceTree = "<group>"; };
 		6009EC352EE4208A000F17BD /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		6009EC382EE4213A000F17BD /* ReportPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportPopup.swift; sourceTree = "<group>"; };
+		6009EC3A2EE42BCA000F17BD /* ApprovalDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalDetailView.swift; sourceTree = "<group>"; };
 		600D63972E48E5A9009FE14F /* AreaResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaResponse.swift; sourceTree = "<group>"; };
 		600D639B2E48E83F009FE14F /* AreaSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaSelectionView.swift; sourceTree = "<group>"; };
 		600D639D2E490D14009FE14F /* IllsangZoneSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IllsangZoneSelectionView.swift; sourceTree = "<group>"; };
@@ -771,6 +773,14 @@
 			path = Report;
 			sourceTree = "<group>";
 		};
+		6009EC3C2EE42BE2000F17BD /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				6009EC3A2EE42BCA000F17BD /* ApprovalDetailView.swift */,
+			);
+			path = Detail;
+			sourceTree = "<group>";
+		};
 		600D639A2E48E6BA009FE14F /* Area */ = {
 			isa = PBXGroup;
 			children = (
@@ -1163,6 +1173,7 @@
 				603CF4E42D732DD800A2D19E /* ImageFullScreenView.swift */,
 				60943FE52C0A38FB00C8A714 /* ApprovalViewModel.swift */,
 				6009EC372EE42120000F17BD /* Report */,
+				6009EC3C2EE42BE2000F17BD /* Detail */,
 			);
 			path = Approval;
 			sourceTree = "<group>";
@@ -2027,6 +2038,7 @@
 				606C87AF2C0B9B8C002D5C3E /* ApprovalItemView.swift in Sources */,
 				60D8974F2E576D46006A8480 /* ResponseMapper.swift in Sources */,
 				60DA1D222E6CC81400AE314E /* Title+UIMapper.swift in Sources */,
+				6009EC3B2EE42BCA000F17BD /* ApprovalDetailView.swift in Sources */,
 				60D897292E537653006A8480 /* ApprovalMissionHistoryItem.swift in Sources */,
 				60943FE62C0A38FB00C8A714 /* ApprovalViewModel.swift in Sources */,
 				60C6B4DC2C2D042700926C0E /* Image.swift in Sources */,

--- a/ILSANG/Sources/Global/ViewModelItem/ApprovalMissionHistoryItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/ApprovalMissionHistoryItem.swift
@@ -52,7 +52,26 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
     let userTitle: UserTitle?
     var emojis: UserEmojis
     
-    init(id: Int, title: String, displayDate: String, likeCount: Int, hateCount: Int, viewCount: Int, imageId: String, image: UIImage? = nil, commercialAreaCode: String?, commercialAreaName: String? = nil, userId: String, nickname: String, profileImageId: String?, profileImage: UIImage? = nil, userTitle: UserTitle?, emojis: UserEmojis) {
+    var questType: QuestType?
+    var repeatType: RepeatType?
+    var writer: String?
+    var expireAt: Date?
+    var lastCompleteDate: Date?
+    var comments: [CommentItem]
+    
+    var questStatus: ApprovalQuestStatus {
+        guard let expireAt, expireAt >= .now else { return .expired }
+        switch questType {
+        case .normal, .event:
+            return lastCompleteDate == nil ? .able : .completed
+        case .repeat:
+            return .able
+        default:
+            return .expired
+        }
+    }
+    
+    init(id: Int, title: String, displayDate: String, likeCount: Int, hateCount: Int, viewCount: Int, imageId: String, image: UIImage? = nil, commercialAreaCode: String?, commercialAreaName: String? = nil, userId: String, nickname: String, profileImageId: String?, profileImage: UIImage? = nil, userTitle: UserTitle?, emojis: UserEmojis, comments: [CommentItem] = CommentItem.mockList) {
         self.id = id
         self.title = title
         self.displayDate = displayDate
@@ -69,6 +88,7 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
         self.profileImage = profileImage
         self.userTitle = userTitle
         self.emojis = emojis
+        self.comments = comments
     }
     
     static var mockDataList = [

--- a/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemContentView.swift
@@ -40,9 +40,7 @@ struct ApprovalItemContentView: View, Equatable {
                 ProfileView(profileImage: profileImage, nickname: nickname, honor: userTitle)
             }
             
-            Text(title)
-                .styledFont(.title1)
-                .foregroundStyle(.black)
+            MetadataView(displayDate: displayDate, commercialAreaName: commercialAreaName)
             
             if #available(iOS 18.0, *) {
                 Image(uiImage: image ?? .logo)
@@ -68,8 +66,6 @@ struct ApprovalItemContentView: View, Equatable {
                         showSheetView.toggle()
                     }
             }
-            
-            MetadataView(displayDate: displayDate, commercialAreaName: commercialAreaName)
         }
         .sheet(isPresented: $showSheetView) {
             ImageFullScreenView(image: image ?? .logo) {
@@ -126,11 +122,6 @@ fileprivate struct MetadataView: View {
     
     var body: some View {
         HStack(spacing: 4) {
-            Text(displayDate)
-                .font(.system(size: 12, weight: .regular))
-            
-            Spacer(minLength: 0)
-            
             if let commercialAreaName, !commercialAreaName.isEmpty {
                 Image(.illsangRegion)
                     .resizable()
@@ -140,6 +131,10 @@ fileprivate struct MetadataView: View {
                 Text(commercialAreaName)
                     .styledFont(.badge1)
             }
+            Spacer(minLength: 0)
+            
+            Text(displayDate)
+                .styledFont(.caption2)
         }
         .foregroundStyle(.gray500)
     }

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -64,27 +64,31 @@ struct ApprovalView: View {
         ScrollView {
             LazyVStack(spacing: 16) {
                 ForEach(Array(vm.currentItems.enumerated()), id: \.element.id) { idx, item in
-                    ApprovalItemView(
-                        item: item,
-                        width: .screenWidth - layout.horizontalPadding * 2,
-                        height: ((.screenWidth-layout.horizontalPadding * 2) / 5) * 4,
-                        padding: layout.horizontalPadding,
-                        onAction: { action in
-                            switch action {
-                            case .like:
-                                vm.onLike(for: idx)
-                            case .hate:
-                                vm.onHate(for: idx)
-                            case .profileTapped(let userId):
-                                userRouter.navigateToUserProfile(userId: userId)
+                    NavigationLink {
+                        ApprovalDetailView(item: item)
+                    } label: {
+                        ApprovalItemView(
+                            item: item,
+                            width: .screenWidth - layout.horizontalPadding * 2,
+                            height: ((.screenWidth-layout.horizontalPadding * 2) / 5) * 4,
+                            padding: layout.horizontalPadding,
+                            onAction: { action in
+                                switch action {
+                                case .like:
+                                    vm.onLike(for: idx)
+                                case .hate:
+                                    vm.onHate(for: idx)
+                                case .profileTapped(let userId):
+                                    userRouter.navigateToUserProfile(userId: userId)
+                                }
                             }
+                        )
+                        .equatable()
+                        .overlay(alignment: .topTrailing) {
+                            trailingButton(for: item)
                         }
-                    )
-                    .equatable()
-                    .overlay(alignment: .topTrailing) {
-                        trailingButton(for: item)
+                        .task { await vm.loadMoreDataIfNeeded(at: idx ) }
                     }
-                    .task { await vm.loadMoreDataIfNeeded(at: idx ) }
                 }
                 
                 LoadMoreIndicatorView(isVisible: vm.canLoadMore)

--- a/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
+++ b/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
@@ -7,6 +7,22 @@
 
 import SwiftUI
 
+enum ApprovalQuestStatus: Equatable {
+    case able, expired, completed
+    
+    func getButtonTitle(source: ApprovalSource) -> String {
+        switch self {
+        case .able:
+            switch source {
+            case .tab: "나도 하기"
+            case .detail: "바로가기"
+            }
+        case .expired: "기간 만료"
+        case .completed: "수행 완료"
+        }
+    }
+}
+
 struct ApprovalQuestView: View {
     @Environment(\.layout) var layout
     let questType: QuestType
@@ -16,22 +32,6 @@ struct ApprovalQuestView: View {
     let approvalSource: ApprovalSource
     let status: ApprovalQuestStatus
     let action: () -> Void
-    
-    enum ApprovalQuestStatus: Equatable {
-        case able, expired, completed
-        
-        func getButtonTitle(source: ApprovalSource) -> String {
-            switch self {
-            case .able:
-                switch source {
-                case .tab: "나도 하기"
-                case .detail: "바로가기"
-                }
-            case .expired: "기간 만료"
-            case .completed: "수행 완료"
-            }
-        }
-    }
     
     var actionDisable: Bool {
         if case .able = status { false } else { true }

--- a/ILSANG/Sources/Views/Approval/Component/CommentView.swift
+++ b/ILSANG/Sources/Views/Approval/Component/CommentView.swift
@@ -124,7 +124,7 @@ struct CommentView: View {
     }
 }
 
-fileprivate struct CommentMenuOverlay: View {
+struct CommentMenuOverlay: View {
     let canDelete: Bool
     let canReport: Bool
     let onDelete: () -> Void

--- a/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
+++ b/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
@@ -1,0 +1,266 @@
+//
+//  ApprovalDetailView.swift
+//  ILLSANG
+//
+//  Created by Lee Jinhee on 12/6/25.
+//
+
+import SwiftUI
+
+struct ApprovalDetailView: View {
+    @State private var activeMenuCommentId: Int?
+    @State private var activeMissionhistoryMenu: Bool = false
+    @State private var comment: String = ""
+    @State private var replyingToComment: (id: Int, nickname: String)? = nil
+    private let maxCommentLength = 300
+    let item: ApprovalMissionHistoryItem
+    var onAction: ((ApprovalDetailAction) -> Void)? = nil
+    
+    @Environment(\.layout) var layout
+    @Environment(\.dismiss) var dismiss
+    
+    enum ApprovalDetailAction {
+        case like
+        case mission
+        case profileTapped(userId: String)
+        case commentEllipsisTapped
+        case commentReport
+        case commentDelete
+        case missionHistoryEllipsisTapped
+        case missionHistoryReport
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            header  // 타이틀
+            content
+        }
+        .background(Color.background)
+        .navigationBarBackButtonHidden(true)
+        .task {
+            // await vm.loadDataIfNeeded() // FIXME: API 호출
+        }
+        .scrollDismissesKeyboard(.immediately)
+        .onTapGesture {
+            activeMissionhistoryMenu = false
+            hideKeyboard()
+        }
+        .safeAreaInset(edge: .bottom) {
+            inputView
+        }
+    }
+    
+    private var header: some View {
+        NavigationTitleView(title: "인증 상세", isSeparatorHidden: true, background: .background) {
+            dismiss()
+        }
+        .padding(.bottom, 8) // 세로로 긴 이미지 대응 (NavigationTitleView의 bottom 패딩과 겹침)
+    }
+    
+    private var content: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    ApprovalItemContentView(
+                        id: item.id,
+                        title: item.title,
+                        image: item.image,
+                        nickname: item.nickname,
+                        userTitle: item.userTitle,
+                        profileImage: item.profileImage,
+                        displayDate: item.displayDate,
+                        commercialAreaName: item.commercialAreaName,
+                        width: .screenWidth - layout.horizontalPadding * 2,
+                        height: ((.screenWidth-layout.horizontalPadding * 2) / 5) * 4,
+                    ) {
+                        onAction?(.profileTapped(userId: item.userId))
+                    }
+                    .overlay(alignment: .topTrailing) {
+                        trailingButton(for: item)
+                    }
+                    .padding(.top, 20)
+                    .padding(.horizontal, layout.horizontalPadding)
+                    .padding(.bottom, 16)
+                    
+                    ApprovalQuestView(
+                        questType: item.questType ?? .normal,
+                        repeatType: item.repeatType,
+                        questTitle: item.title,
+                        writerName: item.writer ?? "",
+                        approvalSource: .tab,
+                        status: item.questStatus,
+                        action: {
+                            onAction?(.mission)
+                        }
+                    )
+                    .padding(.bottom, 32)
+                    .padding(.horizontal, layout.horizontalPadding)
+                    
+                    HStack(spacing: 4) {
+                        Text("댓글")
+                            .foregroundStyle(.black)
+                            .styledFont(.heading1)
+                        Text("\(item.comments.count)")
+                            .foregroundStyle(.gray500)
+                            .styledFont(.body)
+                        Spacer()
+                    }
+                    .padding(.bottom, 8)
+                    .padding(.horizontal, layout.horizontalPadding)
+                }
+                .background(Color.white)
+                
+                divider
+                
+                if item.comments.isEmpty {
+                    emptyCommentView
+                } else {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(item.comments.enumerated()), id: \.offset) { idx, comment in
+                            CommentView(
+                                activeMenuCommentId: $activeMenuCommentId,
+                                comment: comment) { action in
+                                    
+                                }
+                                .overlay(alignment: .bottom) {
+                                    if idx != CommentItem.mockList.count - 1 {
+                                        divider
+                                    }
+                                }
+                        }
+                    }
+                }
+            }
+            .cornerRadius(12, corners: [.topLeft, .topRight])
+        }
+        .padding(.bottom, -10)
+        .padding(.horizontal, layout.horizontalPadding)
+        .simultaneousGesture(
+            DragGesture().onChanged { _ in
+                print("스크롤 중")
+                activeMissionhistoryMenu = false
+                activeMenuCommentId = nil
+            }
+        )
+        .simultaneousGesture(
+            TapGesture().onEnded {
+                print("탭 발생")
+                activeMissionhistoryMenu = false
+                activeMenuCommentId = nil
+            }
+        )
+    }
+    
+    private func trailingButton(for item: ApprovalMissionHistoryItem) -> some View {
+        Button {
+            withAnimation(.snappy) {
+                onAction?(.missionHistoryEllipsisTapped)
+            }
+        } label: {
+            Image(.moreVertical)
+                .resizable()
+                .frame(width: 30, height: 30)
+                .foregroundStyle(.gray500)
+                .frame(height: 35)
+        }
+        .overlay(alignment: .topTrailing) {
+            if activeMissionhistoryMenu {
+                CommentMenuOverlay(
+                    canDelete: false,
+                    canReport: true,
+                    onDelete: { },
+                    onReport: {
+                        onAction?(.missionHistoryReport)
+                    }
+                )
+                .padding(.top, 40)
+            }
+        }
+    }
+    
+    private var inputView: some View {
+        VStack(spacing: 0) {
+            if let (_, nickname) = replyingToComment {
+                HStack {
+                    Text("\(nickname)님께 답글 남기는 중")
+                        .styledFont(.caption2)
+                        .foregroundStyle(.primaryPurple)
+                    Spacer(minLength: 0)
+                    Button {
+                        replyingToComment = nil
+                    } label: {
+                        Text("취소")
+                            .styledFont(.caption2)
+                            .foregroundStyle(.gray400)
+                            .frame(height: 30)
+                    }
+                }
+                .padding(.horizontal, layout.horizontalPadding)
+                .background(Color.primary100)
+            }
+            
+            divider
+            
+            HStack(spacing: 8) {
+                HStack(spacing: 10) {
+                    TextField("", text: $comment, axis: .vertical)
+                        .styledFont(.caption1)
+                        .submitLabel(.return)
+                        .keyboardType(.default)
+                        .foregroundStyle(.black)
+                        .overlay(alignment: .leading) {
+                            if comment.isEmpty {
+                                Text("댓글을 입력해 주세요.")
+                                    .styledFont(.caption1)
+                                    .foregroundStyle(.gray300)
+                                    .padding(.leading, 2)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                    Text("\(comment.count)/\(maxCommentLength)")
+                        .styledFont(.tabBold)
+                        .foregroundStyle(.gray300)
+                }
+                .padding(.vertical, 13)
+                .padding(.horizontal, 16)
+                .frame(minHeight: 50, alignment: .leading)
+                .roundedBackground(cornerRadius: 12, bgColor: .gray100)
+                
+                Button {
+                    
+                } label: {
+                    Text("등록")
+                        .styledFont(.button)
+                        .foregroundStyle(.white)
+                        .frame(width: 70, height: 50)
+                        .roundedBackground(cornerRadius: 12, bgColor: comment.isEmpty ? .gray300 : .primaryPurple)
+                }
+                .disabled(comment.isEmpty)
+            }
+            .frame(maxHeight: 90, alignment: .top)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, layout.horizontalPadding)
+            .padding(.vertical, 11)
+        }
+        .background(Color.white)
+    }
+    
+    private var emptyCommentView: some View {
+        Text("댓글이 아직 없어요.")
+            .styledFont(.subTitle2)
+            .foregroundStyle(.gray500)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 60)
+    }
+    
+    private var divider: some View {
+        Rectangle()
+            .frame(height: 1)
+            .frame(maxWidth: .infinity)
+            .foregroundStyle(.gray100)
+    }
+}
+
+#Preview {
+    ApprovalDetailView(item: .mockDataList[0], onAction: nil)
+}


### PR DESCRIPTION
#### close #505

### ✏️ 개요
인증 상세화면을 구현하고, 인증 목록 화면에서 전환되도록 구현합니다.

### 💻 작업 사항
- 인증 상세화면 구현
- 인증 상세화면 전환 구현

### 📱결과 화면(optional)
<img height="600" alt="IMG_5784" src="https://github.com/user-attachments/assets/8fa2f869-d647-4fbc-a84d-6a3a2822b122" />
<img height="600" alt="IMG_5785" src="https://github.com/user-attachments/assets/62dc87ef-7902-4070-a471-ffc1bc69638f" />