### PR TITLE
[Feat/#515] 인증/인증예시/인증상세 화면: 미션 히스토리에 퀘스트 정보 추가

### DIFF
--- a/ILSANG/Sources/Domain/Entity/MissionHistory.swift
+++ b/ILSANG/Sources/Domain/Entity/MissionHistory.swift
@@ -21,4 +21,9 @@ struct MissionHistory {
     let profileImageId: String?
     let userTitle: UserTitle?
     let emojis: [EmojiType]
+    let questType: QuestType?
+    let repeatType: RepeatType?
+    let writer: String?
+    let expireAt: Date?
+    let lastCompleteDate: Date?
 }

--- a/ILSANG/Sources/Domain/Mapper/MissionHistoryResponse+Mapping.swift
+++ b/ILSANG/Sources/Domain/Mapper/MissionHistoryResponse+Mapping.swift
@@ -28,7 +28,12 @@ extension MissionHistoryResponse {
             nickname: user.nickname,
             profileImageId: user.profileImageId,
             userTitle: userTitle,
-            emojis: emojis
+            emojis: emojis,
+            questType: questType.flatMap { QuestType(rawValue: $0) },
+            repeatType: repeatFrequency.flatMap { RepeatType(param: $0) },
+            writer: writerName,
+            expireAt: expireDate?.toISO8601Date(),
+            lastCompleteDate: lastCompleteDate?.toISO8601Date()
         )
     }
 }

--- a/ILSANG/Sources/Domain/Repository/MissionHistoryRepository.swift
+++ b/ILSANG/Sources/Domain/Repository/MissionHistoryRepository.swift
@@ -104,7 +104,12 @@ final class MockMissionHistoryRepository: MissionHistoryRepositoryInterface {
             nickname: "닉네임",
             profileImageId: "",
             userTitle: nil,
-            emojis: [.hate]
+            emojis: [.hate],
+            questType: .event,
+            repeatType: nil,
+            writer: "작성자",
+            expireAt: .now,
+            lastCompleteDate: nil
         )
     ]
     

--- a/ILSANG/Sources/Global/Mapper/MIssionHistory+UIMapper.swift
+++ b/ILSANG/Sources/Global/Mapper/MIssionHistory+UIMapper.swift
@@ -25,7 +25,38 @@ extension MissionHistory {
             profileImageId: profileImageId,
             profileImage: nil,
             userTitle: userTitle,
-            emojis: UserEmojis(emojis: Set(emojis))
+            emojis: UserEmojis(emojis: Set(emojis)),
+            questType: questType,
+            repeatType: repeatType,
+            writer: writer,
+            expireAt: expireAt,
+            lastCompleteDate: lastCompleteDate
+        )
+    }
+    
+    func toApprovalItem(quest: QuestItem) -> ApprovalMissionHistoryItem {
+        return ApprovalMissionHistoryItem(
+            id: id,
+            title: title,
+            displayDate: createdAt.toDisplayFormat(),
+            likeCount: likeCount,
+            hateCount: hateCount,
+            viewCount: viewCount,
+            imageId: imageId,
+            image: nil,
+            commercialAreaCode: commercialAreaCode,
+            commercialAreaName: nil,
+            userId: userId,
+            nickname: nickname,
+            profileImageId: profileImageId,
+            profileImage: nil,
+            userTitle: userTitle,
+            emojis: UserEmojis(emojis: Set(emojis)),
+            questType: quest.questType,
+            repeatType: quest.repeatType,
+            writer: quest.writer,
+            expireAt: quest.expireDate,
+            lastCompleteDate: quest.lastCompleteDate
         )
     }
 }

--- a/ILSANG/Sources/Global/ViewModelItem/ApprovalMissionHistoryItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/ApprovalMissionHistoryItem.swift
@@ -57,7 +57,6 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
     var writer: String?
     var expireAt: Date?
     var lastCompleteDate: Date?
-    var comments: [CommentItem]
     
     var questStatus: ApprovalQuestStatus {
         guard let expireAt, expireAt >= .now else { return .expired }
@@ -71,7 +70,29 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
         }
     }
     
