### PR TITLE
[Feat/#507] 인증상세화면: 나도하기 버튼 기능 구현, 즐겨찾기 기능 연결

### DIFF
--- a/ILSANG/Sources/Views/Approval/ApprovalView.swift
+++ b/ILSANG/Sources/Views/Approval/ApprovalView.swift
@@ -67,6 +67,7 @@ struct ApprovalView: View {
                     missionHistory: item,
                     commentRepository: dependencies.commentRepository,
                     missionHistoryRepository: dependencies.missionHistoryRepository,
+                    favoriteService: dependencies.favoriteService,
                     questSubmissionNotifier: dependencies.questSubmissionNotifier
                 ),
                 userRouter: userRouter,
@@ -111,7 +112,6 @@ struct ApprovalView: View {
                             case .profileTapped(let userId):
                                 userRouter.navigateToUserProfile(userId: userId)
                             case .showQuestDetail:
-                                // FIXME: questId받기
                                 guard let questId = item.questId else { return }
                                 questRouter.presentQuestDetail(questId: questId) { updatedQuest in
                                     vm.toggleFavoriteStatus(questId: updatedQuest.id, prev: updatedQuest.favoriteYn)

--- a/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
+++ b/ILSANG/Sources/Views/Approval/Component/ApprovalQuestView.swift
@@ -39,28 +39,29 @@ struct ApprovalQuestView: View {
     }
     
     var body: some View {
-        HStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 8) {
-                MissionTagGroupView(questType: questType, repeatType: repeatType, missionType: .photo)
-                VStack(alignment: .leading, spacing: 0) {
-                    Text(questTitle)
-                        .styledFont(.bold, size: 15, lineHeight: 20)
-                        .foregroundStyle(.black)
-                    Text(writerName)
-                        .styledFont(.regular, size: 11, lineHeight: 16)
-                        .foregroundStyle(.gray400)
+        Button {
+            action()
+        } label: {
+            HStack(spacing: 0) {
+                // 퀘스트 정보
+                VStack(alignment: .leading, spacing: 8) {
+                    MissionTagGroupView(questType: questType, repeatType: repeatType, missionType: .photo)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(questTitle)
+                            .styledFont(.bold, size: 15, lineHeight: 20)
+                            .foregroundStyle(.black)
+                        Text(writerName)
+                            .styledFont(.regular, size: 11, lineHeight: 16)
+                            .foregroundStyle(.gray400)
+                    }
                 }
-            }
-            
-            Spacer(minLength: 0)
-            
-            Button {
-                action()
-            } label: {
+                
+                Spacer(minLength: 0)
+                
+                // 나도하기 버튼
                 HStack(spacing: 0) {
                     Text(status.buttonTitle)
                         .styledFont(.tabBold)
-                    
                     Image(.arrowUnder)
                         .resizable()
                         .scaledToFit()
@@ -69,36 +70,37 @@ struct ApprovalQuestView: View {
                 }
                 .padding(.vertical, 6)
                 .padding(.horizontal, 8)
+                .foregroundStyle(actionDisable ? .gray300 : .gray500)
+                .roundedBackground(cornerRadius: 12, bgColor: .background)
             }
-            .foregroundStyle(actionDisable ? .gray300 : .gray500)
-            .roundedBackground(cornerRadius: 12, bgColor: .background)
-            .disabled(actionDisable)
-        }
-        .padding(.horizontal, layout.horizontalPadding)
-        .padding(.vertical, 16)
-        .background(
-            ZStack {
-                switch bgStyle {
-                case .verticalStroke:
-                    VStack(spacing: 0) {
-                        Rectangle()
-                            .fill(.gray100)
-                            .frame(height: 1)
-                        Spacer()
-                        Rectangle()
-                            .fill(.gray100)
-                            .frame(height: 1)
+            .padding(.horizontal, layout.horizontalPadding)
+            .padding(.vertical, 16)
+            .background(
+                ZStack {
+                    switch bgStyle {
+                    case .verticalStroke:
+                        VStack(spacing: 0) {
+                            Rectangle()
+                                .fill(.gray100)
+                                .frame(height: 1)
+                            Spacer()
+                            Rectangle()
+                                .fill(.gray100)
+                                .frame(height: 1)
+                        }
+                        .background(.white)
+                    case .roundedStroke:
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.white)
+                            .strokeBorder(.gray100, style: .init(lineWidth: 1))
                     }
-                    .background(.white)
-                case .roundedStroke:
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(.white)
-                        .strokeBorder(.gray100, style: .init(lineWidth: 1))
                 }
-            }
-        )
+            )
+        }
+        .disabled(actionDisable)
     }
 }
+
 #Preview {
     let action = { print("tapped") }
     ScrollView {

--- a/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
+++ b/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
@@ -93,7 +93,10 @@ struct ApprovalDetailView: View {
                             bgStyle: .roundedStroke,
                             status: vm.missionHistory.questStatus,
                             action: {
-                                vm.send(.mission)
+                                guard let questId = vm.missionHistory.questId else { return }
+                                questRouter.presentQuestDetail(questId: questId) { updatedQuest in
+                                    vm.toggleFavoriteStatus(questId: updatedQuest.id, prev: updatedQuest.favoriteYn)
+                                }
                             }
                         )
                         .padding(.bottom, 32)

--- a/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
+++ b/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailView.swift
@@ -11,7 +11,7 @@ struct ApprovalDetailView: View {
     @StateObject var vm: ApprovalDetailViewModel
     @EnvironmentObject var dependencies: AppDependencies
     @StateObject var userRouter: UserRouter
-    @ObservedObject var questRouter: QuestRouter
+    var questRouter: QuestRouter
     @FocusState private var isCommentFocused: Bool
     @Environment(\.layout) var layout
     @Environment(\.dismiss) var dismiss

--- a/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailViewModel.swift
+++ b/ILSANG/Sources/Views/Approval/Detail/ApprovalDetailViewModel.swift
@@ -11,7 +11,6 @@ import UIKit
 enum ApprovalDetailAction {
     case load
     case reload
-    case mission
     case profileTapped(userId: String)
     case missionHistoryEllipsisTapped
     case missionHistoryReport
@@ -62,6 +61,7 @@ final class ApprovalDetailViewModel: ObservableObject {
     
     let commentRepository: CommentRepositoryInterface
     let missionHistoryRepository: MissionHistoryRepositoryInterface
+    private let favoriteService: FavoriteService
     private let questSubmissionNotifier: QuestSubmissionNotifier
     private var cancellables = Set<AnyCancellable>()
     
@@ -71,10 +71,12 @@ final class ApprovalDetailViewModel: ObservableObject {
         missionHistory: ApprovalMissionHistoryItem,
         commentRepository: CommentRepositoryInterface,
         missionHistoryRepository: MissionHistoryRepositoryInterface,
+        favoriteService: FavoriteService,
         questSubmissionNotifier: QuestSubmissionNotifier
     ) {
         self.missionHistory = missionHistory
         self.commentRepository = commentRepository
+        self.favoriteService = favoriteService
         self.missionHistoryRepository = missionHistoryRepository
         self.questSubmissionNotifier = questSubmissionNotifier
 
@@ -101,8 +103,6 @@ final class ApprovalDetailViewModel: ObservableObject {
         switch action {
         case .load, .reload:
             Task { await loadInitialDataWithLoadingState() }
-        case .mission:
-            print("") // FIXME: 상세 시트 연결
         case .missionHistoryEllipsisTapped:
             activeMissionHistoryMenu.toggle()
         case .missionHistoryReport:
@@ -176,6 +176,10 @@ final class ApprovalDetailViewModel: ObservableObject {
     @MainActor
     private func changeViewStatus(_ viewStatus: ViewStatus) {
         self.viewStatus = viewStatus
+    }
+    
+    func toggleFavoriteStatus(questId: Int, prev: Bool) {
+        favoriteService.toggle(questId: questId, prevFavriteYn: prev)
     }
     
     @MainActor

--- a/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
+++ b/ILSANG/Sources/Views/Router/Quest/QuestRouter.swift
@@ -29,6 +29,8 @@ class QuestRouter: ObservableObject {
     private let illsangZoneManager: IllsangZoneManager
     private let questRepository: QuestRepositoryInterface
     
+    private let delayAfterAction: TimeInterval = 0.1
+
     // Callbacks
     private var onFavoriteToggle: ((QuestItem) -> Void)?
     
@@ -104,7 +106,7 @@ class QuestRouter: ObservableObject {
             isQuestSheetPending = true
             alertType = .illsangZoneNotSelected
         } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delayAfterAction) { [weak self] in
                 self?.showQuestSheet = true
             }
         }
@@ -153,7 +155,7 @@ class QuestRouter: ObservableObject {
             }
             if isQuestSheetPending {
                 isQuestSheetPending = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + delayAfterAction) { [weak self] in
                     self?.showQuestSheet = true
                 }
             }
@@ -173,7 +175,7 @@ class QuestRouter: ObservableObject {
         case .illsangZoneSetSuccess:
             if isQuestSheetPending {
                 isQuestSheetPending = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + delayAfterAction) { [weak self] in
                     self?.showQuestSheet = true
                 }
             }


### PR DESCRIPTION
#### close #507 

### ✏️ 개요
인증 상세 화면에서 퀘스트를 수행할 수 있도록 퀘스트라우터를 연결합니다.

### 💻 작업 사항
- 인증상세화면: 나도하기 버튼 기능 구현
- 인증상세화면: 퀘스트 즐겨찾기 기능 연결