### PR TITLE
[Feat/#496] 댓글 입력 에러 알럿 표시

### DIFF
--- a/ILSANG/Sources/Extension/String++.swift
+++ b/ILSANG/Sources/Extension/String++.swift
@@ -144,4 +144,13 @@ extension String {
             return self
         }
     }
+    
+    /// HTML 태그, 링크 포함 여부 확인
+    func containsInvalidCharacters() -> Bool {
+        let pattern = "(<[^>]+>)|(https?://\\S+)"
+        if let _ = self.range(of: pattern, options: .regularExpression) {
+            return true
+        }
+        return false
+    }
 }

--- a/ILSANG/Sources/Network/Base/CommonResponse.swift
+++ b/ILSANG/Sources/Network/Base/CommonResponse.swift
@@ -49,7 +49,7 @@ struct ResponseWithEmpty: Decodable, EmptyResponse {
 }
 
 struct ErrorResponse: Decodable {
-    let errMessage: String?
-    let status: String?
     let message: String?
+    let status: Int?
+    let error: String?
 }

--- a/ILSANG/Sources/Network/Base/Network.swift
+++ b/ILSANG/Sources/Network/Base/Network.swift
@@ -240,7 +240,7 @@ final class Network {
         guard let data = data,
               let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: data)
         else { return nil }
-        return errorResponse.errMessage
+        return errorResponse.message
     }
 }
 

--- a/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
+++ b/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
@@ -219,6 +219,7 @@ struct ApprovalDetailView: View {
                         .keyboardType(.default)
                         .foregroundStyle(.black)
                         .focused($isCommentFocused)
+                        .disabled(vm.showAlertType != nil)
                         .overlay(alignment: .leading) {
                             if vm.comment.isEmpty {
                                 Text("댓글을 입력해 주세요.")
@@ -226,6 +227,11 @@ struct ApprovalDetailView: View {
                                     .foregroundStyle(.gray300)
                                     .padding(.leading, 2)
                                     .allowsHitTesting(false)
+                            }
+                        }
+                        .onChange(of: vm.comment) { oldValue, newValue in
+                            if newValue.count > vm.maxCommentLength && newValue.count > oldValue.count {
+                                vm.showAlertType = .Comment(.errorTooLong)
                             }
                         }
                     Text("\(vm.comment.count)/\(vm.maxCommentLength)")
@@ -246,7 +252,7 @@ struct ApprovalDetailView: View {
                         .frame(width: 70, height: 50)
                         .roundedBackground(cornerRadius: 12, bgColor: vm.comment.isEmpty ? .gray300 : .primaryPurple)
                 }
-                .disabled(vm.comment.isEmpty)
+                .disabled(vm.comment.isEmpty || vm.comments.count > vm.maxCommentLength)
             }
             .frame(maxHeight: 90, alignment: .top)
             .fixedSize(horizontal: false, vertical: true)

--- a/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailViewModel.swift
@@ -216,6 +216,18 @@ final class ApprovalDetailViewModel: ObservableObject {
     
     @MainActor
     private func createComment() async {
+        let trimmedComment = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        guard !trimmedComment.isEmpty else {
+            showAlertType = .Comment(.errorEmptyInput)
+            return
+        }
+        
+        if trimmedComment.containsInvalidCharacters() {
+            showAlertType = .Comment(.errorInvalidCharacters)
+            return
+        }
+        
         let parentId = replyingToComment?.id
         let result = await commentRepository.createComment(missionHistoryId: missionHistory.id, parentId: parentId, comment: comment)
         
@@ -229,9 +241,16 @@ final class ApprovalDetailViewModel: ObservableObject {
             } else {
                 scrollToLastComment()  // 댓글 >> 전체 댓글의 맨 마지막
             }
-        case .failure:
-            showAlertType = .CommentCreateFail
-            // TODO: 1분이내 등록 불가 대응
+        case .failure(let error):
+            if case NetworkError.clientError(let message) = error {
+                if message.contains("1 minute") {
+                    showAlertType = .Comment(.errorCreateTooFast)
+                } else {
+                    showAlertType = .Comment(.createFail)
+                }
+            } else {
+                showAlertType = .Comment(.createFail)
+            }
         }
     }
     
@@ -244,7 +263,7 @@ final class ApprovalDetailViewModel: ObservableObject {
                 comments[idx].state = .deleted
             }
         case .failure:
-            showAlertType = .CommentDeleteFail
+            showAlertType = .Comment(.deleteFail)
         }
     }
 }

--- a/ILSANG/Sources/Views/Setting/Component/SettingAlertView.swift
+++ b/ILSANG/Sources/Views/Setting/Component/SettingAlertView.swift
@@ -154,8 +154,37 @@ enum AlertType: AlertPresentable {
     case Logout
     case Withdrawal
     case ChallengeDelete
-    case CommentDeleteFail
-    case CommentCreateFail
+    case Comment(CommentAlertType)
+    
+    enum CommentAlertType: String {
+        case errorTooLong
+        case errorEmptyInput
+        case errorInvalidCharacters
+        case errorCreateTooFast
+        case createFail
+        case deleteFail
+
+        var title: String {
+            switch self {
+            case .errorTooLong, .errorEmptyInput, .errorInvalidCharacters, .errorCreateTooFast:
+                "댓글 입력"
+            case .createFail:
+                "댓글 등록 실패"
+            case .deleteFail:
+                "댓글 삭제 실패"
+            }
+        }
+        var subtitle: String {
+            switch self {
+            case .errorTooLong: "300자 이하로 작성해 주세요."
+            case .errorEmptyInput: "공백 제외 1자 이상 입력하세요."
+            case .errorInvalidCharacters: "허용되지 않은 문자가 포함되어 있습니다."
+            case .errorCreateTooFast: "1분 이내에는 댓글을 여러 번 작성하실 수 없습니다."
+            case .createFail: "댓글을 등록할 수 없습니다"
+            case .deleteFail: "댓글을 삭제할 수 없습니다"
+            }
+        }
+    }
     
     var title: String {
         switch self {
@@ -169,10 +198,8 @@ enum AlertType: AlertPresentable {
             "정말 탈퇴하시겠어요?"
         case .ChallengeDelete:
             "챌린지를 삭제 할까요?"
-        case .CommentDeleteFail:
-            "댓글을 삭제할 수 없습니다"
-        case .CommentCreateFail:
-            "댓글을 등록할 수 없습니다"
+        case .Comment(let type):
+            type.title
         }
     }
     
@@ -186,6 +213,8 @@ enum AlertType: AlertPresentable {
             "확인 시 일상 계정이 영구적으로 삭제되며,\n모든 데이터는 복구가 불가능합니다."
         case .ChallengeDelete:
             "삭제하면 복구가 불가합니다"
+        case .Comment(let type):
+            type.subtitle
         default: nil
         }
     }


### PR DESCRIPTION
#### close #496 

### ✏️ 개요
요구사항에 따라 댓글 에러를 표시합니다.

### 💻 작업 사항
- 입력 에러처리 (300자 / 공백제외 1자 / 허용되지않는 문자열 / 1분 이내 등록 불가)