-    init(id: Int, title: String, displayDate: String, likeCount: Int, hateCount: Int, viewCount: Int, imageId: String, image: UIImage? = nil, commercialAreaCode: String?, commercialAreaName: String? = nil, userId: String, nickname: String, profileImageId: String?, profileImage: UIImage? = nil, userTitle: UserTitle?, emojis: UserEmojis, comments: [CommentItem] = CommentItem.mockList) {
+    init(
+        id: Int,
+        title: String,
+        displayDate: String,
+        likeCount: Int,
+        hateCount: Int,
+        viewCount: Int,
+        imageId: String,
+        image: UIImage? = nil,
+        commercialAreaCode: String?,
+        commercialAreaName: String? = nil,
+        userId: String,
+        nickname: String,
+        profileImageId: String?,
+        profileImage: UIImage? = nil,
+        userTitle: UserTitle?,
+        emojis: UserEmojis,
+        questType: QuestType?,
+        repeatType: RepeatType?,
+        writer: String?,
+        expireAt: Date?,
+        lastCompleteDate: Date?
+    ) {
         self.id = id
         self.title = title
         self.displayDate = displayDate
@@ -88,7 +109,11 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
         self.profileImage = profileImage
         self.userTitle = userTitle
         self.emojis = emojis
-        self.comments = comments
+        self.questType = questType
+        self.repeatType = repeatType
+        self.writer = writer
+        self.expireAt = expireAt
+        self.lastCompleteDate = lastCompleteDate
     }
     
     static var mockDataList = [
@@ -108,7 +133,12 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
             profileImageId: "profile_001",
             profileImage: nil,
             userTitle: UserTitle(titleHistoryId: 1, name: "칭호1", grade: .standard, createdAt: .now),
-            emojis: .init(emojis: [.hate])
+            emojis: .init(emojis: [.hate]),
+            questType: .event,
+            repeatType: nil,
+            writer: "작성자",
+            expireAt: .now,
+            lastCompleteDate: nil
         ),
         ApprovalMissionHistoryItem(
             id: 2,
@@ -126,7 +156,12 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
             profileImageId: "profile_002",
             profileImage: nil,
             userTitle: UserTitle(titleHistoryId: 2, name: "칭호2", grade: .legend, createdAt: .now),
-            emojis: .init(emojis: [.hate])
+            emojis: .init(emojis: [.hate]),
+            questType: .event,
+            repeatType: nil,
+            writer: "작성자",
+            expireAt: .now,
+            lastCompleteDate: nil
         ),
         ApprovalMissionHistoryItem(
             id: 3,
@@ -144,7 +179,12 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
             profileImageId: "profile_003",
             profileImage: .img2,
             userTitle: UserTitle(titleHistoryId: 3, name: "칭호3", grade: .rare, createdAt: .now),
-            emojis: .init(emojis: [.hate])
+            emojis: .init(emojis: [.hate]),
+            questType: .event,
+            repeatType: nil,
+            writer: "작성자",
+            expireAt: .now,
+            lastCompleteDate: nil
         )
     ]
     
@@ -162,6 +202,11 @@ class ApprovalMissionHistoryItem: Identifiable, Equatable {
         nickname: "",
         profileImageId: nil,
         userTitle: nil,
-        emojis: .init(emojis: [])
+        emojis: .init(emojis: []),
+        questType: .event,
+        repeatType: nil,
+        writer: "작성자",
+        expireAt: .now,
+        lastCompleteDate: nil
     )
 }

--- a/ILSANG/Sources/Global/ViewModelItem/QuestItem.swift
+++ b/ILSANG/Sources/Global/ViewModelItem/QuestItem.swift
@@ -90,6 +90,18 @@ class QuestItem: Hashable, Identifiable {
     var coupon: CouponItem? { coupons.first }
     var hasCouponReward: Bool { !coupons.isEmpty }
     
+    var questStatus: ApprovalQuestStatus {
+        guard let expireDate, expireDate >= .now else { return .expired }
+        switch questType {
+        case .normal, .event:
+            return lastCompleteDate == nil ? .able : .completed
+        case .repeat:
+            return .able
+        default:
+            return .expired
+        }
+    }
+    
     func totalRewardPoint() -> Int {
         guard let rewards else { return 0 }
         return rewards.reduce(0) { total, reward in

--- a/ILSANG/Sources/Network/Response/MissionHistoryResponse.swift
+++ b/ILSANG/Sources/Network/Response/MissionHistoryResponse.swift
@@ -15,6 +15,12 @@ struct MissionHistoryResponse: Decodable {
     let imageId, commercialAreaCode: String
     let emojis: [EmojiType]
     
+    let questType: String?
+    let repeatFrequency: String?
+    let writerName: String?
+    let expireDate: String?
+    var lastCompleteDate: String?
+    
     struct User: Decodable {
         let userId, nickname: String
         let profileImageId: String?
@@ -32,5 +38,6 @@ struct MissionHistoryResponse: Decodable {
         case imageId = "submitImageId"
         case commercialAreaCode
         case emojis = "currentUserEmojis"
+        case questType, repeatFrequency, writerName, expireDate, lastCompleteDate
     }
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalItemView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalItemView.swift
@@ -15,6 +15,7 @@ struct ApprovalItemView: View, Equatable {
     let width: CGFloat
     let height: CGFloat
     let padding: CGFloat
+    let showQuestInfo: Bool
     let onAction: (ApprovalAction) -> Void
     
     enum ApprovalAction {
@@ -40,6 +41,20 @@ struct ApprovalItemView: View, Equatable {
                 onAction(.profileTapped(userId: item.userId))
             }
             .equatable()
+            
+            if showQuestInfo {
+                ApprovalQuestView(
+                    questType: item.questType ?? .normal,
+                    repeatType: item.repeatType,
+                    questTitle: item.title,
+                    writerName: item.writer ?? "",
+                    bgStyle: .roundedStroke,
+                    status: item.questStatus,
+                    action: {
+                        // FIXME: 퀘스트 라우터 연결
+                    }
+                )
+            }
             
             ReactionView(likeCount: item.likeCount, hateCount: item.hateCount)
                 .equatable()
@@ -99,6 +114,7 @@ struct ApprovalItemView: View, Equatable {
         width: .screenWidth-40,
         height: 200,
         padding: 20,
+        showQuestInfo: true,
         onAction: { _ in}
     )
 }

--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -79,6 +79,7 @@ struct ApprovalView: View {
                             width: .screenWidth - layout.horizontalPadding * 2,
                             height: ((.screenWidth-layout.horizontalPadding * 2) / 5) * 4,
                             padding: layout.horizontalPadding,
+                            showQuestInfo: vm.approvalSource == .tab,
                             onAction: { action in
                                 switch action {
                                 case .like:
@@ -100,7 +101,7 @@ struct ApprovalView: View {
                 
                 LoadMoreIndicatorView(isVisible: vm.canLoadMore)
             }
-            .padding(.top, vm.approvalSource == .tab ? 47 : 0)
+            .padding(.top, vm.approvalSource == .tab ? 47 : 16)
             .padding(.bottom, layout.bottomSpacing)
         }
         .refreshable {

--- a/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalViewModel.swift
@@ -19,7 +19,7 @@ import UIKit
 
 enum ApprovalSource: Equatable {
     case tab
-    case detail(missionId: Int)
+    case detail(missionId: Int, quest: QuestItem)
 }
 
 final class ApprovalViewModel: ObservableObject, SinglePaginationLoadable {
@@ -114,8 +114,8 @@ final class ApprovalViewModel: ObservableObject, SinglePaginationLoadable {
         case .tab:
             let result = await getRandomChallenges(page: page, size: paginationManager.size)
             return (result.data, result.isLast)
-        case .detail(let missionId):
-            let result = await getChallenges(missionId: missionId, page: page, size: paginationManager.size)
+        case .detail(let missionId, let quest):
+            let result = await getChallenges(missionId: missionId, page: page, size: paginationManager.size, quest: quest)
             return (result.data, result.isLast)
         }
     }
@@ -267,13 +267,13 @@ final class ApprovalViewModel: ObservableObject, SinglePaginationLoadable {
         }
     }
     
-    private func getChallenges(missionId: Int, page: Int, size: Int) async -> (data: [ApprovalMissionHistoryItem], isLast: Bool) {
+    private func getChallenges(missionId: Int, page: Int, size: Int, quest: QuestItem) async -> (data: [ApprovalMissionHistoryItem], isLast: Bool) {
         let res = await missionHistoryRepository.getMissionHistories(missionId: missionId, page: page, size: size)
         switch res {
         case .success(let response):
-            return (response.data.map {$0.toApprovalItem()}, response.isLast)
+            return (response.data.map {$0.toApprovalItem(quest: quest)}, response.isLast)
         case .failure(let err):
-            Log("도전내역랜덤 조회 실패 \(err.localizedDescription)")
+            Log("미션 \(missionId) 도전내역 조회 실패 \(err.localizedDescription)")
             return ([], true)
         }
     }

--- a/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
+++ b/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
@@ -10,13 +10,9 @@ import SwiftUI
 enum ApprovalQuestStatus: Equatable {
     case able, expired, completed
     
-    func getButtonTitle(source: ApprovalSource) -> String {
+    var buttonTitle: String {
         switch self {
-        case .able:
-            switch source {
-            case .tab: "나도 하기"
-            case .detail: "바로가기"
-            }
+        case .able: "나도 하기"
         case .expired: "기간 만료"
         case .completed: "수행 완료"
         }
@@ -29,12 +25,17 @@ struct ApprovalQuestView: View {
     let repeatType: RepeatType?
     let questTitle: String
     let writerName: String
-    let approvalSource: ApprovalSource
+    let bgStyle: BackgroundStyle
     let status: ApprovalQuestStatus
     let action: () -> Void
     
     var actionDisable: Bool {
         if case .able = status { false } else { true }
+    }
+    
+    enum BackgroundStyle {
+        case verticalStroke
+        case roundedStroke
     }
     
     var body: some View {
@@ -57,7 +58,7 @@ struct ApprovalQuestView: View {
                 action()
             } label: {
                 HStack(spacing: 0) {
-                    Text(status.getButtonTitle(source: approvalSource))
+                    Text(status.buttonTitle)
                         .styledFont(.tabBold)
                     
                     Image(.arrowUnder)
@@ -73,11 +74,12 @@ struct ApprovalQuestView: View {
             .roundedBackground(cornerRadius: 12, bgColor: .background)
             .disabled(actionDisable)
         }
-        .padding(.horizontal, approvalSource == .tab ? 16 : layout.horizontalPadding)
+        .padding(.horizontal, layout.horizontalPadding)
         .padding(.vertical, 16)
         .background(
             ZStack {
-                if case .detail = approvalSource {
+                switch bgStyle {
+                case .verticalStroke:
                     VStack(spacing: 0) {
                         Rectangle()
                             .fill(.gray100)
@@ -88,8 +90,8 @@ struct ApprovalQuestView: View {
                             .frame(height: 1)
                     }
                     .background(.white)
-                } else {
-                    RoundedRectangle(cornerRadius: approvalSource == .tab ? 12 : 0)
+                case .roundedStroke:
+                    RoundedRectangle(cornerRadius: 12)
                         .fill(.white)
                         .strokeBorder(.gray100, style: .init(lineWidth: 1))
                 }
@@ -100,13 +102,13 @@ struct ApprovalQuestView: View {
 #Preview {
     let action = { print("tapped") }
     ScrollView {
-        ApprovalQuestView(questType: .normal, repeatType: nil, questTitle: "일반 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action )
-        ApprovalQuestView(questType: .repeat, repeatType: .daily, questTitle: "일간 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action)
-        ApprovalQuestView(questType: .repeat, repeatType: .weekly, questTitle: "주간 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action)
-        ApprovalQuestView(questType: .repeat, repeatType: .monthly, questTitle: "월간 퀘스트", writerName: "작성자이름", approvalSource: .tab, status: .able, action: action)
-        ApprovalQuestView(questType: .event, repeatType: nil, questTitle: "이벤트 퀘스트 참여완료", writerName: "작성자이름", approvalSource: .tab, status: .completed, action: action)
-        ApprovalQuestView(questType: .event, repeatType: nil, questTitle: "이벤트 퀘스트 기간만료", writerName: "작성자이름", approvalSource: .tab, status: .expired, action: action)
-        ApprovalQuestView(questType: .repeat, repeatType: .daily, questTitle: "인증예시 퀘스트", writerName: "작성자이름", approvalSource: .detail(missionId: 2, quest: .mockData), status: .able, action: action)
+        ApprovalQuestView(questType: .normal, repeatType: nil, questTitle: "일반 퀘스트", writerName: "작성자이름", bgStyle: .verticalStroke, status: .able, action: action )
+        ApprovalQuestView(questType: .repeat, repeatType: .daily, questTitle: "일간 퀘스트", writerName: "작성자이름", bgStyle: .verticalStroke, status: .able, action: action)
+        ApprovalQuestView(questType: .repeat, repeatType: .weekly, questTitle: "주간 퀘스트", writerName: "작성자이름", bgStyle: .verticalStroke, status: .able, action: action)
+        ApprovalQuestView(questType: .repeat, repeatType: .monthly, questTitle: "월간 퀘스트", writerName: "작성자이름", bgStyle: .verticalStroke, status: .able, action: action)
+        ApprovalQuestView(questType: .event, repeatType: nil, questTitle: "이벤트 퀘스트 참여완료", writerName: "작성자이름", bgStyle: .verticalStroke, status: .completed, action: action)
+        ApprovalQuestView(questType: .event, repeatType: nil, questTitle: "이벤트 퀘스트 기간만료", writerName: "작성자이름", bgStyle: .verticalStroke, status: .expired, action: action)
+        ApprovalQuestView(questType: .repeat, repeatType: .daily, questTitle: "인증예시 퀘스트", writerName: "작성자이름", bgStyle: .verticalStroke,  status: .able, action: action)
     }
     .padding(20)
 }

--- a/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
+++ b/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
@@ -74,7 +74,7 @@ struct ApprovalDetailView: View {
                             repeatType: vm.missionHistory.repeatType,
                             questTitle: vm.missionHistory.title,
                             writerName: vm.missionHistory.writer ?? "",
-                            approvalSource: .tab,
+                            bgStyle: .roundedStroke,
                             status: vm.missionHistory.questStatus,
                             action: {
                                 vm.send(.mission)

--- a/ILSANG/Sources/Views/Approval/MissionApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/MissionApprovalView.swift
@@ -11,6 +11,7 @@ struct MissionApprovalView: View {
     @EnvironmentObject var dependencies: AppDependencies
 
     let missionId: Int
+    let quest: QuestItem
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
@@ -21,7 +22,7 @@ struct MissionApprovalView: View {
             .padding(.bottom, 8)
 
             ApprovalView(
-                approvalSource: .detail(missionId: missionId),
+                approvalSource: .detail(missionId: missionId, quest: quest),
                 emojiNetwork: dependencies.emojiNetwork,
                 missionHistoryRepository: dependencies.missionHistoryRepository,
                 areaNameService: dependencies.areaNameService

--- a/ILSANG/Sources/Views/Approval/MissionApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/MissionApprovalView.swift
@@ -9,18 +9,30 @@ import SwiftUI
 
 struct MissionApprovalView: View {
     @EnvironmentObject var dependencies: AppDependencies
-
+    
     let missionId: Int
     let quest: QuestItem
     @Environment(\.dismiss) var dismiss
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            NavigationTitleView(title: "퀘스트 인증 예시", isSeparatorHidden: true, background: .background) {
+            NavigationTitleView(title: "퀘스트 인증 예시", isSeparatorHidden: true) {
                 dismiss()
             }
             .padding(.bottom, 8)
-
+            
+            ApprovalQuestView(
+                questType: quest.questType ?? .normal,
+                repeatType: quest.repeatType,
+                questTitle: quest.title,
+                writerName: quest.writer,
+                bgStyle: .verticalStroke,
+                status: quest.questStatus, 
+                action: {
+                    // FIXME: 퀘스트 라우터 연결
+                }
+            )
+            
             ApprovalView(
                 approvalSource: .detail(missionId: missionId, quest: quest),
                 emojiNetwork: dependencies.emojiNetwork,
@@ -28,6 +40,7 @@ struct MissionApprovalView: View {
                 areaNameService: dependencies.areaNameService
             )
         }
+        .background(Color.background)
         .navigationBarBackButtonHidden()
     }
 }

--- a/ILSANG/Sources/Views/Router/Quest/QuestNavigationSetup.swift
+++ b/ILSANG/Sources/Views/Router/Quest/QuestNavigationSetup.swift
@@ -63,7 +63,7 @@ struct QuestNavigationSetup: ViewModifier {
             }
         // 도전내역 상세
             .navigationDestination(isPresented: $questRouter.showChallengeImage) {
-                MissionApprovalView(missionId: questRouter.selectedQuest.missionId)
+                MissionApprovalView(missionId: questRouter.selectedQuest.missionId, quest: questRouter.selectedQuest)
             }
         // 일상존 선택
             .navigationDestination(isPresented: $questRouter.showIllsangZoneSelection) {


### PR DESCRIPTION
#### close #515 

### ✏️ 개요
미션 히스토리 컴포넌트에 퀘스트 컴포넌트를 추가합니다.

### 💻 작업 사항
- MissionHistoryResponse 응답 구조에 퀘스트 정보 추가
- 인증 화면: 퀘스트 컴포넌트 추가
- 인증예시 화면: 퀘스트 컴포넌트 추가
- 인증상세 화면: 퀘스트 컴포넌트 추가

### 📄 리뷰 노트

### 📱결과 화면(optional)
| 인증 | 인증예시 | 인증상세 |
|--------|--------|--------|
| <img width="300" alt="IMG_5826" src="https://github.com/user-attachments/assets/be3c9b3f-01e4-4541-9a1f-ac9e85bccd95" /> | <img width="300" alt="IMG_5824" src="https://github.com/user-attachments/assets/da5bc4cf-59ba-46dc-ab8e-95dbf0fcb6d0" /> | <img width="300" alt="IMG_5825" src="https://github.com/user-attachments/assets/7f4b6c7d-de6a-4f6e-80f6-2157196a0162" /> | 

